### PR TITLE
STORY-8887: add support for belongs_to optional:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 - Added support for `belongs_to optional:`.
 If given, it is passed through to `ActiveRecord`'s `belong_to`.
 If not given in Rails 5+, the `optional:` value is set equal to the `null:` value (default: `false`) and that
-is is passed to `ActiveRecord`'s `belong_to`. 
+is passed to `ActiveRecord`'s `belong_to`.
+Similarly, if `null:` is not given, it is inferred from `optional:`.
+If both are given, their values are respected, even if contradictory;
+this is a legitimate case when migrating to/from an optional association.
 
 ## [0.2.0] - 2020-10-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - Unreleased
+### Added
+- Added support for `belongs_to optional:`.
+If given, it is passed through to `ActiveRecord`'s `belong_to`.
+If not given in Rails 5+, the `optional:` value is set equal to the `null:` value (default: `false`) and that
+is is passed to `ActiveRecord`'s `belong_to`. 
+
 ## [0.2.0] - 2020-10-26
 ### Added
 - Automatically eager_load! all Rails::Engines before generating migrations.
@@ -29,6 +36,7 @@ using the appropriate Rails configuration attributes.
 ### Added
 - Initial version from https://github.com/Invoca/hobo_fields v4.1.0.
 
+[0.3.0]: https://github.com/Invoca/declare_schema/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Invoca/declare_schema/compare/v0.1.3...v0.2.0
 [0.1.3]: https://github.com/Invoca/declare_schema/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/Invoca/declare_schema/compare/v0.1.1...v0.1.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (0.2.0)
+    declare_schema (0.3.0.pre.1)
       rails (>= 4.2)
 
 GEM

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -108,7 +108,12 @@ module DeclareSchema
       # Extend belongs_to so that it creates a FieldSpec for the foreign key
       def belongs_to(name, scope = nil, **options, &block)
         column_options = {}
-        column_options[:null] = options.delete(:null) || false
+
+        column_options[:null] = if options.has_key?(:null)
+                                  options.delete(:null)
+                                elsif options.has_key?(:optional)
+                                  options[:optional] # infer :null from :optional
+                                end || false
         column_options[:default] = options.delete(:default) if options.has_key?(:default)
         column_options[:limit] = options.delete(:limit) if options.has_key?(:limit)
 
@@ -124,7 +129,7 @@ module DeclareSchema
         fk = options[:foreign_key]&.to_s || "#{name}_id"
 
         if !options.has_key?(:optional) && Rails::VERSION::MAJOR >= 5
-          options[:optional] = column_options[:null]
+          options[:optional] = column_options[:null] # infer :optional from :null
         end
 
         fk_options[:dependent] = options.delete(:far_end_dependent) if options.has_key?(:far_end_dependent)

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -106,15 +106,7 @@ module DeclareSchema
       end
 
       # Extend belongs_to so that it creates a FieldSpec for the foreign key
-      def belongs_to(name, *args, &block)
-        if args.size == 0 || (args.size == 1 && args[0].is_a?(Proc))
-          options = {}
-          args.push(options)
-        elsif args.size == 1
-          options = args[0]
-        else
-          options = args[1]
-        end
+      def belongs_to(name, scope = nil, **options, &block)
         column_options = {}
         column_options[:null] = options.delete(:null) || false
         column_options[:default] = options.delete(:default) if options.has_key?(:default)

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "0.2.0"
+  VERSION = "0.3.0.pre.1"
 end

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       end
     end
 
-    up, down = Generators::DeclareSchema::Migration::Migrator.run
+    up = Generators::DeclareSchema::Migration::Migrator.run.first
     expect(up).to eq("add_column :adverts, :price, :integer, limit: 2")
 
     # Now run the migration, then change the limit:
@@ -154,7 +154,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       end
     end
 
-    up, down = Generators::DeclareSchema::Migration::Migrator.run
+    up = Generators::DeclareSchema::Migration::Migrator.run.first
     expect(up).to eq("add_column :adverts, :price, :decimal")
 
     # Limits are generally not needed for `text` fields, because by default, `text` fields will use the maximum size
@@ -170,7 +170,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       end
     end
 
