### PR TITLE
Tech 4937 create test dsl for acceptance tests

### DIFF
--- a/spec/lib/declare_schema/api_spec.rb
+++ b/spec/lib/declare_schema/api_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'DeclareSchema API' do
       # The migration generator uses this information to create a migration.
       # The following creates and runs the migration:
 
-      expect(system("bundle exec rails generate declare_schema:migration -n -m")).to be_truthy
+      generate_migrations '-n', '-m'
 
       # We're now ready to start demonstrating the API
 
@@ -42,7 +42,7 @@ RSpec.describe 'DeclareSchema API' do
 
       unless Rails::VERSION::MAJOR >= 6
         # TODO: get this to work on Travis for Rails 6
-        Rails::Generators.invoke('declare_schema:migration', %w[-n -m])
+        generate_migrations '-n', '-m'
       end
 
       require 'advert'

--- a/spec/lib/declare_schema/api_spec.rb
+++ b/spec/lib/declare_schema/api_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'DeclareSchema API' do
       # The migration generator uses this information to create a migration.
       # The following creates and runs the migration:
 
-      generate_migrations '-n', '-m'
+      expect(system("bundle exec rails generate declare_schema:migration -n -m")).to be_truthy
 
       # We're now ready to start demonstrating the API
 

--- a/spec/lib/declare_schema/api_spec.rb
+++ b/spec/lib/declare_schema/api_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'DeclareSchema API' do
 
   describe 'example models' do
     it 'generates a model' do
-      expect(system("bundle exec rails generate declare_schema:model advert title:string body:text")).to be_truthy
+      generate_model 'advert', 'title:string', 'body:text'
 
       # The above will generate the test, fixture and a model file like this:
       # model_declaration = Rails::Generators.invoke('declare_schema:model', ['advert2', 'title:string', 'body:text'])

--- a/spec/lib/declare_schema/api_spec.rb
+++ b/spec/lib/declare_schema/api_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'DeclareSchema API' do
       # expect(model_declaration.first).to eq([["Advert"], nil, "app/models/advert.rb", nil,
       #                                       [["AdvertTest"], "test/models/advert_test.rb", nil, "test/fixtures/adverts.yml"]])
 
-      expect(File.read("#{TESTAPP_PATH}/app/models/advert.rb")).to eq(<<~EOS)
+      expect_model_definition_to_eq('advert', <<~EOS)
         class Advert < #{active_record_base_class}
 
           fields do
@@ -27,7 +27,8 @@ RSpec.describe 'DeclareSchema API' do
 
         end
       EOS
-      system("rm -rf #{TESTAPP_PATH}/app/models/advert2.rb #{TESTAPP_PATH}/test/models/advert2.rb #{TESTAPP_PATH}/test/fixtures/advert2.rb")
+
+      clean_up_model('advert2')
 
       # The migration generator uses this information to create a migration.
       # The following creates and runs the migration:
@@ -36,9 +37,7 @@ RSpec.describe 'DeclareSchema API' do
 
       # We're now ready to start demonstrating the API
 
-      Rails.application.config.autoload_paths += ["#{TESTAPP_PATH}/app/models"]
-
-      $LOAD_PATH << "#{TESTAPP_PATH}/app/models"
+      load_models
 
       unless Rails::VERSION::MAJOR >= 6
         # TODO: get this to work on Travis for Rails 6

--- a/spec/lib/declare_schema/generator_spec.rb
+++ b/spec/lib/declare_schema/generator_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     expect_test_fixture_to_eq('alpha/beta', <<~EOS)
       # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-      # This model initially had no columns defined. If you add columns to the
+      # This model initially had no columns defined.  If you add columns to the
       # model remove the '{}' from the fixture names and add the columns immediately
       # below each fixture, per the syntax in the comments below
       #
@@ -48,7 +48,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       # column: value
       #
       two: {}
-      # column: value
+      #  column: value
     EOS
 
     $LOAD_PATH << "#{TESTAPP_PATH}/app/models"

--- a/spec/lib/declare_schema/generator_spec.rb
+++ b/spec/lib/declare_schema/generator_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
   it "generates nested models" do
     generate_model 'alpha/beta', 'one:string', 'two:integer'
 
