### PR TITLE
no-jira/omit sqlite3 in mysql appraisals

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -2,30 +2,30 @@
 
 appraise 'rails-4-sqlite' do
   gem 'rails', '~> 4.2'
-  gem 'sqlite3', '~> 1.3.0'
 end
 
 appraise 'rails-4-mysql' do
   gem 'rails', '~> 4.2'
+  remove_gem 'sqlite3'
   gem 'mysql2'
 end
 
 appraise 'rails-5-sqlite' do
   gem 'rails', '~> 5.2'
-  gem 'sqlite3'
 end
 
 appraise 'rails-5-mysql' do
   gem 'rails', '~> 5.2'
+  remove_gem 'sqlite3'
   gem 'mysql2'
 end
 
 appraise 'rails-6-sqlite' do
   gem 'rails', '~> 6.1'
-  gem 'sqlite3'
 end
 
 appraise 'rails-6-mysql' do
   gem 'rails', '~> 6.1'
+  remove_gem 'sqlite3'
   gem 'mysql2'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :testapp do
   gem 'listen'
 end
 
-gem 'appraisal'
+gem 'appraisal',        github: 'thoughtbot/appraisal'
 gem 'bundler',          '< 2'
 gem "climate_control",  '~> 0.2'
 gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: git://github.com/thoughtbot/appraisal.git
+  revision: e095b8f48c1c6499941106c82d46dda7949c7cd7
+  specs:
+    appraisal (2.3.0)
+      bundler
+      rake
+      thor (>= 0.14.0)
+
 PATH
   remote: .
   specs:
@@ -48,10 +57,6 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    appraisal (2.3.0)
-      bundler
-      rake
-      thor (>= 0.14.0)
     arel (9.0.0)
     ast (2.4.1)
     bootsnap (1.5.1)
@@ -125,7 +130,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
-    rake (13.0.1)
+    rake (13.0.3)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -181,7 +186,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  appraisal
+  appraisal!
   bootsnap (>= 1.1.0)
   bundler (< 2)
   climate_control (~> 0.2)

--- a/gemfiles/rails_4_mysql.gemfile
+++ b/gemfiles/rails_4_mysql.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
+gem "appraisal", github: "thoughtbot/appraisal"
 gem "bundler", "< 2"
 gem "climate_control", "~> 0.2"
 gem "pry"

--- a/gemfiles/rails_4_sqlite.gemfile
+++ b/gemfiles/rails_4_sqlite.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
+gem "appraisal", github: "thoughtbot/appraisal"
 gem "bundler", "< 2"
 gem "climate_control", "~> 0.2"
 gem "pry"
@@ -12,7 +12,7 @@ gem "responders"
 gem "rspec"
 gem "rubocop"
 gem "yard"
-gem "sqlite3", "~> 1.3.0"
+gem "sqlite3", "~> 1.4"
 
 group :testapp do
   gem "bootsnap", ">= 1.1.0", require: false

--- a/gemfiles/rails_5_mysql.gemfile
+++ b/gemfiles/rails_5_mysql.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
+gem "appraisal", github: "thoughtbot/appraisal"
 gem "bundler", "< 2"
 gem "climate_control", "~> 0.2"
 gem "pry"

--- a/gemfiles/rails_5_sqlite.gemfile
+++ b/gemfiles/rails_5_sqlite.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
+gem "appraisal", github: "thoughtbot/appraisal"
 gem "bundler", "< 2"
 gem "climate_control", "~> 0.2"
 gem "pry"
@@ -12,7 +12,7 @@ gem "responders"
 gem "rspec"
 gem "rubocop"
 gem "yard"
-gem "sqlite3"
+gem "sqlite3", "~> 1.4"
 
 group :testapp do
   gem "bootsnap", ">= 1.1.0", require: false

--- a/gemfiles/rails_6_mysql.gemfile
+++ b/gemfiles/rails_6_mysql.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
+gem "appraisal", github: "thoughtbot/appraisal"
 gem "bundler", "< 2"
 gem "climate_control", "~> 0.2"
 gem "pry"

--- a/gemfiles/rails_6_sqlite.gemfile
+++ b/gemfiles/rails_6_sqlite.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
+gem "appraisal", github: "thoughtbot/appraisal"
 gem "bundler", "< 2"
 gem "climate_control", "~> 0.2"
 gem "pry"
@@ -12,7 +12,7 @@ gem "responders"
 gem "rspec"
 gem "rubocop"
 gem "yard"
-gem "sqlite3"
+gem "sqlite3", "~> 1.4"
 
 group :testapp do
   gem "bootsnap", ">= 1.1.0", require: false


### PR DESCRIPTION
- use thoughtbot appraisal so we can use `remove_gem`
- omit `sqlite3` gem in mysql appraisals