### PR TITLE
TECH-4970: never omit text limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 ### Changed
 - Changed tests from rdoctest to rspec.
 
+### Fixed
+- Fixed a bug where `:text limit: 0xffff_ffff` (max size) was omitted from migrations.
+- Fixed a bug where `:bigint` foreign keys were omitted from the migration. 
+
 ## [0.1.3] - Unreleased
 ### Changed
 - Updated the `always_ignore_tables` list in `Migrator` to access Rails metadata table names

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -410,7 +410,7 @@ module Generators
             spec = model.field_specs[c]
             if spec.different_to?(col) # TODO: DRY this up to a diff function that returns the differences. It's different if it has differences. -Colin
               change_spec = fk_field_options(model, c)
-              change_spec[:limit]     = spec.limit     if (spec.sql_type != :text ||
+              change_spec[:limit]     ||= spec.limit   if (spec.sql_type != :text ||
                                                          ::DeclareSchema::Model::FieldSpec.mysql_text_limits?) &&
                                                           (spec.limit || col.limit)
               change_spec[:precision] = spec.precision unless spec.precision.nil?

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     up, down = Generators::DeclareSchema::Migration::Migrator.run
     expect(up).to eq(<<~EOS.strip)
-      add_column :adverts, :notes, :text, null: false
+      add_column :adverts, :notes, :text, null: false, limit: 4294967295
       add_column :adverts, :description, :text, null: false, limit: 255
     EOS
 
@@ -238,7 +238,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     end
 
     up, down = Generators::DeclareSchema::Migration::Migrator.run
-    expect(up).to eq("change_column :adverts, :description, :text, null: false")
+    expect(up).to eq("change_column :adverts, :description, :text, limit: 4294967295, null: false")
     expect(down).to eq("change_column :adverts, :description, :text")
 
     # TODO TECH-4814: The above test should have this output:
@@ -253,7 +253,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     end
 
     up, down = Generators::DeclareSchema::Migration::Migrator.run
-    expect(up).to eq("change_column :adverts, :description, :text, null: false")
+    expect(up).to eq("change_column :adverts, :description, :text, limit: 4294967295, null: false")
     expect(down).to eq("change_column :adverts, :description, :text")
     ::DeclareSchema::Model::FieldSpec::instance_variable_set(:@mysql_text_limits, false)
 

--- a/spec/lib/generators/declare_schema/migration/migrator_spec.rb
+++ b/spec/lib/generators/declare_schema/migration/migrator_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails'
+require 'rails/generators'
+
+module Generators
+  module DeclareSchema
+    module Migration
+      RSpec.describe Migrator do
+        before do
+          ActiveRecord::Base.connection.tables
+        end
+
+        subject { described_class.new }
+
+        describe 'format_options' do
+          let(:mysql_longtext_limit) { 0xffff_ffff }
+
+          context 'MySQL' do
+            before do
+              expect(::DeclareSchema::Model::FieldSpec).to receive(:mysql_text_limits?).and_return(true)
+            end
+
+            it 'returns text limits' do
+              expect(subject.format_options({ limit: mysql_longtext_limit }, :text)).to eq(["limit: #{mysql_longtext_limit}"])
+            end
+          end
+
+          context 'non-MySQL' do
+            before do
+              expect(::DeclareSchema::Model::FieldSpec).to receive(:mysql_text_limits?).and_return(false)
+            end
+
+            it 'returns text limits' do
+              expect(subject.format_options({ limit: mysql_longtext_limit }, :text)).to eq([])
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes 2 bugs from TECH-4970:

1. The `:text limit:` was being omitted if it was the max, 0xffff_ffff. This was a bug because I misunderstood and thought that was the Rails default size. Actually, the Rails default matches the MySQL default, which is `0xffff`. The fix always emits the `limit:` since it's harmless to be explicit, just like we do with `:string limit: 255`.
2. The `:integer limit: 8` change that Alec added for foreign keys was actually broken in `declare_schema` because it was being overwritten. This is fixed here. Note that we still have a bit of a problem generating these migrations in that Rails 5 will consider the columns type `:bigint` whereas `declare_schema` calls them `:integer limit: 8` and doesn't know these are equivalent. So I think it will forever try to migrate those. I created TECH-4971 to track that.