-    expect(File.exist?('app/models/alpha/beta.rb')).to be_truthy
-
-    expect(File.read('app/models/alpha/beta.rb')).to eq(<<~EOS)
+    expect_model_definition_to_eq('alpha/beta', <<~EOS)
       class Alpha::Beta < #{active_record_base_class}
 
         fields do
@@ -21,7 +19,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       end
     EOS
 
-    expect(File.read('app/models/alpha.rb')).to eq(<<~EOS)
+    expect_model_definition_to_eq('alpha', <<~EOS)
       module Alpha
         def self.table_name_prefix
           'alpha_'
@@ -29,7 +27,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       end
     EOS
 
-    expect(File.read('test/models/alpha/beta_test.rb')).to eq(<<~EOS)
+    expect_test_definition_to_eq('alpha/beta', <<~EOS)
       require 'test_helper'
 
       class Alpha::BetaTest < ActiveSupport::TestCase
@@ -39,7 +37,19 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       end
     EOS
 
-    expect(File.exist?('test/fixtures/alpha/beta.yml')).to be_truthy
+    expect_test_fixture_to_eq('alpha/beta', <<~EOS)
+      # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+      # This model initially had no columns defined. If you add columns to the
+      # model remove the '{}' from the fixture names and add the columns immediately
+      # below each fixture, per the syntax in the comments below
+      #
+      one: {}
+      # column: value
+      #
+      two: {}
+      # column: value
+    EOS
 
     $LOAD_PATH << "#{TESTAPP_PATH}/app/models"
 

--- a/spec/lib/declare_schema/generator_spec.rb
+++ b/spec/lib/declare_schema/generator_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     $LOAD_PATH << "#{TESTAPP_PATH}/app/models"
 
-    expect(system("bundle exec rails generate declare_schema:migration -n -m")).to be_truthy
+    generate_migrations '-n', '-m'
 
     expect(File.exist?('db/schema.rb')).to be_truthy
 

--- a/spec/lib/declare_schema/generator_spec.rb
+++ b/spec/lib/declare_schema/generator_spec.rb
@@ -6,18 +6,18 @@ RSpec.describe 'DeclareSchema Migration Generator' do
   end
 
   it "generates nested models" do
-    Rails::Generators.invoke('declare_schema:model', %w[alpha/beta one:string two:integer])
+    generate_model 'alpha/beta', 'one:string', 'two:integer'
 
     expect(File.exist?('app/models/alpha/beta.rb')).to be_truthy
 
     expect(File.read('app/models/alpha/beta.rb')).to eq(<<~EOS)
       class Alpha::Beta < #{active_record_base_class}
-  
+
         fields do
           one :string, limit: 255
           two :integer
         end
-  
+
       end
     EOS
 
@@ -31,7 +31,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     expect(File.read('test/models/alpha/beta_test.rb')).to eq(<<~EOS)
       require 'test_helper'
-      
+
       class Alpha::BetaTest < ActiveSupport::TestCase
         # test "the truth" do
         #   assert true

--- a/spec/lib/declare_schema/generator_spec.rb
+++ b/spec/lib/declare_schema/generator_spec.rb
@@ -37,19 +37,35 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       end
     EOS
 
-    expect_test_fixture_to_eq('alpha/beta', <<~EOS)
-      # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+    if Rails::VERSION::MAJOR >= 5
+      expect_test_fixture_to_eq('alpha/beta', <<~EOS)
+        # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-      # This model initially had no columns defined.  If you add columns to the
-      # model remove the '{}' from the fixture names and add the columns immediately
-      # below each fixture, per the syntax in the comments below
-      #
-      one: {}
-      # column: value
-      #
-      two: {}
-      #  column: value
-    EOS
+        # This model initially had no columns defined. If you add columns to the
+        # model remove the '{}' from the fixture names and add the columns immediately
+        # below each fixture, per the syntax in the comments below
+        #
+        one: {}
+        # column: value
+        #
+        two: {}
+        # column: value
+      EOS
+    else
+      expect_test_fixture_to_eq('alpha/beta', <<~EOS)
+        # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+        # This model initially had no columns defined.  If you add columns to the
+        # model remove the '{}' from the fixture names and add the columns immediately
+        # below each fixture, per the syntax in the comments below
+        #
+        one: {}
+        # column: value
+        #
+        two: {}
+        #  column: value
+      EOS
+    end
 
     $LOAD_PATH << "#{TESTAPP_PATH}/app/models"
 

