### PR TITLE
Tech 4972 create callback for loading other models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 ## [0.3.0] - Unreleased
 ### Added
-- Added a new callback `after_load_rails_models` to the `Migrator` that can be
+- Added a new callback `before_generating_migration` to the `Migrator` that can be
 defined in order to custom load more models that might be missed by `eager_load!`
 
 ## [0.2.0] - 2020-10-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - Unreleased
+### Added
+- Added a new callback `after_load_rails_models` to the `Migrator` that can be
+defined in order to custom load more models that might be missed by `eager_load!`
+
 ## [0.2.0] - 2020-10-26
 ### Added
 - Automatically eager_load! all Rails::Engines before generating migrations.
@@ -13,7 +18,7 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 ### Fixed
 - Fixed a bug where `:text limit: 0xffff_ffff` (max size) was omitted from migrations.
-- Fixed a bug where `:bigint` foreign keys were omitted from the migration. 
+- Fixed a bug where `:bigint` foreign keys were omitted from the migration.
 
 ## [0.1.3] - 2020-10-08
 ### Changed
@@ -29,6 +34,7 @@ using the appropriate Rails configuration attributes.
 ### Added
 - Initial version from https://github.com/Invoca/hobo_fields v4.1.0.
 
+[0.3.0]: https://github.com/Invoca/declare_schema/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Invoca/declare_schema/compare/v0.1.3...v0.2.0
 [0.1.3]: https://github.com/Invoca/declare_schema/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/Invoca/declare_schema/compare/v0.1.1...v0.1.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (0.2.0)
+    declare_schema (0.3.0.pre.1)
       rails (>= 4.2)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (0.3.0.pre.1)
+    declare_schema (0.3.0.pre.2)
       rails (>= 4.2)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -59,9 +59,8 @@ during the initialization of your Rails application.
 
 During the initializtion process for generating migrations, `DeclareSchema` will
 trigger the `eager_load!` on the `Rails` application and all `Rails::Engine`s loaded
-into scope.  This sometimes won't load all the necessary models for generating
-migrations against, so we've introduced a callback that when defined is executed just
-after this eager loading process.
+into scope.  If you need to generate migrations for models that aren't automatically loaded by `eager_load!`,
+load them in the `after_load_rails_models` block.
 
 **Example Configuration**
 

--- a/README.md
+++ b/README.md
@@ -55,17 +55,17 @@ Note that the migration generator is interactive -- it can't tell the difference
 The following configuration options are available for the gem and can be used
 during the initialization of your Rails application.
 
-### after_load_rails_models callback
+### before_generating_migration callback
 
 During the initializtion process for generating migrations, `DeclareSchema` will
 trigger the `eager_load!` on the `Rails` application and all `Rails::Engine`s loaded
 into scope.  If you need to generate migrations for models that aren't automatically loaded by `eager_load!`,
-load them in the `after_load_rails_models` block.
+load them in the `before_generating_migration` block.
 
 **Example Configuration**
 
 ```ruby
-DeclareSchema::Migration::Migrator.after_load_rails_models do
+DeclareSchema::Migration::Migrator.before_generating_migration do
   require 'lib/some/hidden/models.rb'
 end
 ```