-    up, down = Generators::DeclareSchema::Migration::Migrator.run
+    up = Generators::DeclareSchema::Migration::Migrator.run.first
     expect(up).to eq(<<~EOS.strip)
       add_column :adverts, :price, :decimal
       add_column :adverts, :notes, :text, null: false
@@ -194,7 +194,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       end
     end
 
-    up, down = Generators::DeclareSchema::Migration::Migrator.run
+    up = Generators::DeclareSchema::Migration::Migrator.run.first
     expect(up).to eq(<<~EOS.strip)
       add_column :adverts, :notes, :text, null: false, limit: 4294967295
       add_column :adverts, :description, :text, null: false, limit: 255
@@ -266,7 +266,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       end
     end
 
-    up, down = Generators::DeclareSchema::Migration::Migrator.run
+    up = Generators::DeclareSchema::Migration::Migrator.run.first
     ActiveRecord::Migration.class_eval up
     Advert.connection.schema_cache.clear!
     Advert.reset_column_information
@@ -278,6 +278,9 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     class Category < ActiveRecord::Base; end
     class Advert < ActiveRecord::Base
+      fields do
+        name :string, limit: 255, null: true
+      end
       belongs_to :category
     end
 
@@ -298,9 +301,10 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     class Category < ActiveRecord::Base; end
     class Advert < ActiveRecord::Base
+      fields { }
       belongs_to :category, foreign_key: "c_id", class_name: 'Category'
     end