--- a/spec/lib/declare_schema/generator_spec.rb
+++ b/spec/lib/declare_schema/generator_spec.rb
@@ -37,7 +37,22 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       end
     EOS
 
-    if Rails::VERSION::MAJOR >= 5
+    case Rails::VERSION::MAJOR
+    when 4
+      expect_test_fixture_to_eq('alpha/beta', <<~EOS)
+        # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+        # This model initially had no columns defined.  If you add columns to the
+        # model remove the '{}' from the fixture names and add the columns immediately
+        # below each fixture, per the syntax in the comments below
+        #
+        one: {}
+        # column: value
+        #
+        two: {}
+        #  column: value
+      EOS
+    when 5
       expect_test_fixture_to_eq('alpha/beta', <<~EOS)
         # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
@@ -51,11 +66,11 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         two: {}
         # column: value
       EOS
-    else
+    when 6
       expect_test_fixture_to_eq('alpha/beta', <<~EOS)
-        # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+        # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-        # This model initially had no columns defined.  If you add columns to the
+        # This model initially had no columns defined. If you add columns to the
         # model remove the '{}' from the fixture names and add the columns immediately
         # below each fixture, per the syntax in the comments below
         #
@@ -63,7 +78,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         # column: value
         #
         two: {}
-        #  column: value
+        # column: value
       EOS
     end
 

--- a/spec/lib/declare_schema/generator_spec.rb
+++ b/spec/lib/declare_schema/generator_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     $LOAD_PATH << "#{TESTAPP_PATH}/app/models"
 
-    generate_migrations '-n', '-m'
+    expect(system("bundle exec rails generate declare_schema:migration -n -m")).to be_truthy
 
     expect(File.exist?('db/schema.rb')).to be_truthy
 

--- a/spec/lib/declare_schema/interactive_primary_key_spec.rb
+++ b/spec/lib/declare_schema/interactive_primary_key_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
       self.primary_key = "foo_id"
     end
 
-    Rails::Generators.invoke('declare_schema:migration', %w[-n -m])
+    generate_migrations '-n', '-m'
     expect(Foo.primary_key).to eq('foo_id')
 
     ### migrate from
@@ -24,7 +24,7 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
     end
 
     puts "\n\e[45m Please enter 'id' (no quotes) at the next prompt \e[0m"
-    Rails::Generators.invoke('declare_schema:migration', %w[-n -m])
+    generate_migrations '-n', '-m'
     expect(Foo.primary_key).to eq('id')
 
     nuke_model_class(Foo)
@@ -39,7 +39,7 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
     end
 
     puts "\n\e[45m Please enter 'drop id' (no quotes) at the next prompt \e[0m"
-    Rails::Generators.invoke('declare_schema:migration', %w[-n -m])
+    generate_migrations '-n', '-m'
     expect(Foo.primary_key).to eq('foo_id')
 
     ### ensure it doesn't cause further migrations

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -614,10 +614,12 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         drop_table :adverts
       EOS
       .and migrate_down(<<~EOS.strip)
-        create_table "adverts", id: :integer, force: :cascade do |t|
-          t.string "name", limit: 255
-          t.index ["id"], name: "PRIMARY_KEY", unique: true
+        create_table "adverts", id: false, force: :cascade do |t|
+          t.integer "id",   limit: 8
+          t.string  "name", limit: 255
         end
+
+        add_index "adverts", ["id"], name: "PRIMARY_KEY", unique: true
       EOS
     )
 

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -315,15 +315,18 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       belongs_to :category
     end
 
