### PR TITLE
TECH-4876: use rails apis for getting internal metadata table names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - Unreleased
+### Changed
+- Updated the `always_ignore_tables` list in `Migrator` to access Rails metadata table names
+using the appropriate Rails configuration attributes.
+
 ## [0.1.2] - 2020-09-29
 ### Changed
 - Added travis support and created 2 specs as a starting point.
@@ -13,5 +18,6 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 ### Added
 - Initial version from https://github.com/Invoca/hobo_fields v4.1.0.
 
+[0.1.3]: https://github.com/Invoca/declare_schema/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/Invoca/declare_schema/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/Invoca/declare_schema/tree/v0.1.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (0.1.2)
+    declare_schema (0.1.3)
       rails (>= 4.2)
 
 GEM

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -230,10 +230,10 @@ module Generators
             end
 
           [
+            'schema_info',
             ActiveRecord::Base.schema_migrations_table_name,
             ActiveRecord::Base.internal_metadata_table_name,
-            sessions_table,
-            'schema_info'
+            sessions_table
           ].compact
         end
 

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -232,7 +232,8 @@ module Generators
           [
             ActiveRecord::Base.schema_migrations_table_name,
             ActiveRecord::Base.internal_metadata_table_name,
-            sessions_table
+            sessions_table,
+            'schema_info'
           ].compact
         end
 

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -229,7 +229,11 @@ module Generators
               nil
             end
 
-          ['schema_info', 'schema_migrations', 'ar_internal_metadata', sessions_table].compact
+          [
+            ActiveRecord::Base.schema_migrations_table_name,
+            ActiveRecord::Base.internal_metadata_table_name,
+            sessions_table
+          ].compact
         end
 
         def generate


### PR DESCRIPTION
This is converting from a statically defined list for ignorable tables to use the Rails APIs in order to get the configured metadata tables.

Note: `schema_info` was removed because it is the table that Rails used instead of `schema_migrations` as the default `schema_migrations_table_name` pre Rails 3.  Because (1) this gem does not support anything pre Rails 4, and (2) any projects that are still using `schema_info` instead of `schema_migrations` for the schema migration table should be setting the `schema_migrations_table_name` attribute in their Rails configuration, this static declaration has been removed.