### PR TITLE
TECH-4995: support serialize columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 ## [0.4.0] - Unreleased
 ### Added
-- Fields may be declared with `serialize: true` or `serialize: Array`, `serialize: Hash` etc.
-This invokes the `ActiveSupport::Base#serialize` macro for that field, passing the coder type like `Array` or `Hash`, if given.
-Also, defaults may be given in their matching Ruby type--for example, `[]` or `{}`--in which case they will be transformed with `.to_yaml`
-before being set as the SQL default.
+- Fields may be declared with `serialize: true` or `serialize: <serializeable-class>`, where `<serializeable-class>` 
+may be `Array` (`Array` stored as YAML) or `Hash` (`Hash` stored as YAML), (`Array` or `Hash` or any scalar value stored as JSON)
+or any custom serializable class.
+This invokes `ActiveSupport`'s `serialize` macro for that field, passing the serializable class, if given.
+
+  Note: when `serialize:` is used, any `default:` should be given in a matching Ruby type--for example, `[]` or `{}` or `{ 'currency' => 'USD' }`--in
+which case the serializeable class will be used to determine the serialized default value and that will be set as the SQL default.
 
 ### Fixed
 - Sqlite now correctly infers the PRIMARY KEY so it won't attempt to add that index again.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.2] - Unreleased
+## [0.4.0] - Unreleased
+### Added
+- Fields may be declared with `serialize: true` or `serialize: Array`, `serialize: Hash` etc.
+This invokes the `ActiveSupport::Base#serialize` macro for that field, passing the coder type like `Array` or `Hash`, if given.
+Also, defaults may be given in their matching Ruby type--for example, `[]` or `{}`--in which case they will be transformed with `.to_yaml`
+before being set as the SQL default.
+
 ### Fixed
 - Sqlite now correctly infers the PRIMARY KEY so it won't attempt to add that index again.
 
@@ -51,7 +57,7 @@ using the appropriate Rails configuration attributes.
 ### Added
 - Initial version from https://github.com/Invoca/hobo_fields v4.1.0.
 
-[0.3.2]: https://github.com/Invoca/declare_schema/compare/v0.3.1...v0.3.2
+[0.4.0]: https://github.com/Invoca/declare_schema/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/Invoca/declare_schema/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Invoca/declare_schema/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Invoca/declare_schema/compare/v0.1.3...v0.2.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (0.3.2)
+    declare_schema (0.4.0)
       rails (>= 4.2)
 
 GEM

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -193,12 +193,12 @@ module DeclareSchema
       end
 
       def add_serialize_for_field(name, type, options)
-        if (serialize_value = options.delete(:serialize))
+        if (serialize_class = options.delete(:serialize))
           type == :string || type == :text or raise ArgumentError, "serialize field type must be :string or :text"
-          serialize_args = Array((serialize_value unless serialize_value == true))
+          serialize_args = Array((serialize_class unless serialize_class == true))
           serialize(name, *serialize_args)
           if options.has_key?(:default)
-            options[:default] = serialized_default(name, serialize_value == true ? Object : serialize_value, options[:default])
+            options[:default] = serialized_default(name, serialize_class == true ? Object : serialize_class, options[:default])
           end
         end
       end
@@ -209,8 +209,10 @@ module DeclareSchema
                   ActiveRecord::Coders::JSON
                 elsif [:load, :dump].all? { |x| class_name_or_coder.respond_to?(x) }
                   class_name_or_coder
-                else
+                elsif Rails::VERSION::MAJOR >= 5
                   ActiveRecord::Coders::YAMLColumn.new(attr_name, class_name_or_coder)
+                else
+                  ActiveRecord::Coders::YAMLColumn.new(class_name_or_coder)
                 end
 
         if default == coder.load(nil)

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -84,7 +84,7 @@ module DeclareSchema
         add_validations_for_field(name, type, args, options)
         add_index_for_field(name, args, options)
         field_specs[name] = ::DeclareSchema::Model::FieldSpec.new(self, name, type, options)
-        attr_order << name unless name.in?(attr_order)
+        attr_order << name unless attr_order.include?(name)
       end
 
       def index_definitions_with_primary_key

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -79,7 +79,7 @@ module DeclareSchema
       # declarations.
       def declare_field(name, type, *args)
         options = args.extract_options!
-        field_added(name, type, args, options) if respond_to?(:field_added)
+        try(:field_added, name, type, args, options)
         add_formatting_for_field(name, type, args)
         add_validations_for_field(name, type, args, options)
         add_index_for_field(name, args, options)
@@ -166,9 +166,8 @@ module DeclareSchema
       # does not effect the attribute in any way - it just records the
       # metadata.
       def declare_attr_type(name, type, options = {})
-        klass = DeclareSchema.to_class(type)
-        attr_types[name] = DeclareSchema.to_class(type)
-        klass.declared(self, name, options) if klass.respond_to?(:declared)
+        attr_types[name] = klass = DeclareSchema.to_class(type)
+        klass.try(:declared, self, name, options)
       end
 
       # Add field validations according to arguments in the

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -80,7 +80,7 @@ module DeclareSchema
       def declare_field(name, type, *args)
         options = args.extract_options!
         try(:field_added, name, type, args, options)