-    up, down = Generators::DeclareSchema::Migration::Migrator.run
-    expect(up.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
-      add_column :adverts, :category_id, :integer, limit: 8, null: false
-      add_index :adverts, [:category_id], name: 'on_category_id'
-    EOS
-    expect(down.sub(/\n+/, "\n")).to eq(<<~EOS.strip)
-      remove_column :adverts, :category_id
-      remove_index :adverts, name: :on_category_id rescue ActiveRecord::StatementInvalid
-    EOS
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :category_id, :integer, limit: 8, null: false
+
+        add_index :adverts, [:category_id], name: 'on_category_id'
+      EOS
+      .and migrate_down(<<~EOS.strip)
+        remove_column :adverts, :category_id
+
+        remove_index :adverts, name: :on_category_id rescue ActiveRecord::StatementInvalid
+      EOS
+    )
 
     Advert.field_specs.delete(:category_id)
     Advert.index_specs.delete_if {|spec| spec.fields==["category_id"]}
@@ -335,11 +338,14 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       fields { }
       belongs_to :category, foreign_key: "c_id", class_name: 'Category'
     end
-    up = Generators::DeclareSchema::Migration::Migrator.run.first
-    expect(up.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
-      add_column :adverts, :c_id, :integer, limit: 8, null: false
-      add_index :adverts, [:c_id], name: 'on_c_id'
-    EOS
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :c_id, :integer, limit: 8, null: false
+
+        add_index :adverts, [:c_id], name: 'on_c_id'
+      EOS
+    )
 
     Advert.field_specs.delete(:c_id)
     Advert.index_specs.delete_if { |spec| spec.fields == ["c_id"] }
@@ -351,8 +357,12 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       fields { }
       belongs_to :category, index: false
     end
-    up = Generators::DeclareSchema::Migration::Migrator.run.first
-    expect(up.gsub(/\n+/, "\n")).to eq("add_column :adverts, :category_id, :integer, limit: 8, null: false")
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :category_id, :integer, limit: 8, null: false
+      EOS
+    )
 
     Advert.field_specs.delete(:category_id)
     Advert.index_specs.delete_if { |spec| spec.fields == ["category_id"] }
@@ -364,11 +374,14 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       fields { }
       belongs_to :category, index: 'my_index'
     end
-    up = Generators::DeclareSchema::Migration::Migrator.run.first
-    expect(up.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
-      add_column :adverts, :category_id, :integer, limit: 8, null: false
-      add_index :adverts, [:category_id], name: 'my_index'
-    EOS
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :category_id, :integer, limit: 8, null: false
+
+        add_index :adverts, [:category_id], name: 'my_index'
+      EOS
+    )
 
     Advert.field_specs.delete(:category_id)
     Advert.index_specs.delete_if { |spec| spec.fields == ["category_id"] }
@@ -384,17 +397,19 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         optimistic_lock
       end
     end
