### PR TITLE
TECH-5016: suppress belongs_to optional: in rails4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 ## [0.3.1] - 2020-11-13
 ### Fixed
-- When passing `belongs_to` to Rails, suppress `optional:` option in Rails 4, since it predates the introduction of that option.  
+- When passing `belongs_to` to Rails, suppress the `optional:` option in Rails 4, since that option was added in Rails 5.
 
 ## [0.3.0] - 2020-11-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2020-11-13
+### Fixed
+- When passing `belongs_to` to Rails, suppress `optional:` option in Rails 4, since it predates the introduction of that option.  
+
 ## [0.3.0] - 2020-11-02
 ### Added
 - Added support for `belongs_to optional:`.
@@ -43,6 +47,7 @@ using the appropriate Rails configuration attributes.
 ### Added
 - Initial version from https://github.com/Invoca/hobo_fields v4.1.0.
 
+[0.3.1]: https://github.com/Invoca/declare_schema/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Invoca/declare_schema/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Invoca/declare_schema/compare/v0.1.3...v0.2.0
 [0.1.3]: https://github.com/Invoca/declare_schema/compare/v0.1.2...v0.1.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (0.3.0)
+    declare_schema (0.3.1)
       rails (>= 4.2)
 
 GEM

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -128,13 +128,17 @@ module DeclareSchema
 
         fk = options[:foreign_key]&.to_s || "#{name}_id"
 
-        if !options.has_key?(:optional) && Rails::VERSION::MAJOR >= 5
+        if !options.has_key?(:optional)
           options[:optional] = column_options[:null] # infer :optional from :null
         end
 
         fk_options[:dependent] = options.delete(:far_end_dependent) if options.has_key?(:far_end_dependent)
 
-        super(name, scope, options)
+        if Rails::VERSION::MAJOR >= 5
+          super(name, scope, options)
+        else
+          super(name, scope, options.except(:optional))
+        end
 
         refl = reflections[name.to_s] or raise "Couldn't find reflection #{name} in #{reflections.keys}"
         fkey = refl.foreign_key or raise "Couldn't find foreign_key for #{name} in #{refl.inspect}"

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -149,7 +149,6 @@ module DeclareSchema
           index([foreign_type, fkey], index_options) if index_options[:name] != false
         else
           index(fkey, index_options) if index_options[:name] != false
-          # options[:constraint_name] = options
           constraint(fkey, fk_options) if fk_options[:constraint_name] != false
         end
       end

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -145,7 +145,7 @@ module DeclareSchema
           index([foreign_type, fkey], index_options) if index_options[:name] != false
         else
           index(fkey, index_options) if index_options[:name] != false
-          options[:constraint_name] = options
+          # options[:constraint_name] = options
           constraint(fkey, fk_options) if fk_options[:constraint_name] != false
         end
       end

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -106,7 +106,7 @@ module DeclareSchema
       end
 
       # Extend belongs_to so that it creates a FieldSpec for the foreign key
-      def belongs_to(name, scope = nil, **options, &block)
+      def belongs_to(name, scope = nil, **options)
         column_options = {}
 
         column_options[:null] = if options.has_key?(:null)
@@ -135,7 +135,7 @@ module DeclareSchema
         fk_options[:dependent] = options.delete(:far_end_dependent) if options.has_key?(:far_end_dependent)
 
         if Rails::VERSION::MAJOR >= 5
-          super(name, scope, options)
+          super
         else
           super(name, scope, options.except(:optional))
         end

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -413,7 +413,7 @@ module Generators
             col_name = old_names[c] || c
             col = db_columns[col_name]
             spec = model.field_specs[c]
-            if spec.different_to?(col) # TODO: DRY this up to a diff function that returns the differences. It's different if it has differences. -Colin
+            if spec.different_to?(col) # TODO: TECH-4814 DRY this up to a diff function that returns the differences. It's different if it has differences. -Colin
               change_spec = fk_field_options(model, c)
               change_spec[:limit]     ||= spec.limit   if (spec.sql_type != :text ||
                                                          ::DeclareSchema::Model::FieldSpec.mysql_text_limits?) &&


### PR DESCRIPTION
Fixes TECH-5016

## [0.3.1] - 2020-11-13
### Fixed
- When passing `belongs_to` to Rails, suppress `optional:` option in Rails 4, since it predates the introduction of that option.  