-    up, down = Generators::DeclareSchema::Migration::Migrator.run
+    up = Generators::DeclareSchema::Migration::Migrator.run.first
     expect(up.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
       add_column :adverts, :c_id, :integer, limit: 8, null: false
       add_index :adverts, [:c_id], name: 'on_c_id'
@@ -313,9 +317,10 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     class Category < ActiveRecord::Base; end
     class Advert < ActiveRecord::Base
+      fields { }
       belongs_to :category, index: false
     end
-    up, down = Generators::DeclareSchema::Migration::Migrator.run
+    up = Generators::DeclareSchema::Migration::Migrator.run.first
     expect(up.gsub(/\n+/, "\n")).to eq("add_column :adverts, :category_id, :integer, limit: 8, null: false")
 
     Advert.field_specs.delete(:category_id)
@@ -325,9 +330,10 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     class Category < ActiveRecord::Base; end
     class Advert < ActiveRecord::Base
+      fields { }
       belongs_to :category, index: 'my_index'
     end
-    up, down = Generators::DeclareSchema::Migration::Migrator.run
+    up = Generators::DeclareSchema::Migration::Migrator.run.first
     expect(up.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
       add_column :adverts, :category_id, :integer, limit: 8, null: false
       add_index :adverts, [:category_id], name: 'my_index'
@@ -372,7 +378,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         title :string, index: true, limit: 255, null: true
       end
     end
-    up, down = Generators::DeclareSchema::Migration::Migrator.run
+    up = Generators::DeclareSchema::Migration::Migrator.run.first
     expect(up.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
       add_column :adverts, :title, :string, limit: 255
       add_index :adverts, [:title], name: 'on_title'
@@ -387,7 +393,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         title :string, index: true, unique: true, null: true, limit: 255
       end
     end
-    up, down = Generators::DeclareSchema::Migration::Migrator.run
+    up = Generators::DeclareSchema::Migration::Migrator.run.first
     expect(up.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
       add_column :adverts, :title, :string, limit: 255
       add_index :adverts, [:title], unique: true, name: 'on_title'
@@ -402,20 +408,20 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         title :string, index: 'my_index', limit: 255, null: true
       end
     end
-    up, down = Generators::DeclareSchema::Migration::Migrator.run
+    up = Generators::DeclareSchema::Migration::Migrator.run.first
     expect(up.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
       add_column :adverts, :title, :string, limit: 255
       add_index :adverts, [:title], name: 'my_index'
     EOS
 
-    Advert.index_specs.delete_if {|spec| spec.fields==["title"]}
+    Advert.index_specs.delete_if { |spec| spec.fields==["title"] }
 
     # You can ask for an index outside of the fields block
 
     class Advert < ActiveRecord::Base
       index :title
     end
-    up, down = Generators::DeclareSchema::Migration::Migrator.run
+    up = Generators::DeclareSchema::Migration::Migrator.run.first
     expect(up.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
       add_column :adverts, :title, :string, limit: 255
       add_index :adverts, [:title], name: 'on_title'
@@ -428,7 +434,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     class Advert < ActiveRecord::Base
       index :title, unique: true, name: 'my_index'
     end
-    up, down = Generators::DeclareSchema::Migration::Migrator.run
+    up = Generators::DeclareSchema::Migration::Migrator.run.first
     expect(up.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
       add_column :adverts, :title, :string, limit: 255
       add_index :adverts, [:title], unique: true, name: 'my_index'
@@ -441,7 +447,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     class Advert < ActiveRecord::Base
       index [:title, :category_id]
     end
-    up, down = Generators::DeclareSchema::Migration::Migrator.run
+    up = Generators::DeclareSchema::Migration::Migrator.run.first
     expect(up.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
       add_column :adverts, :title, :string, limit: 255
       add_index :adverts, [:title, :category_id], name: 'on_title_and_category_id'
@@ -544,7 +550,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         title :string, default: "Untitled", limit: 255, null: true
       end
     end
-    up, down = Generators::DeclareSchema::Migration::Migrator.run
+    up = Generators::DeclareSchema::Migration::Migrator.run.first
     ActiveRecord::Migration.class_eval(up)
 
     class FancyAdvert < Advert
@@ -613,7 +619,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         created_at :datetime
       end
     end
-    up, down = Generators::DeclareSchema::Migration::Migrator.run(adverts: :ads)
+    up = Generators::DeclareSchema::Migration::Migrator.run(adverts: :ads).first
     expect(up.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
       rename_table :adverts, :ads
       add_column :ads, :created_at, :datetime, null: false
@@ -682,5 +688,48 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     ActiveRecord::Migration.class_eval(up)
     expect(Ad.field_specs['company'].options[:validates].inspect).to eq("{:presence=>true, :uniqueness=>{:case_sensitive=>false}}")
   end
-end
 
+  describe 'belongs_to' do
+    before do
+      unless defined?(AdCategory)
+        class AdCategory < ActiveRecord::Base
+          fields { }
+        end
+      end
+
+      class Advert < ActiveRecord::Base
+        fields do
+          name :string, limit: 255, null: true
+          category_id :integer, limit: 8
+          nullable_category_id :integer, limit: 8, null: true
+        end
+      end
+      up = Generators::DeclareSchema::Migration::Migrator.run.first
+      ActiveRecord::Migration.class_eval(up)
+    end
+
+    it 'passes through optional:, if given' do
+      class AdvertBelongsTo < ActiveRecord::Base
+        self.table_name = 'adverts'
+        fields { }
+        reset_column_information
+        belongs_to :ad_category, optional: true
+      end
+      expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional: true)
+    end
+
+    [false, true].each do |nullable|
+      context "nullable=#{nullable}" do
+        it 'infers the optional: argument from null: option' do
+          eval <<~EOS
+            class AdvertBelongsTo < ActiveRecord::Base
+              fields { }
+              belongs_to :ad_category, null: #{nullable}
+            end
+          EOS
+          expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional: nullable)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/declare_schema/prepare_testapp.rb
+++ b/spec/lib/declare_schema/prepare_testapp.rb
@@ -18,6 +18,8 @@ require "#{TESTAPP_PATH}/config/environment"
 require 'rails/generators'
 Rails::Generators.configure!(Rails.application.config.generators)
 
+ActiveRecord::Base.connection.schema_cache.clear!
+
 (ActiveRecord::Base.connection.tables - Generators::DeclareSchema::Migration::Migrator.always_ignore_tables).each do |table|
   ActiveRecord::Base.connection.execute("DROP TABLE #{ActiveRecord::Base.connection.quote_table_name(table)}")
 end


### PR DESCRIPTION
## [0.3.0] - Unreleased
### Added
- Added support for `belongs_to optional:`.
If given, it is passed through to `ActiveRecord`'s `belong_to`.
If not given in Rails 5+, the `optional:` value is set equal to the `null:` value (default: `false`) and that is passed to `ActiveRecord`'s `belong_to`.
Similarly, if `null:` is not given, it is inferred from `optional:`.
If both are given, their values are respected, even if contradictory; this is a legitimate case when migrating to/from an optional association.