-    up, down = Generators::DeclareSchema::Migration::Migrator.run
-    expect(up.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
-      add_column :adverts, :created_at, :datetime
-      add_column :adverts, :updated_at, :datetime
-      add_column :adverts, :lock_version, :integer, null: false, default: 1
-    EOS
-    expect(down.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
-      remove_column :adverts, :created_at
-      remove_column :adverts, :updated_at
-      remove_column :adverts, :lock_version
-    EOS
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :created_at, :datetime
+        add_column :adverts, :updated_at, :datetime
+        add_column :adverts, :lock_version, :integer, null: false, default: 1
+      EOS
+      .and migrate_down(<<~EOS.strip)
+        remove_column :adverts, :created_at
+        remove_column :adverts, :updated_at
+        remove_column :adverts, :lock_version
+      EOS
+    )
 
     Advert.field_specs.delete(:updated_at)
     Advert.field_specs.delete(:created_at)
@@ -409,11 +424,14 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         title :string, index: true, limit: 255, null: true
       end
     end
-    up = Generators::DeclareSchema::Migration::Migrator.run.first
-    expect(up.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
-      add_column :adverts, :title, :string, limit: 255
-      add_index :adverts, [:title], name: 'on_title'
-    EOS
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :title, :string, limit: 255
+
+        add_index :adverts, [:title], name: 'on_title'
+      EOS
+    )
 
     Advert.index_specs.delete_if { |spec| spec.fields==["title"] }
 
@@ -424,11 +442,14 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         title :string, index: true, unique: true, null: true, limit: 255
       end
     end
-    up = Generators::DeclareSchema::Migration::Migrator.run.first
-    expect(up.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
-      add_column :adverts, :title, :string, limit: 255
-      add_index :adverts, [:title], unique: true, name: 'on_title'
-    EOS
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :title, :string, limit: 255
+
+        add_index :adverts, [:title], unique: true, name: 'on_title'
+      EOS
+    )
 
     Advert.index_specs.delete_if { |spec| spec.fields == ["title"] }
 
@@ -439,11 +460,14 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         title :string, index: 'my_index', limit: 255, null: true
       end
     end
-    up = Generators::DeclareSchema::Migration::Migrator.run.first
-    expect(up.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
-      add_column :adverts, :title, :string, limit: 255
-      add_index :adverts, [:title], name: 'my_index'
-    EOS
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :title, :string, limit: 255
+
+        add_index :adverts, [:title], name: 'my_index'
+      EOS
+    )
 
     Advert.index_specs.delete_if { |spec| spec.fields==["title"] }
 
@@ -452,11 +476,14 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     class Advert < ActiveRecord::Base
       index :title
     end
-    up = Generators::DeclareSchema::Migration::Migrator.run.first
-    expect(up.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
-      add_column :adverts, :title, :string, limit: 255
-      add_index :adverts, [:title], name: 'on_title'
-    EOS
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :title, :string, limit: 255
+
+        add_index :adverts, [:title], name: 'on_title'
+      EOS
+    )
 
     Advert.index_specs.delete_if { |spec| spec.fields == ["title"] }
 
@@ -465,11 +492,14 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     class Advert < ActiveRecord::Base
       index :title, unique: true, name: 'my_index'
     end
-    up = Generators::DeclareSchema::Migration::Migrator.run.first
-    expect(up.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
-      add_column :adverts, :title, :string, limit: 255
-      add_index :adverts, [:title], unique: true, name: 'my_index'
-    EOS
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :title, :string, limit: 255
+
+        add_index :adverts, [:title], unique: true, name: 'my_index'
+      EOS
+    )
 
     Advert.index_specs.delete_if { |spec| spec.fields == ["title"] }
 
@@ -478,11 +508,14 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     class Advert < ActiveRecord::Base
       index [:title, :category_id]
     end
-    up = Generators::DeclareSchema::Migration::Migrator.run.first
-    expect(up.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
-      add_column :adverts, :title, :string, limit: 255
-      add_index :adverts, [:title, :category_id], name: 'on_title_and_category_id'
-    EOS
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :title, :string, limit: 255
+
+        add_index :adverts, [:title, :category_id], name: 'on_title_and_category_id'
+      EOS
+    )
 
     Advert.index_specs.delete_if { |spec| spec.fields==["title", "category_id"] }
 
@@ -505,19 +538,24 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     Advert.connection.schema_cache.clear!
     Advert.reset_column_information
 
-    up, down = Generators::DeclareSchema::Migration::Migrator.run("adverts" => "ads")
-    expect(up.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
-      rename_table :adverts, :ads
-      add_column :ads, :title, :string, limit: 255
-      add_column :ads, :body, :text
-      add_index :ads, [:id], unique: true, name: 'PRIMARY_KEY'
-    EOS
-    expect(down.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
-      remove_column :ads, :title
-      remove_column :ads, :body
-      rename_table :ads, :adverts
-      add_index :adverts, [:id], unique: true, name: 'PRIMARY_KEY'
-    EOS
+    expect(Generators::DeclareSchema::Migration::Migrator.run("adverts" => "ads")).to(
+      migrate_up(<<~EOS.strip)
+        rename_table :adverts, :ads
+
+        add_column :ads, :title, :string, limit: 255
+        add_column :ads, :body, :text
+
+        add_index :ads, [:id], unique: true, name: 'PRIMARY_KEY'
+      EOS
+      .and migrate_down(<<~EOS.strip)
+        remove_column :ads, :title
+        remove_column :ads, :body
+
+        rename_table :ads, :adverts
+
+        add_index :adverts, [:id], unique: true, name: 'PRIMARY_KEY'
+      EOS
+    )
 
     # Set the table name back to what it should be and confirm we're in sync:
 
@@ -541,21 +579,27 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         body :text, null: true
       end
     end
-    up, down = Generators::DeclareSchema::Migration::Migrator.run("adverts" => "advertisements")
-    expect(up.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
-      rename_table :adverts, :advertisements
-      add_column :advertisements, :title, :string, limit: 255
-      add_column :advertisements, :body, :text
-      remove_column :advertisements, :name
-      add_index :advertisements, [:id], unique: true, name: 'PRIMARY_KEY'
-    EOS
-    expect(down.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
-      remove_column :advertisements, :title
-      remove_column :advertisements, :body
-      add_column :adverts, :name, :string, limit: 255
-      rename_table :advertisements, :adverts
-      add_index :adverts, [:id], unique: true, name: 'PRIMARY_KEY'
-    EOS
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run("adverts" => "advertisements")).to(
+      migrate_up(<<~EOS.strip)
+        rename_table :adverts, :advertisements
+
+        add_column :advertisements, :title, :string, limit: 255
+        add_column :advertisements, :body, :text
+        remove_column :advertisements, :name
+
+        add_index :advertisements, [:id], unique: true, name: 'PRIMARY_KEY'
+      EOS
+      .and migrate_down(<<~EOS.strip)
+        remove_column :advertisements, :title
+        remove_column :advertisements, :body
+        add_column :adverts, :name, :string, limit: 255
+
+        rename_table :advertisements, :adverts
+
+        add_index :adverts, [:id], unique: true, name: 'PRIMARY_KEY'
+      EOS
+    )
 
     ### Drop a table
 
@@ -565,9 +609,17 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     # Dropping tables is where the automatic down-migration really comes in handy:
 
-    up, down = Generators::DeclareSchema::Migration::Migrator.run
-    expect(up).to eq("drop_table :adverts")
-    expect(down.gsub(/,.*/m, '')).to eq("create_table \"adverts\"")
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        drop_table :adverts
+      EOS
+      .and migrate_down(<<~EOS.strip)
+        create_table "adverts", id: :integer, force: :cascade do |t|
+          t.string "name", limit: 255
+          t.index ["id"], name: "PRIMARY_KEY", unique: true
+        end
+      EOS
+    )
 
     ## STI
 
@@ -588,15 +640,21 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     end
     class SuperFancyAdvert < FancyAdvert
     end
-    up, down = Generators::DeclareSchema::Migration::Migrator.run
-    expect(up.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
-      add_column :adverts, :type, :string, limit: 255
-      add_index :adverts, [:type], name: 'on_type'
-    EOS
-    expect(down.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
-      remove_column :adverts, :type
-      remove_index :adverts, name: :on_type rescue ActiveRecord::StatementInvalid
-    EOS
+
+    up, _ = Generators::DeclareSchema::Migration::Migrator.run do |migrations|
+      expect(migrations).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :type, :string, limit: 255
+
+          add_index :adverts, [:type], name: 'on_type'
+        EOS
+        .and migrate_down(<<~EOS.strip)
+          remove_column :adverts, :type
+
+          remove_index :adverts, name: :on_type rescue ActiveRecord::StatementInvalid
+        EOS
+      )
+    end
 
     Advert.field_specs.delete(:type)
     nuke_model_class(SuperFancyAdvert)
@@ -629,16 +687,17 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         body :text, null: true
       end
     end
-    up, down = Generators::DeclareSchema::Migration::Migrator.run(adverts: { title: :name })
-    expect(up).to eq(<<~EOS.strip)
-      rename_column :adverts, :title, :name
-      change_column :adverts, :name, :string, limit: 255, default: \"No Name\"
-    EOS
 
-    expect(down).to eq(<<~EOS.strip)
-      rename_column :adverts, :name, :title
-      change_column :adverts, :title, :string, limit: 255, default: \"Untitled\"
-    EOS
+    expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: { title: :name })).to(
+      migrate_up(<<~EOS.strip)
+        rename_column :adverts, :title, :name
+        change_column :adverts, :name, :string, limit: 255, default: "No Name"
+      EOS
+      .and migrate_down(<<~EOS.strip)
+        rename_column :adverts, :name, :title
+        change_column :adverts, :title, :string, limit: 255, default: "Untitled"
+      EOS
+    )
 
     ### Rename a table and add a column
 
@@ -650,13 +709,17 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         created_at :datetime
       end
     end
-    up = Generators::DeclareSchema::Migration::Migrator.run(adverts: :ads).first
-    expect(up.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
-      rename_table :adverts, :ads
-      add_column :ads, :created_at, :datetime, null: false
-      change_column :ads, :title, :string, limit: 255, null: false, default: \"Untitled\"
-      add_index :ads, [:id], unique: true, name: 'PRIMARY_KEY'
-    EOS
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: :ads)).to(
+      migrate_up(<<~EOS.strip)
+        rename_table :adverts, :ads
+
+        add_column :ads, :created_at, :datetime, null: false
+        change_column :ads, :title, :string, limit: 255, null: false, default: \"Untitled\"
+
+        add_index :ads, [:id], unique: true, name: 'PRIMARY_KEY'
+      EOS
+    )
 
     class Advert < ActiveRecord::Base
       fields do
@@ -677,11 +740,14 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       end
       self.primary_key = "advert_id"
     end
-    up, _down = Generators::DeclareSchema::Migration::Migrator.run(adverts: { id: :advert_id })
-    expect(up.gsub(/\n+/, "\n")).to eq(<<~EOS.strip)
-      rename_column :adverts, :id, :advert_id
-      add_index :adverts, [:advert_id], unique: true, name: 'PRIMARY_KEY'
-    EOS
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: { id: :advert_id })).to(
+      migrate_up(<<~EOS.strip)
+        rename_column :adverts, :id, :advert_id
+
+        add_index :adverts, [:advert_id], unique: true, name: 'PRIMARY_KEY'
+      EOS
+    )
 
     nuke_model_class(Advert)
     ActiveRecord::Base.connection.execute("drop table `adverts`;")

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -781,7 +781,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         end
       end
 