-        add_serializa_for_field(name, type, options)
+        add_serialize_for_field(name, type, options)
         add_formatting_for_field(name, type)
         add_validations_for_field(name, type, args, options)
         add_index_for_field(name, args, options)
@@ -192,12 +192,12 @@ module DeclareSchema
         end
       end
 
-      def add_serializa_for_field(name, type, options)
+      def add_serialize_for_field(name, type, options)
         if (serialize_value = options.delete(:serialize))
           type == :string || type == :text or raise ArgumentError, "serialize type must be :string or :text"
           serialize_args = Array((serialize_value unless serialize_value == true))
           serialize(name, *serialize_args)
-          if options.has_key?(:default) && !options[:default].is_a?(String)
+          if options.has_key?(:default) && !options[:default].is_a?(String) && !options[:default].nil?
             options[:default] = options[:default].to_yaml # ActiveRecord serialization is always stored as YAML
           end
         end

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "0.3.2"
+  VERSION = "0.4.0"
 end

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -839,6 +839,17 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       expect(Ad.serialize_args).to eq([[:allow_list, Hash]])
     end
 
+    it 'allows a nil default' do
+      class Ad < ActiveRecord::Base
+        fields do
+          allow_list :string, limit: 1024, serialize: Array, null: true, default: nil
+        end
+      end
+
+      expect(Ad.serialize_args).to eq([[:allow_list, Array]])
+      expect(Ad.field_specs['allow_list'].default).to eq(nil)
+    end
+
     it 'allows a String default' do
       class Ad < ActiveRecord::Base
         fields do
@@ -847,7 +858,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       end
 
       expect(Ad.serialize_args).to eq([[:allow_list, Array]])
-      expect(Ad.field_specs['allow_list']&.default).to eq("--- []\n")
+      expect(Ad.field_specs['allow_list'].default).to eq("--- []\n")
     end
 
     it 'allows a literal default' do

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -825,14 +825,14 @@ RSpec.describe 'DeclareSchema Migration Generator' do
           fields do
             allow_list :string, limit: 255, serialize: true, null: true, default: []
             allow_hash :string, limit: 255, serialize: true, null: true, default: {}
-            allow_string :string, limit: 255, serialize: true, null: true, default: 'abc'
+            allow_string :string, limit: 255, serialize: true, null: true, default: ['abc']
             allow_null :string, limit: 255, serialize: true, null: true, default: nil
           end
         end
 
         expect(Ad.field_specs['allow_list'].default).to eq("--- []\n")
         expect(Ad.field_specs['allow_hash'].default).to eq("--- {}\n")
-        expect(Ad.field_specs['allow_string'].default).to eq("--- abc\n")
+        expect(Ad.field_specs['allow_string'].default).to eq("---\n- abc\n")
         expect(Ad.field_specs['allow_null'].default).to eq(nil)
       end
     end


### PR DESCRIPTION
TECH-4995

## [0.4.0] - Unreleased
### Added
- Fields may be declared with `serialize: true` or `serialize: <serializeable-class>`, where `<serializeable-class>` 
may be `Array` (`Array` stored as YAML) or `Hash` (`Hash` stored as YAML), (`Array` or `Hash` or any scalar value stored as JSON) or any custom serializable class. This invokes `ActiveSupport`'s `serialize` macro for that field, passing the serializable class, if given.

  Note: when `serialize:` is used, any `default:` should be given in a matching Ruby type--for example, `[]` or `{}` or `{ 'currency' => 'USD' }`--in which case the serializeable class will be used to determine the serialized default value and that will be set as the SQL default.


BTW, here's how `deploybot` changes:
```
-    required_statuses    :string, array: true, limit: 1024, default: nil, null: true # ActiveRecord stores [] as null
+    required_statuses    :string, serialize: Array, limit: 1024, default: nil, null: true # ActiveRecord stores [] as null
     # TODO: rename this column (or remove it if it's not even used) to ignore_statuses
-    blacklisted_statuses :string, array: true, limit: 1024, default: nil, null: true # github statuses to ignore during deploys
-    git_status_configs   :string, array: true, limit: 1024, default: nil, null: true # Array of GitStatusConfigs
+    blacklisted_statuses :string, serialize: Array, limit: 1024, default: nil, null: true # github statuses to ignore during deploys
+    git_status_configs   :string, serialize: Array, limit: 1024, default: nil, null: true # Array of GitStatusConfigs
     can_rollback         :boolean, default: false
 
     disabled             :boolean, default: false
@@ -27,10 +27,6 @@ class DeployTypeConfig < ActiveRecord::Base
     timestamps
   end
 
-  serialize :required_statuses, Array
-  serialize :blacklisted_statuses, Array
-  serialize :git_status_configs, Array
```