### PR TITLE
TECH-4985: generate migrations that can run in Rails 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ is passed to `ActiveRecord`'s `belong_to`.
 Similarly, if `null:` is not given, it is inferred from `optional:`.
 If both are given, their values are respected, even if contradictory;
 this is a legitimate case when migrating to/from an optional association.
+### Fixed
+- Migrations are now generated where the `[4.2]` is only applied after `ActiveRecord::Migration` in Rails 5+ (since Rails 4 didn't know about that notation).
 
 ## [0.2.0] - 2020-10-26
 ### Added

--- a/lib/generators/declare_schema/migration/templates/migration.rb.erb
+++ b/lib/generators/declare_schema/migration/templates/migration.rb.erb
@@ -1,4 +1,4 @@
-class <%= @migration_class_name %> < ActiveRecord::Migration<%= ('[4.2]' if Rails::VERSION::MAJOR >= 5) %>
+class <%= @migration_class_name %> < (Rails::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration)
   def self.up
     <%= @up %>
   end


### PR DESCRIPTION
### Fixed
- Migrations are now generated where the `[4.2]` is only applied after `ActiveRecord::Migration` in Rails 5+ (since Rails 4 didn't know about that notation).