-      Rails::Generators.invoke('declare_schema:migration', %w[-n -m])
+      generate_migrations '-n', '-m'
 
       migrations = Dir.glob('db/migrate/*declare_schema_migration*.rb')
       expect(migrations.size).to eq(1), migrations.inspect

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,11 @@ require "bundler/setup"
 require "declare_schema"
 require "climate_control"
 
+require_relative "./support/acceptance_spec_helpers"
+
 RSpec.configure do |config|
+  config.include AcceptanceSpecHelpers
+
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 

--- a/spec/support/acceptance_spec_helpers.rb
+++ b/spec/support/acceptance_spec_helpers.rb
@@ -38,4 +38,24 @@ module AcceptanceSpecHelpers
     Rails.application.config.autoload_paths += ["#{TESTAPP_PATH}/app/models"]
     $LOAD_PATH << "#{TESTAPP_PATH}/app/models"
   end
+
+  def migrate_up(expected_value)
+    MigrationUpEquals.new(expected_value)
+  end
+
+  def migrate_down(expected_value)
+    MigrationDownEquals.new(expected_value)
+  end
+
+  class MigrationUpEquals < RSpec::Matchers::BuiltIn::Eq
+    def matches?(subject)
+      super(subject[0])
+    end
+  end
+
+  class MigrationDownEquals < RSpec::Matchers::BuiltIn::Eq
+    def matches?(subject)
+      super(subject[1])
+    end
+  end
 end