--- a/README.md
+++ b/README.md
@@ -50,6 +50,27 @@ Migration filename: [<enter>=declare_schema_migration_1|<custom_name>]: add_comp
 ```
 Note that the migration generator is interactive -- it can't tell the difference between renaming something vs. adding one thing and removing another, so sometimes it will ask you to clarify.
 
+## Migrator Configuration
+
+The following configuration options are available for the gem and can be used
+during the initialization of your Rails application.
+
+### after_load_rails_models callback
+
+During the initializtion process for generating migrations, `DeclareSchema` will
+trigger the `eager_load!` on the `Rails` application and all `Rails::Engine`s loaded
+into scope.  This sometimes won't load all the necessary models for generating
+migrations against, so we've introduced a callback that when defined is executed just
+after this eager loading process.
+
+**Example Configuration**
+
+```ruby
+DeclareSchema::Migration::Migrator.after_load_rails_models do
+  require 'lib/some/hidden/models.rb'
+end
+```
+
 ## Installing
 
 Install the `DeclareSchema` gem directly:

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "0.2.0"
+  VERSION = "0.3.0.pre.1"
 end

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "0.3.0.pre.1"
+  VERSION = "0.3.0.pre.2"
 end

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -113,9 +113,9 @@ module Generators
             @native_types ||= fix_native_types(connection.native_database_types)
           end
 
-          def after_load_rails_models(&blk)
-            block_given? or raise ArgumentError, 'A block is required when setting the after_load_rails_models callback'
-            @after_load_rails_models_callback = blk
+          def after_load_rails_models(&block)
+            block or raise ArgumentError, 'A block is required when setting the after_load_rails_models callback'
+            @after_load_rails_models_callback = block
           end
         end
 
@@ -127,9 +127,6 @@ module Generators
 
         attr_accessor :renames
 
-        # TODO: Add an application callback (maybe an initializer in a special group?) that
-        # the application can use to load other models that live in the database, to support DeclareSchema migrations
-        # for them.
         def load_rails_models
           ActiveRecord::Migration.verbose = false
 

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -71,12 +71,12 @@ module Generators
 
         @ignore_models                    = []
         @ignore_tables                    = []
-        @after_load_rails_models_callback = nil
+        @before_generating_migration_callback = nil
         @active_record_class              = ActiveRecord::Base
 
         class << self
           attr_accessor :ignore_models, :ignore_tables, :disable_indexing, :disable_constraints, :active_record_class
-          attr_reader :after_load_rails_models_callback
+          attr_reader :before_generating_migration_callback
 
           def active_record_class
             @active_record_class.is_a?(Class) or @active_record_class = @active_record_class.to_s.constantize
@@ -113,9 +113,9 @@ module Generators
             @native_types ||= fix_native_types(connection.native_database_types)
           end
 
-          def after_load_rails_models(&block)
-            block or raise ArgumentError, 'A block is required when setting the after_load_rails_models callback'
-            @after_load_rails_models_callback = block
+          def before_generating_migration(&block)
+            block or raise ArgumentError, 'A block is required when setting the before_generating_migration callback'
+            @before_generating_migration_callback = block
           end
         end
 
@@ -132,7 +132,7 @@ module Generators
 
           Rails.application.eager_load!
           Rails::Engine.subclasses.each(&:eager_load!)
-          self.class.after_load_rails_models_callback&.call
+          self.class.before_generating_migration_callback&.call
         end
 
         # Returns an array of model classes that *directly* extend

--- a/spec/lib/generators/declare_schema/migration/migrator_spec.rb
+++ b/spec/lib/generators/declare_schema/migration/migrator_spec.rb
@@ -37,9 +37,9 @@ module Generators
           end
         end
 
-        describe '#after_load_rails_models' do
+        describe '#before_generating_migration' do
           it 'requires a block be passed' do
-            expect { described_class.after_load_rails_models }.to raise_error(ArgumentError, 'A block is required when setting the after_load_rails_models callback')
+            expect { described_class.before_generating_migration }.to raise_error(ArgumentError, 'A block is required when setting the before_generating_migration callback')
           end
         end
 
@@ -51,18 +51,18 @@ module Generators
 
           subject { described_class.new.load_rails_models }
 
-          context 'when a after_load_rails_models callback is configured' do
+          context 'when a before_generating_migration callback is configured' do
             let(:dummy_proc) { -> {} }
 
             before do
-              described_class.after_load_rails_models(&dummy_proc)
+              described_class.before_generating_migration(&dummy_proc)
               expect(dummy_proc).to receive(:call).and_return(true)
             end
 
             it { should be_truthy }
           end
 
-          context 'when no after_load_rails_models callback is configured' do
+          context 'when no before_generating_migration callback is configured' do
             it { should be_nil }
           end
         end

--- a/spec/lib/generators/declare_schema/migration/migrator_spec.rb
+++ b/spec/lib/generators/declare_schema/migration/migrator_spec.rb
@@ -36,6 +36,36 @@ module Generators
             end
           end
         end
+
+        describe '#after_load_rails_models' do
+          it 'requires a block be passed' do
+            expect { described_class.after_load_rails_models }.to raise_error(ArgumentError, 'A block is required when setting the after_load_rails_models callback')
+          end
+        end
+
+        describe 'load_rails_models' do
+          before do
+            expect(Rails.application).to receive(:eager_load!)
+            expect(Rails::Engine).to receive(:subclasses).and_return([])
+          end
+
+          subject { described_class.new.load_rails_models }
+
+          context 'when a after_load_rails_models callback is configured' do
+            let(:dummy_proc) { -> {} }
+
+            before do
+              described_class.after_load_rails_models(&dummy_proc)
+              expect(dummy_proc).to receive(:call).and_return(true)
+            end
+
+            it { should be_truthy }
+          end
+
+          context 'when no after_load_rails_models callback is configured' do
+            it { should be_nil }
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## [0.3.0] - Unreleased
### Added
- Added a new callback `before_generating_migrations` to the `Migrator` that can be
defined in order to custom load more models that might be missed by `eager_load!`

## Migrator Configuration

The following configuration options are available for the gem and can be used
during the initialization of your Rails application.

### before_generating_migrations callback

During the initializtion process for generating migrations, `DeclareSchema` will
trigger the `eager_load!` on the `Rails` application and all `Rails::Engine`s loaded
into scope.  This sometimes won't load all the necessary models for generating
migrations against, so we've introduced a callback that when defined is executed just
after this eager loading process.

**Example Configuration**

```ruby
DeclareSchema::Migration::Migrator.before_generating_migrations do
  require 'lib/some/hidden/models.rb'
end
```