--- a/spec/support/acceptance_spec_helpers.rb
+++ b/spec/support/acceptance_spec_helpers.rb
@@ -4,4 +4,8 @@ module AcceptanceSpecHelpers
   def generate_model(model_name, *fields)
     Rails::Generators.invoke('declare_schema:model', [model_name, *fields])
   end
+
+  def generate_migrations(*flags)
+    Rails::Generators.invoke('declare_schema:migration', flags)
+  end
 end

--- a/spec/support/acceptance_spec_helpers.rb
+++ b/spec/support/acceptance_spec_helpers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module AcceptanceSpecHelpers
+  def generate_model(model_name, *fields)
+    Rails::Generators.invoke('declare_schema:model', [model_name, *fields])
+  end
+end

--- a/spec/support/acceptance_spec_helpers.rb
+++ b/spec/support/acceptance_spec_helpers.rb
@@ -10,24 +10,20 @@ module AcceptanceSpecHelpers
   end
 
   def expect_model_definition_to_eq(model, expectation)
-    model_file_path = "#{TESTAPP_PATH}/app/models/#{model}.rb"
-
-    expect(File.exist?(model_file_path)).to be_truthy
-    expect(File.read(model_file_path)).to eq(expectation)
+    expect_file_to_eq("#{TESTAPP_PATH}/app/models/#{model}.rb", expectation)
   end
 
   def expect_test_definition_to_eq(model, expectation)
-    test_file_path = "#{TESTAPP_PATH}/test/models/#{model}_test.rb"
-
-    expect(File.exist?(test_file_path)).to be_truthy
-    expect(File.read(test_file_path)).to eq(expectation)
+    expect_file_to_eq("#{TESTAPP_PATH}/test/models/#{model}_test.rb", expectation)
   end
 
   def expect_test_fixture_to_eq(model, expectation)
-    fixture_file_path = "#{TESTAPP_PATH}/test/fixtures/#{model}.yml"
+    expect_file_to_eq("#{TESTAPP_PATH}/test/fixtures/#{model}.yml", expectation)
+  end
 
-    expect(File.exist?(fixture_file_path)).to be_truthy
-    expect(File.read(fixture_file_path)).to eq(expectation)
+  def expect_file_to_eq(file_path, expectation)
+    expect(File.exist?(file_path)).to be_truthy
+    expect(File.read(file_path)).to eq(expectation)
   end
 
   def clean_up_model(model)

--- a/spec/support/acceptance_spec_helpers.rb
+++ b/spec/support/acceptance_spec_helpers.rb
@@ -8,4 +8,34 @@ module AcceptanceSpecHelpers
   def generate_migrations(*flags)
     Rails::Generators.invoke('declare_schema:migration', flags)
   end
+
+  def expect_model_definition_to_eq(model, expectation)
+    model_file_path = "#{TESTAPP_PATH}/app/models/#{model}.rb"
+
+    expect(File.exist?(model_file_path)).to be_truthy
+    expect(File.read(model_file_path)).to eq(expectation)
+  end
+
+  def expect_test_definition_to_eq(model, expectation)
+    test_file_path = "#{TESTAPP_PATH}/test/models/#{model}_test.rb"
+
+    expect(File.exist?(test_file_path)).to be_truthy
+    expect(File.read(test_file_path)).to eq(expectation)
+  end
+
+  def expect_test_fixture_to_eq(model, expectation)
+    fixture_file_path = "#{TESTAPP_PATH}/test/fixtures/#{model}.yml"
+
+    expect(File.exist?(fixture_file_path)).to be_truthy
+    expect(File.read(fixture_file_path)).to eq(expectation)
+  end
+
+  def clean_up_model(model)
+    system("rm -rf #{TESTAPP_PATH}/app/models/#{model}.rb #{TESTAPP_PATH}/test/models/#{model}.rb #{TESTAPP_PATH}/test/fixtures/#{model}.rb")
+  end
+
+  def load_models
+    Rails.application.config.autoload_paths += ["#{TESTAPP_PATH}/app/models"]
+    $LOAD_PATH << "#{TESTAPP_PATH}/app/models"
+  end
 end


### PR DESCRIPTION
This is the pre-review PR for the new helpers that are being added for running acceptance tests in the gem. These should help with readability and understandability of the code that is doing the tests.

The following helpers have been added so far with:
1. `generate_model` acts as a shorthand for running the command line generator method for `declare_schema:model`
2. `generate_migrations` acts as a shorthand for executing the command line generator `declare_schema:migration`
3. `clean_up_model` cleans up the necessary generated files for a given model
4. `expect_model_definition_to_eq` is a slim helper to help with comparing generated model files with the expected generated  source
5. `expect_test_definition_to_eq` is a slim helper to help with comparing generated model test files with the expected generated source
6. `expect_test_fixture_to_eq` is a slim helper to help with comparing generated fixture files with the expected generated source
7. `load_models` loads the test app's models into the ruby path
8. `migrate_up` is an RSpec matcher that takes in the result of `Migrator.run` and compares its expectation against the up portion of the migrations
9. `migrate_down` is an RSpec matcher that takes in the result of `Migrator.run` and compares its expectation against the down portion of the migrations

I've gone ahead and implemented the majority of usages, but not all because I would like some eyes on the new contract to make sure it's achieving it's original purpose before finalizing anything.