### PR TITLE
TECH-4814: make down migrations inverse of up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - Unreleased
+### Changed
+- Use `schema_attributes` for generating both up and down change migrations, so they are guaranteed to be symmetrical.
+  Note: Rails schema dumper is still used for the down migration to replace a model that has been dropped.
+
 ## [0.6.4] - 2020-02-08
 - Fixed a bug where the generated call to add_foreign_key() was not setting `column:`,
   so it only worked in cases where Rails could infer the foreign key by convention.
@@ -114,6 +119,7 @@ using the appropriate Rails configuration attributes.
 ### Added
 - Initial version from https://github.com/Invoca/hobo_fields v4.1.0.
 
+[0.7.0]: https://github.com/Invoca/declare_schema/compare/v0.6.3...v0.7.0
 [0.6.4]: https://github.com/Invoca/declare_schema/compare/v0.6.3...v0.6.4
 [0.6.3]: https://github.com/Invoca/declare_schema/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/Invoca/declare_schema/compare/v0.6.1...v0.6.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (0.6.4)
+    declare_schema (0.7.0)
       rails (>= 4.2)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
       thor (>= 0.14.0)
     arel (9.0.0)
     ast (2.4.1)
-    bootsnap (1.5.1)
+    bootsnap (1.7.2)
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
@@ -84,7 +84,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)
-    msgpack (1.3.3)
+    msgpack (1.4.2)
     nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
@@ -175,7 +175,7 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.25)
+    yard (0.9.26)
 
 PLATFORMS
   ruby

--- a/lib/declare_schema/model/column.rb
+++ b/lib/declare_schema/model/column.rb
@@ -37,12 +37,10 @@ module DeclareSchema
         #  time: { name: "time" },
         #  date: { name: "date" },
         #  binary: { name: "blob" },
-        #  boolean: { name: "boolean" },
-        #  json: { name: "json" } }
+        #  boolean: { name: "boolean" }
         def native_types
           @native_types ||= ActiveRecord::Base.connection.native_database_types.tap do |types|
             if ActiveRecord::Base.connection.class.name.match?(/mysql/i)
-              types[:integer][:limit] ||= 11
               types[:text][:limit]    ||= 0xffff
               types[:binary][:limit]  ||= 0xffff
             end
@@ -61,6 +59,7 @@ module DeclareSchema
 
         def deserialize_default_value(column, sql_type, default_value)
           sql_type or raise ArgumentError, "must pass sql_type; got #{sql_type.inspect}"
+
           case Rails::VERSION::MAJOR
           when 4
             # TODO: Delete this code ASAP! This could be wrong, since it's using the type of the old column...which

--- a/lib/declare_schema/model/column.rb
+++ b/lib/declare_schema/model/column.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+module DeclareSchema
+  class UnknownSqlTypeError < RuntimeError; end
+
+  module Model
+    # This class is a wrapper for the ActiveRecord::...::Column class
+    class Column
+      class << self
+        def native_type?(type)
+          type != :primary_key && native_types.has_key?(type)
+        end
+
+        def fix_native_types(types)
+          case ActiveRecord::Base.connection.class.name
+          when /mysql/i
+            types[:integer][:limit] ||= 11
+            types[:text][:limit]    ||= 0xffff
+            types[:binary][:limit]  ||= 0xffff
+          end
+          types
+        end
+
+        # MySQL example:
+        # { primary_key: "bigint auto_increment PRIMARY KEY",
+        #   string: { name: "varchar", limit: 255 },
+        #   text: { name: "text", limit: 65535},
+        #   integer: {name: "int", limit: 4 },
+        #   float: {name: "float", limit: 24 },
+        #   decimal: { name: "decimal" },
+        #   datetime: { name: "datetime" },
+        #   timestamp: { name: "timestamp" },
+        #   time: { name: "time" },
+        #   date: { name: "date" },
+        #   binary: { name>: "blob", limit: 65535 },
+        #   boolean: { name: "tinyint", limit: 1 },
+        #   json: { name: "json" } }
+        #
+        # SQLite example:
+        # { primary_key: "integer PRIMARY KEY AUTOINCREMENT NOT NULL",
+        #  string: { name: "varchar" },
+        #  text: { name: "text"},
+        #  integer: { name: "integer" },
+        #  float: { name: "float" },
+        #  decimal: { name: "decimal" },
+        #  datetime: { name: "datetime" },
+        #  time: { name: "time" },
+        #  date: { name: "date" },
+        #  binary: { name: "blob" },
+        #  boolean: { name: "boolean" },
+        #  json: { name: "json" } }
+        def native_types
+          @native_types ||= fix_native_types(ActiveRecord::Base.connection.native_database_types)
+        end
+
+        def sql_type(type)
+          if native_type?(type)
+            type
+          else
+            if (field_class = DeclareSchema.to_class(type))
+              field_class::COLUMN_TYPE
+            end or raise UnknownSqlTypeError, "#{type.inspect} for type #{type.inspect}"
+          end
+        end
+
+        def deserialize_default_value(column, sql_type, default_value)
+          sql_type or raise ArgumentError, "must pass sql_type; got #{sql_type.inspect}"
+          case Rails::VERSION::MAJOR
+          when 4
+            # TODO: Delete this code ASAP! This could be wrong, since it's using the type of the old column...which
+            # might be getting migrated to a new type. We should be using just sql_type. -Colin
+            column.type_cast_from_database(default_value)
+          else
+            cast_type = ActiveRecord::Base.connection.send(:lookup_cast_type, sql_type) or
+              raise "cast_type not found for #{sql_type}"
+            cast_type.deserialize(default_value)
+          end
+        end
+      end
+
+      def initialize(model, current_table_name, column)
+        @model = model or raise ArgumentError, "must pass model"
+        @current_table_name = current_table_name or raise ArgumentError, "must pass current_table_name"
+        @column = column or raise ArgumentError, "must pass column"
+      end
+
+      def sql_type
+        @sql_type ||= self.class.sql_type(@column.type)
+      end
+
+      SCHEMA_KEYS = [:type, :limit, :precision, :scale, :null, :default].freeze
+
+      def schema_attributes
+        SCHEMA_KEYS.each_with_object({}) do |key, result|
+          # omit any of these keys that aren't applicable for this column
+          next if key.in?([:limit, :precision, :scale]) &&
+            (@column.sql_type_metadata.try(key).nil? || @column.send(key).nil?)
+
+          result[key] =
+            case key
+            when :default
+              self.class.deserialize_default_value(@column, sql_type, @column.default)
+            else
+              col_value = @column.send(key)
+              if col_value.nil? && (native_type = self.class.native_types[@column.type])
+                native_type[key]
+              else
+                col_value
+              end
+            end
+        end.tap do |result|
+          if ActiveRecord::Base.connection.class.name.match?(/mysql/i) && @column.type.in?([:string, :text])
+            result.merge!(collation_and_charset_for_column(@current_table_name, @column.name))
+          end
+        end
+      end
+
+      private
+
+      def collation_and_charset_for_column(current_table_name, column_name)
+        connection    = ActiveRecord::Base.connection
+        connection.class.name.match?(/mysql/i) or raise ArgumentError, "only supported for MySQL"
+
+        database_name = connection.current_database
+
+        defaults = connection.select_one(<<~EOS)
+          SELECT C.character_set_name, C.collation_name
+          FROM information_schema.`COLUMNS` C
+          WHERE C.table_schema = '#{connection.quote_string(database_name)}' AND
+                C.table_name = '#{connection.quote_string(current_table_name)}' AND
+                C.column_name = '#{connection.quote_string(column_name)}';
+        EOS
+
+        defaults && defaults["character_set_name"] or raise "character_set_name missing from #{defaults.inspect} from #{database_name}.#{current_table_name}.#{column_name}"
+        defaults && defaults["collation_name"]     or raise "collation_name missing from #{defaults.inspect}"
+
+        {
+          charset:   defaults["character_set_name"],
+          collation: defaults["collation_name"]
+        }
+      end
+    end
+  end
+end

--- a/lib/declare_schema/model/column.rb
+++ b/lib/declare_schema/model/column.rb
@@ -86,6 +86,7 @@ module DeclareSchema
 
       SCHEMA_KEYS = [:type, :limit, :precision, :scale, :null, :default].freeze
 
+      # omits keys with nil values
       def schema_attributes
         SCHEMA_KEYS.each_with_object({}) do |key, result|
           # omit any of these keys that aren't applicable for this column
@@ -108,7 +109,7 @@ module DeclareSchema
           if ActiveRecord::Base.connection.class.name.match?(/mysql/i) && @column.type.in?([:string, :text])
             result.merge!(collation_and_charset_for_column(@current_table_name, @column.name))
           end
-        end
+        end.compact
       end
 
       private

--- a/lib/declare_schema/model/column.rb
+++ b/lib/declare_schema/model/column.rb
@@ -37,7 +37,8 @@ module DeclareSchema
         #  time: { name: "time" },
         #  date: { name: "date" },
         #  binary: { name: "blob" },
-        #  boolean: { name: "boolean" }
+        #  boolean: { name: "boolean" },
+        #  json: { name: "json" } }
         def native_types
           @native_types ||= ActiveRecord::Base.connection.native_database_types.tap do |types|
             if ActiveRecord::Base.connection.class.name.match?(/mysql/i)

--- a/lib/declare_schema/model/column.rb
+++ b/lib/declare_schema/model/column.rb
@@ -63,8 +63,8 @@ module DeclareSchema
 
           case Rails::VERSION::MAJOR
           when 4
-            # TODO: Delete this code ASAP! This could be wrong, since it's using the type of the old column...which
-            # might be getting migrated to a new type. We should be using just sql_type. -Colin
+            # TODO: Delete this Rails 4 support ASAP! This could be wrong, since it's using the type of the old column...which
+            # might be getting migrated to a new type. We should be using just sql_type as below. -Colin
             column.type_cast_from_database(default_value)
           else
             cast_type = ActiveRecord::Base.connection.send(:lookup_cast_type, sql_type) or

--- a/lib/declare_schema/model/column.rb
+++ b/lib/declare_schema/model/column.rb
@@ -78,8 +78,8 @@ module DeclareSchema
         # may be run with a different adapter.
         # This method never mutates its argument. In fact it freezes it to be certain.
         def normalize_schema_attributes(schema_attributes)
-          schema_attributes.freeze
           schema_attributes[:type] or raise ArgumentError, ":type key not found; keys: #{schema_attributes.keys.inspect}"
+          schema_attributes.freeze
 
           case ActiveRecord::Base.connection.class.name
           when /mysql/i

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -121,10 +121,11 @@ module DeclareSchema
 
       # returns the attributes for schema migrations as a Hash
       # omits name and position since those are meta-data above the schema
+      # omits keys with nil values
       def schema_attributes(col_spec)
         @options.merge(type: @type).tap do |attrs|
           attrs[:default] = Column.deserialize_default_value(col_spec, @sql_type, attrs[:default])
-        end
+        end.compact
       end
     end
   end

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -60,8 +60,6 @@ module DeclareSchema
         @position = position
         @options = options.dup
 
-        @options.has_key?(:default) or @options[:default] = nil
-
         @options.has_key?(:null) or @options[:null] = false
 
         case type
@@ -79,7 +77,7 @@ module DeclareSchema
           @options[:limit] = 8
         end
 
-        # TODO: Do we really need to support a :sql_type option? Ideally drop it. -Colin
+        # TODO: Do we really need to support a :sql_type option? Ideally, drop it. -Colin
         @sql_type = @options.delete(:sql_type) || Column.sql_type(@type)
 
         if @sql_type.in?([:string, :text, :binary, :varbinary, :integer, :enum])
@@ -113,13 +111,6 @@ module DeclareSchema
 
         @sql_options = @options.except(*NON_SQL_OPTIONS)
       end
-
-      SQLITE_COLUMN_CLASS =
-        begin
-          ActiveRecord::ConnectionAdapters::SQLiteColumn
-        rescue NameError
-          NilClass
-        end
 
       # returns the attributes for schema migrations as a Hash
       # omits name and position since those are meta-data above the schema

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -69,6 +69,8 @@ module DeclareSchema
           if self.class.mysql_text_limits?
             @options[:default].nil? or raise MysqlTextMayNotHaveDefault, "when using MySQL, non-nil default may not be given for :text field #{model}##{@name}"
             @options[:limit] = self.class.round_up_mysql_text_limit(@options[:limit] || MYSQL_LONGTEXT_LIMIT)
+          else
+            @options[:limit] = nil
           end
         when :string
           @options[:limit] or raise "limit: must be given for :string field #{model}##{@name}: #{@options.inspect}; do you want `limit: 255`?"

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -62,6 +62,9 @@ module DeclareSchema
           if ActiveRecord::Base.connection.class.name.match?(/mysql/i)
             @options[:charset]   ||= model.table_options[:charset]   || Generators::DeclareSchema::Migration::Migrator.default_charset
             @options[:collation] ||= model.table_options[:collation] || Generators::DeclareSchema::Migration::Migrator.default_collation
+          else
+            @options.delete(:charset)
+            @options.delete(:collation)
           end
         else
           @options[:charset]   and raise "charset may only given for :string and :text fields"

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -83,15 +83,18 @@ module DeclareSchema
         if @sql_type.in?([:string, :text, :binary, :varbinary, :integer, :enum])
           @options[:limit] ||= Column.native_types[@sql_type][:limit]
         else
-          @options.has_key?(:limit) and raise "unsupported limit: for SQL type #{@sql_type} in field #{model}##{@name}"
+          @sql_type != :decimal && @options.has_key?(:limit) and warn("unsupported limit: for SQL type #{@sql_type} in field #{model}##{@name}")
+          @options.delete(:limit)
         end
 
         if @sql_type == :decimal
-          @options[:precision] or raise 'precision: required for :decimal type'
-          @options[:scale] or raise 'scale: required for :decimal type'
+          @options[:precision] or warn("precision: required for :decimal type in field #{model}##{@name}")
+          @options[:scale] or warn("scale: required for :decimal type in field #{model}##{@name}")
         else
-          @options.has_key?(:precision) and raise "precision: only allowed for :decimal type"
-          @options.has_key?(:scale) and raise "scale: only allowed for :decimal type"
+          if @sql_type != :datetime
+            @options.has_key?(:precision) and warn("precision: only allowed for :decimal type or :datetime for SQL type #{@sql_type} in field #{model}##{@name}")
+          end
+          @options.has_key?(:scale) and warn("scale: only allowed for :decimal type for SQL type #{@sql_type} in field #{model}##{@name}")
         end
 
         if @type.in?([:text, :string])
@@ -103,8 +106,8 @@ module DeclareSchema
             @options.delete(:collation)
           end
         else
-          @options[:charset]   and raise "charset may only given for :string and :text fields"
-          @options[:collation] and raise "collation may only given for :string and :text fields"
+          @options[:charset]   and warn("charset may only given for :string and :text fields for SQL type #{@sql_type} in field #{model}##{@name}")
+          @options[:collation] and warne("collation may only given for :string and :text fields for SQL type #{@sql_type} in field #{model}##{@name}")
         end
 
         @options = Hash[@options.sort_by { |k, _v| OPTION_INDEXES[k] || 9999 }]

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -156,23 +156,21 @@ module DeclareSchema
       private
 
       def same_attributes?(col_spec)
-        native_type = native_types[type]
-        check_attributes = [:null, :default, :precision, :scale]
-        check_attributes.all? do |k|
+        schema_attributes.all? do |k, v|
           if k == :default
             case Rails::VERSION::MAJOR
             when 4
-              col_spec.type_cast_from_database(col_spec.default) == col_spec.type_cast_from_database(default)
+              col_spec.type_cast_from_database(col_spec.default) == col_spec.type_cast_from_database(v)
             else
               cast_type = ActiveRecord::Base.connection.lookup_cast_type_from_column(col_spec) or raise "cast_type not found for #{col_spec.inspect}"
-              cast_type.deserialize(col_spec.default) == cast_type.deserialize(default)
+              cast_type.deserialize(col_spec.default) == cast_type.deserialize(v)
             end
           else
             col_value = col_spec.send(k)
-            if col_value.nil? && native_type
+            if col_value.nil? && (native_type = native_types[type])
               col_value = native_type[k]
             end
-            col_value == send(k)
+            col_value == v
           end
         end
       end

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -78,6 +78,12 @@ module DeclareSchema
           NilClass
         end
 
+      # returns the attributes for schema migrations as a Hash
+      # omits name and position since those are meta-data above the schema
+      def schema_attributes
+        { type: @type }.merge(@options)
+      end
+
       def sql_type
         @options[:sql_type] || begin
                                 if native_type?(type)

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -150,7 +150,7 @@ module DeclareSchema
       def same_attributes?(col_spec)
         native_type = native_types[type]
         check_attributes = [:null, :default]
-        check_attributes += [:precision, :scale] if @sql_type == :decimal && !col_spec.is_a?(SQLITE_COLUMN_CLASS)  # remove when rails fixes https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/2872
+        check_attributes += [:precision, :scale] if @sql_type == :decimal
         check_attributes.all? do |k|
           if k == :default
             case Rails::VERSION::MAJOR

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -128,14 +128,13 @@ module DeclareSchema
         @options[:collation]
       end
 
-      def different_to?(table_name, col_spec)
-        !same_as(table_name, col_spec)
+      def different_to?(col_spec)
+        !same_as(col_spec)
       end
 
-      def same_as(table_name, col_spec)
+      def same_as(col_spec)
         @sql_type == col_spec.type &&
-          same_attributes?(col_spec) &&
-          (!type.in?([:text, :string]) || same_charset_and_collation?(table_name, col_spec))
+          same_attributes?(col_spec)
       end
 
       private

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
+require_relative 'column'
+
 module DeclareSchema
-  class UnknownSqlTypeError < RuntimeError; end
   class MysqlTextMayNotHaveDefault < RuntimeError; end
 
   module Model
@@ -29,20 +30,6 @@ module DeclareSchema
               mysql_supported_text_limit
             end
           end or raise ArgumentError, "limit of #{limit} is too large for MySQL"
-        end
-
-        def deserialize_default_value(col_spec, sql_type, default_value)
-          sql_type or raise ArgumentError, "must pass sql_type; got #{sql_type.inspect}"
-          case Rails::VERSION::MAJOR
-          when 4
-            # TODO: Delete this code ASAP! This could be wrong, since it's using the type of the old column...which
-            # might be getting migrated to a new type. We should be using just sql_type. -Colin
-            col_spec.type_cast_from_database(default_value)
-          else
-            cast_type = ActiveRecord::Base.connection.send(:lookup_cast_type, sql_type) or
-              raise "cast_type not found for #{sql_type}"
-            cast_type.deserialize(default_value)
-          end
         end
       end
 
@@ -90,17 +77,11 @@ module DeclareSchema
           @options[:limit] = 8
         end
 
-        @sql_type = @options.delete(:sql_type) || # TODO: Do we really need to support a :sql_type option? Ideally drop it. -Colin
-          if native_type?(@type)
-            @type
-          else
-            if (field_class = DeclareSchema.to_class(@type))
-              field_class::COLUMN_TYPE
-            end or raise UnknownSqlTypeError, "#{@type.inspect} for #{model}##{@name}"
-          end
+        # TODO: Do we really need to support a :sql_type option? Ideally drop it. -Colin
+        @sql_type = @options.delete(:sql_type) || Column.sql_type(@type)
 
         if @sql_type.in?([:string, :text, :binary, :varbinary, :integer, :enum])
-          @options[:limit] ||= native_types[@sql_type][:limit]
+          @options[:limit] ||= Column.native_types[@sql_type][:limit]
         else
           @options.has_key?(:limit) and raise "unsupported limit: for SQL type #{@sql_type} in field #{model}##{@name}"
         end
@@ -142,101 +123,8 @@ module DeclareSchema
       # omits name and position since those are meta-data above the schema
       def schema_attributes(col_spec)
         @options.merge(type: @type).tap do |attrs|
-          attrs[:default] = self.class.deserialize_default_value(col_spec, @sql_type, attrs[:default])
+          attrs[:default] = Column.deserialize_default_value(col_spec, @sql_type, attrs[:default])
         end
-      end
-
-      # TODO: introduce a new class that encapsulates the Column Spec. Move this and cached_collation_and_charset_for_column
-      # into that class. -Colin
-      def col_spec_attributes(col_spec, keys)
-        keys.each_with_object({}) do |key, result|
-          result[key] =
-            case key
-            when :default
-              self.class.deserialize_default_value(col_spec, @sql_type, col_spec.default)
-            when :charset
-              cached_collation_and_charset_for_column(col_spec.table_name, col_spec)[:charset]
-            when :collation
-              cached_collation_and_charset_for_column(col_spec.table_name, col_spec)[:collation]
-            else
-              col_value = col_spec.send(key)
-              if col_value.nil? && (native_type = native_types[type])
-                native_type[key]
-              else
-                col_value
-              end
-            end
-        end
-      end
-
-      private
-
-      def cached_collation_and_charset_for_column(table_name, col_spec)
-        @collation_and_charset_for_column_cache ||= {}
-        @collation_and_charset_for_column_cache[[table_name, col_spec]] ||= collation_and_charset_for_column(table_name, col_spec)
-      end
-
-      def collation_and_charset_for_column(table_name, col_spec)
-        column_name   = col_spec.name
-        connection    = ActiveRecord::Base.connection
-
-        if connection.class.name.match?(/mysql/i)
-          database_name = connection.current_database
-
-          defaults = connection.select_one(<<~EOS)
-            SELECT C.character_set_name, C.collation_name
-            FROM information_schema.`COLUMNS` C
-            WHERE C.table_schema = '#{connection.quote_string(database_name)}' AND
-                  C.table_name = '#{connection.quote_string(table_name)}' AND
-                  C.column_name = '#{connection.quote_string(column_name)}';
-          EOS
-
-          defaults["character_set_name"] or raise "character_set_name missing from #{defaults.inspect}"
-          defaults["collation_name"]     or raise "collation_name missing from #{defaults.inspect}"
-
-          {
-            charset:   defaults["character_set_name"],
-            collation: defaults["collation_name"]
-          }
-        else
-          {}
-        end
-      end
-
-      def native_type?(type)
-        type != :primary_key && native_types.has_key?(type)
-      end
-
-      # MySQL example:
-      # { primary_key: "bigint auto_increment PRIMARY KEY",
-      #   string: { name: "varchar", limit: 255 },
-      #   text: { name: "text", limit: 65535},
-      #   integer: {name: "int", limit: 4 },
-      #   float: {name: "float", limit: 24 },
-      #   decimal: { name: "decimal" },
-      #   datetime: { name: "datetime" },
-      #   timestamp: { name: "timestamp" },
-      #   time: { name: "time" },
-      #   date: { name: "date" },
-      #   binary: { name>: "blob", limit: 65535 },
-      #   boolean: { name: "tinyint", limit: 1 },
-      #   json: { name: "json" } }
-      #
-      # SQLite example:
-      # { primary_key: "integer PRIMARY KEY AUTOINCREMENT NOT NULL",
-      #  string: { name: "varchar" },
-      #  text: { name: "text"},
-      #  integer: { name: "integer" },
-      #  float: { name: "float" },
-      #  decimal: { name: "decimal" },
-      #  datetime: { name: "datetime" },
-      #  time: { name: "time" },
-      #  date: { name: "date" },
-      #  binary: { name: "blob" },
-      #  boolean: { name: "boolean" },
-      #  json: { name: "json" } }
-      def native_types
-        Generators::DeclareSchema::Migration::Migrator.native_types
       end
     end
   end

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -205,9 +205,37 @@ module DeclareSchema
       end
 
       def native_type?(type)
-        type.to_sym != :primary_key && native_types.has_key?(type)
+        type != :primary_key && native_types.has_key?(type)
       end
 
+      # MySQL example:
+      # { primary_key: "bigint auto_increment PRIMARY KEY",
+      #   string: { name: "varchar", limit: 255 },
+      #   text: { name: "text", limit: 65535},
+      #   integer: {name: "int", limit: 4 },
+      #   float: {name: "float", limit: 24 },
+      #   decimal: { name: "decimal" },
+      #   datetime: { name: "datetime" },
+      #   timestamp: { name: "timestamp" },
+      #   time: { name: "time" },
+      #   date: { name: "date" },
+      #   binary: { name>: "blob", limit: 65535 },
+      #   boolean: { name: "tinyint", limit: 1 },
+      #   json: { name: "json" } }
+      #
+      # SQLite example:
+      # { primary_key: "integer PRIMARY KEY AUTOINCREMENT NOT NULL",
+      #  string: { name: "varchar" },
+      #  text: { name: "text"},
+      #  integer: { name: "integer" },
+      #  float: { name: "float" },
+      #  decimal: { name: "decimal" },
+      #  datetime: { name: "datetime" },
+      #  time: { name: "time" },
+      #  date: { name: "date" },
+      #  binary: { name: "blob" },
+      #  boolean: { name: "boolean" },
+      #  json: { name: "json" } }
       def native_types
         Generators::DeclareSchema::Migration::Migrator.native_types
       end

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -107,7 +107,7 @@ module DeclareSchema
           @options[:collation] and raise "collation may only given for :string and :text fields"
         end
 
-        @options = Hash[@options.sort_by { |k, v| OPTION_INDEXES[k] }]
+        @options = Hash[@options.sort_by { |k, _v| OPTION_INDEXES[k] || 9999 }]
 
         @sql_options = @options.except(*NON_SQL_OPTIONS)
       end

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "0.6.4"
+  VERSION = "0.7.0"
 end

--- a/lib/generators/declare_schema/migration/migration_generator.rb
+++ b/lib/generators/declare_schema/migration/migration_generator.rb
@@ -96,7 +96,7 @@ module DeclareSchema
           end
         end
       end
-    rescue ::DeclareSchema::Model::FieldSpec::UnknownSqlTypeError => ex
+    rescue ::DeclareSchema::UnknownSqlTypeError => ex
       say "Invalid field type: #{ex}"
     end
 

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -438,12 +438,12 @@ module Generators
           changes = []
           undo_changes = []
           to_change.each do |col_name_to_change|
-            orig_col_name = old_names[col_name_to_change] || col_name_to_change
-            column = db_columns[orig_col_name] or raise "failed to find column info for #{orig_col_name.inspect}"
-            spec = model.field_specs[col_name_to_change] or raise "failed to find field spec for #{col_name_to_change.inspect}"
-            spec_attrs = spec.schema_attributes(column)
+            orig_col_name      = old_names[col_name_to_change] || col_name_to_change
+            column             = db_columns[orig_col_name] or raise "failed to find column info for #{orig_col_name.inspect}"
+            spec               = model.field_specs[col_name_to_change] or raise "failed to find field spec for #{col_name_to_change.inspect}"
+            spec_attrs         = spec.schema_attributes(column)
             column_declaration = ::DeclareSchema::Model::Column.new(model, current_table_name, column)
-            col_attrs = column_declaration.schema_attributes
+            col_attrs          = column_declaration.schema_attributes
             if !::DeclareSchema::Model::Column.equivalent_schema_attributes?(spec_attrs, col_attrs)
               normalized_schema_attributes = spec_attrs.merge(fk_field_options(model, col_name_to_change))
 

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -453,8 +453,9 @@ module Generators
           to_change.each do |c|
             col_name = old_names[c] || c
             col = db_columns[col_name]
-            spec = model.field_specs[c]
-            if spec.different_to?(current_table_name, col) # TODO: TECH-4814 DRY this up to a diff function that returns the differences. It's different if it has differences. -Colin
+            spec = model.field_specs[c] or raise "failed to find field spec for #{c.inspect}"
+            declared_schema_attributes = spec.schema_attributes
+            if spec.different_to?(current_table_name, col)
               change_spec = fk_field_options(model, c)
               change_spec[:limit]     ||= spec.limit   if (spec.sql_type != :text ||
                                                          ::DeclareSchema::Model::FieldSpec.mysql_text_limits?) &&

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -454,8 +454,9 @@ module Generators
             col_name = old_names[c] || c
             col = db_columns[col_name] or raise "failed to find column info for #{col_name.inspect}"
             spec = model.field_specs[c] or raise "failed to find field spec for #{c.inspect}"
-            declared_schema_attributes = spec.schema_attributes
-            if spec.different_to?(col)
+            declared_schema_attributes = spec.schema_attributes(col)
+            col_attrs = spec.class.col_spec_attributes(col, declared_schema_attributes.keys)
+            if schema_attrs != col_attrs
               change_spec = fk_field_options(model, c)
               change_spec[:limit]     ||= spec.limit   if (spec.sql_type != :text ||
                                                          ::DeclareSchema::Model::FieldSpec.mysql_text_limits?) &&

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -455,10 +455,10 @@ module Generators
           end
 
           index_changes, undo_index_changes = change_indexes(model, current_table_name, to_remove)
-          fk_changes, undo_fk_changes = if ActiveRecord::Base.connection.class.name.match?(/mysql/i)
-                                          change_foreign_key_constraints(model, current_table_name)
-                                        else
+          fk_changes, undo_fk_changes = if ActiveRecord::Base.connection.class.name.match?(/SQLite3Adapter/)
                                           [[], []]
+                                        else
+                                          change_foreign_key_constraints(model, current_table_name)
                                         end
           table_options_changes, undo_table_options_changes = if ActiveRecord::Base.connection.class.name.match?(/mysql/i)
                                                                 change_table_options(model, current_table_name)

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -450,7 +450,7 @@ module Generators
               # changing_keys = normalized_schema_attributes.keys - same_attrs.keys
               type = normalized_schema_attributes.delete(:type) or raise "no :type found in #{normalized_schema_attributes.inspect}"
               changes << ["change_column #{new_table_name.to_sym.inspect}", c.to_sym.inspect,
-                          type.to_sym.inspect, *format_options(normalized_schema_attributes.compact)].join(", ")
+                          type.to_sym.inspect, *format_options(normalized_schema_attributes)].join(", ")
               undo_changes << change_column_back(model, current_table_name, col_name)
             end
           end.compact
@@ -609,9 +609,9 @@ module Generators
           with_previous_model_table_name(model, current_table_name) do
             col = model.columns_hash[column] or raise "no columns_hash entry found for #{column} in #{model.inspect}"
             col_spec = ::DeclareSchema::Model::Column.new(model, current_table_name, col)
-            options = col_spec.schema_attributes
-            type = options.delete(:type) or raise "no :type found in #{options.inspect}"
-            ["add_column :#{current_table_name}, :#{column}, #{type.inspect}", *format_options(options.compact)].join(', ')
+            schema_attributes = col_spec.schema_attributes
+            type = schema_attributes.delete(:type) or raise "no :type found in #{schema_attributes.inspect}"
+            ["add_column :#{current_table_name}, :#{column}, #{type.inspect}", *format_options(schema_attributes)].join(', ')
           end
         end
 
@@ -619,9 +619,9 @@ module Generators
           with_previous_model_table_name(model, current_table_name) do
             col = model.columns_hash[column] or raise "no columns_hash entry found for #{column} in #{model.inspect}"
             col_spec = ::DeclareSchema::Model::Column.new(model, current_table_name, col)
-            options = col_spec.schema_attributes
-            type = options.delete(:type) or raise "no :type found in #{options.inspect}"
-            ["change_column #{current_table_name.to_sym.inspect}", column.to_sym.inspect, type.to_sym.inspect, *format_options(options.compact)].join(', ')
+            schema_attributes = col_spec.schema_attributes
+            type = schema_attributes.delete(:type) or raise "no :type found in #{schema_attributes.inspect}"
+            ["change_column #{current_table_name.to_sym.inspect}", column.to_sym.inspect, type.to_sym.inspect, *format_options(schema_attributes)].join(', ')
           end
         end
 

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -443,7 +443,7 @@ module Generators
             spec = model.field_specs[c] or raise "failed to find field spec for #{c.inspect}"
             declared_schema_attributes = spec.schema_attributes(col)
             col_attrs = column_declaration.schema_attributes
-            if declared_schema_attributes != col_attrs
+            if !::DeclareSchema::Model::Column.equivalent_schema_attributes?(declared_schema_attributes, col_attrs)
               normalized_schema_attributes = declared_schema_attributes.merge(fk_field_options(model, c))
 
               # same_attrs = Hash[normalized_schema_attributes.map { |k, v| col_attrs[k] == v }]
@@ -551,10 +551,6 @@ module Generators
 
         def format_options(options)
           options.map do |k, v|
-            # if !changing && ((k == :limit && type == :decimal) || (k == :null && v == true))
-            #   next
-            # end
-
             if k.is_a?(Symbol)
               "#{k}: #{v.inspect}"
             else

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'active_record'
+require 'active_record/connection_adapters/abstract_adapter'
 
 module Generators
   module DeclareSchema

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -452,10 +452,10 @@ module Generators
           undo_changes = []
           to_change.each do |c|
             col_name = old_names[c] || c
-            col = db_columns[col_name]
+            col = db_columns[col_name] or raise "failed to find column info for #{col_name.inspect}"
             spec = model.field_specs[c] or raise "failed to find field spec for #{c.inspect}"
             declared_schema_attributes = spec.schema_attributes
-            if spec.different_to?(current_table_name, col)
+            if spec.different_to?(col)
               change_spec = fk_field_options(model, c)
               change_spec[:limit]     ||= spec.limit   if (spec.sql_type != :text ||
                                                          ::DeclareSchema::Model::FieldSpec.mysql_text_limits?) &&

--- a/spec/lib/declare_schema/field_declaration_dsl_spec.rb
+++ b/spec/lib/declare_schema/field_declaration_dsl_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe DeclareSchema::FieldDeclarationDsl do
   end
 
   it 'stores limits' do
-    expect(TestModel.field_specs['name'].limit).to eq(127)
+    expect(TestModel.field_specs['name'].limit).to eq(127), TestModel.field_specs['name'].inspect
   end
 
   # TODO: fill out remaining tests

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -84,16 +84,14 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
           expect(subject.schema_attributes(col_spec)).to eq(type: :decimal, precision: 8, scale: 10, null: true)
         end
 
-        it 'requires and precision:' do
-          expect do
-            described_class.new(model, :quantity, :decimal, scale: 10, null: true, position: 3)
-          end.to raise_exception(RuntimeError, 'precision: required for :decimal type')
+        it 'requires precision:' do
+          expect_any_instance_of(described_class).to receive(:warn).with(/precision: required for :decimal type/)
+          described_class.new(model, :quantity, :decimal, scale: 10, null: true, position: 3)
         end
 
         it 'requires scale:' do
-          expect do
-            described_class.new(model, :quantity, :decimal, precision: 8, null: true, position: 3)
-          end.to raise_exception(RuntimeError, 'scale: required for :decimal type')
+          expect_any_instance_of(described_class).to receive(:warn).with(/scale: required for :decimal type/)
+          described_class.new(model, :quantity, :decimal, precision: 8, null: true, position: 3)
         end
       end
 
@@ -102,15 +100,13 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
           let(:extra) { t == :string ? { limit: 100 } : {} }
 
           it 'does not allow precision:' do
-            expect do
-              described_class.new(model, :quantity, t, { precision: 8, null: true, position: 3 }.merge(extra))
-            end.to raise_exception(RuntimeError, 'precision: only allowed for :decimal type')
-          end
+            expect_any_instance_of(described_class).to receive(:warn).with(/precision: only allowed for :decimal type/)
+            described_class.new(model, :quantity, t, { precision: 8, null: true, position: 3 }.merge(extra))
+          end unless t == :datetime
 
           it 'does not allow scale:' do
-            expect do
-              described_class.new(model, :quantity, t, { scale: 10, null: true, position: 3 }.merge(extra))
-            end.to raise_exception(RuntimeError, 'scale: only allowed for :decimal type')
+            expect_any_instance_of(described_class).to receive(:warn).with(/scale: only allowed for :decimal type/)
+            described_class.new(model, :quantity, t, { scale: 10, null: true, position: 3 }.merge(extra))
           end
         end
       end

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'DeclareSchema Model FieldSpec' do
+RSpec.describe DeclareSchema::Model::FieldSpec do
   before do
     load File.expand_path('prepare_testapp.rb', __dir__)
   end

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -19,21 +19,21 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
     describe 'integer 4' do
       it 'returns schema attributes' do
         subject = described_class.new(model, :price, :integer, limit: 4, null: false, position: 0)
-        expect(subject.schema_attributes(col_spec)).to eq(type: :integer, limit: 4, null: false, default: nil)
+        expect(subject.schema_attributes(col_spec)).to eq(type: :integer, limit: 4, null: false)
       end
     end
 
     describe 'integer 8' do
       it 'returns schema attributes' do
         subject = described_class.new(model, :price, :integer, limit: 8, null: true, position: 2)
-        expect(subject.schema_attributes(col_spec)).to eq(type: :integer, limit: 8, null: true, default: nil)
+        expect(subject.schema_attributes(col_spec)).to eq(type: :integer, limit: 8, null: true)
       end
     end
 
     describe 'bigint' do
       it 'returns schema attributes' do
         subject = described_class.new(model, :price, :bigint, null: false, position: 2)
-        expect(subject.schema_attributes(col_spec)).to eq(type: :integer, limit: 8, null: false, default: nil)
+        expect(subject.schema_attributes(col_spec)).to eq(type: :integer, limit: 8, null: false)
       end
     end
 
@@ -41,20 +41,20 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
       it 'returns schema attributes (including charset/collation iff mysql)' do
         subject = described_class.new(model, :title, :string, limit: 100, null: true, charset: 'utf8mb4', position: 0)
         if defined?(Mysql2)
-          expect(subject.schema_attributes(col_spec)).to eq(type: :string, limit: 100, null: true, default: nil, charset: 'utf8mb4', collation: 'utf8mb4_bin')
+          expect(subject.schema_attributes(col_spec)).to eq(type: :string, limit: 100, null: true, charset: 'utf8mb4', collation: 'utf8mb4_bin')
         else
-          expect(subject.schema_attributes(col_spec)).to eq(type: :string, limit: 100, null: true, default: nil)
+          expect(subject.schema_attributes(col_spec)).to eq(type: :string, limit: 100, null: true)
         end
       end
     end
 
     describe 'text' do
       it 'returns schema attributes (including charset/collation iff mysql)' do
-        subject = described_class.new(model, :title, :text, limit: 200, null: true, default: nil, charset: 'utf8mb4', position: 2)
+        subject = described_class.new(model, :title, :text, limit: 200, null: true, charset: 'utf8mb4', position: 2)
         if defined?(Mysql2)
-          expect(subject.schema_attributes(col_spec)).to eq(type: :text, limit: 255, null: true, default: nil, charset: 'utf8mb4', collation: 'utf8mb4_bin')
+          expect(subject.schema_attributes(col_spec)).to eq(type: :text, limit: 255, null: true, charset: 'utf8mb4', collation: 'utf8mb4_bin')
         else
-          expect(subject.schema_attributes(col_spec)).to eq(type: :text, limit: 200, null: true, default: nil)
+          expect(subject.schema_attributes(col_spec)).to eq(type: :text, null: true)
         end
       end
 
@@ -65,14 +65,14 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
           end.to raise_exception(DeclareSchema::MysqlTextMayNotHaveDefault)
         else
           subject = described_class.new(model, :title, :text, limit: 200, null: true, default: 'none', charset: 'utf8mb4', position: 2)
-          expect(subject.schema_attributes(col_spec)).to eq(type: :text, limit: 200, null: true, default: 'none')
+          expect(subject.schema_attributes(col_spec)).to eq(type: :text, null: true, default: 'none')
         end
       end
 
       describe 'decimal' do
         it 'allows precision: and scale:' do
           subject = described_class.new(model, :quantity, :decimal, precision: 8, scale: 10, null: true, position: 3)
-          expect(subject.schema_attributes(col_spec)).to eq(type: :decimal, precision: 8, scale: 10, null: true, default: nil)
+          expect(subject.schema_attributes(col_spec)).to eq(type: :decimal, precision: 8, scale: 10, null: true)
         end
 
         it 'requires and precision:' do
@@ -110,14 +110,14 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
     describe 'datetime' do
       it 'keeps type as "datetime"' do
         subject = described_class.new(model, :created_at, :datetime, null: false, position: 1)
-        expect(subject.schema_attributes(col_spec)).to eq(type: :datetime, null: false, default: nil)
+        expect(subject.schema_attributes(col_spec)).to eq(type: :datetime, null: false)
       end
     end
 
     describe 'timestamp' do
       it 'normalizes type to "datetime"' do
         subject = described_class.new(model, :created_at, :timestamp, null: true, position: 2)
-        expect(subject.schema_attributes(col_spec)).to eq(type: :datetime, null: true, default: nil)
+        expect(subject.schema_attributes(col_spec)).to eq(type: :datetime, null: true)
       end
     end
 
@@ -153,7 +153,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
       int8 = described_class.new(model, :price, :integer, limit: 8, null: false, position: 0)
       bigint = described_class.new(model, :price, :bigint,          null: false, position: 0)
 
-      expected_attributes = { type: :integer, limit: 8, null: false, default: nil }
+      expected_attributes = { type: :integer, limit: 8, null: false }
       expect(int8.schema_attributes(col_spec)).to eq(expected_attributes)
       expect(bigint.schema_attributes(col_spec)).to eq(expected_attributes)
     end

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -170,7 +170,8 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
       end
 
       it 'returns the requested keys' do
-        expect(described_class.col_spec_attributes(col_spec, [:type, :limit, :null, :default])).to eq(type: :integer, limit: 8, null: false, default: nil)
+        subject = described_class.new(model, :price, :bigint, null: true, default: 0, position: 2)
+        expect(subject.col_spec_attributes(col_spec, [:type, :limit, :null, :default])).to eq(type: :integer, limit: 8, null: false, default: nil)
       end
     end
   end

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
     end
   end
 
+  describe '#initialize' do
+    it 'normalizes option order' do
+      subject = described_class.new(model, :price, :integer, anonymize_using: 'x', null: false, position: 0, limit: 4)
+      expect(subject.options.keys).to eq([:limit, :null, :anonymize_using])
+    end
+  end
+
   describe '#schema_attributes' do
     describe 'integer 4' do
       it 'returns schema attributes' do

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -65,6 +65,43 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
           expect(subject.schema_attributes).to eq(type: :text, limit: 200, null: true, default: 'none')
         end
       end
+
+      describe 'decimal' do
+        it 'allows precision: and scale:' do
+          subject = described_class.new(model, :quantity, :decimal, precision: 8, scale: 10, null: true, position: 3)
+          expect(subject.schema_attributes).to eq(type: :decimal, precision: 8, scale: 10, null: true)
+        end
+
+        it 'requires and precision:' do
+          expect do
+            described_class.new(model, :quantity, :decimal, scale: 10, null: true, position: 3)
+          end.to raise_exception(RuntimeError, 'precision: required for :decimal type')
+        end
+
+        it 'requires scale:' do
+          expect do
+            described_class.new(model, :quantity, :decimal, precision: 8, null: true, position: 3)
+          end.to raise_exception(RuntimeError, 'scale: required for :decimal type')
+        end
+      end
+
+      [:integer, :bigint, :string, :text, :binary, :datetime, :date, :time].each do |t|
+        describe t.to_s do
+          let(:extra) { t == :string ? { limit: 100 } : {} }
+
+          it 'does not allow precision:' do
+            expect do
+              described_class.new(model, :quantity, t, { precision: 8, null: true, position: 3 }.merge(extra))
+            end.to raise_exception(RuntimeError, 'precision: only allowed for :decimal type')
+          end
+
+          it 'does not allow scale:' do
+            expect do
+              described_class.new(model, :quantity, t, { scale: 10, null: true, position: 3 }.merge(extra))
+            end.to raise_exception(RuntimeError, 'scale: only allowed for :decimal type')
+          end
+        end
+      end
     end
 
     describe 'datetime' do

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -1,13 +1,63 @@
 # frozen_string_literal: true
 
+begin
+  require 'mysql2'
+rescue LoadError
+end
+
 RSpec.describe DeclareSchema::Model::FieldSpec do
   before do
     load File.expand_path('prepare_testapp.rb', __dir__)
   end
 
+  describe '#schema_attributes' do
+    context 'integer 4' do
+      it 'returns schema attributes' do
+        subject = described_class.new(Object, :price, :integer, limit: 4, null: false, position: 0)
+        expect(subject.schema_attributes).to eq(type: :integer, limit: 4, null: false)
+      end
+    end
+
+    context 'integer 8' do
+      it 'returns schema attributes' do
+        subject = described_class.new(Object, :price, :integer, limit: 8, null: true, position: 2)
+        expect(subject.schema_attributes).to eq(type: :integer, limit: 8, null: true)
+      end
+    end
+
+    context 'bigint' do
+      it 'returns schema attributes' do
+        subject = described_class.new(Object, :price, :bigint, null: false, position: 2)
+        expect(subject.schema_attributes).to eq(type: :integer, limit: 8, null: false)
+      end
+    end
+
+    context 'string' do
+      it 'returns schema attributes' do
+        subject = described_class.new(Object, :title, :string, limit: 100, null: true, position: 0)
+        if defined?(Mysql2)
+          expect(subject.schema_attributes).to eq(type: :string, limit: 100, null: true, charset: 'utf8', collation: 'utf8_general_ci')
+        else
+          expect(subject.schema_attributes).to eq(type: :string, limit: 100, null: true)
+        end
+      end
+    end
+
+    context 'text' do
+      it 'returns schema attributes' do
+        subject = described_class.new(Object, :title, :text, limit: 200, null: true, position: 2)
+        if defined?(Mysql2)
+          expect(subject.schema_attributes).to eq(type: :text, limit: 255, null: true, charset: 'utf8', collation: 'utf8_general_ci')
+        else
+          expect(subject.schema_attributes).to eq(type: :text, limit: 200, null: true)
+        end
+      end
+    end
+  end
+
   context 'There are no model columns to change' do
     it '#different_to should return false for int8 == int8' do
-      subject = DeclareSchema::Model::FieldSpec.new(Object, :price, :integer, limit: 8, null: false, position: 0)
+      subject = described_class.new(Object, :price, :integer, limit: 8, null: false, position: 0)
 
       case Rails::VERSION::MAJOR
       when 4
@@ -22,7 +72,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
     end
 
     it '#different_to should return false for bigint == bigint' do
-      subject = DeclareSchema::Model::FieldSpec.new(Object, :price, :bigint, null: false, position: 0)
+      subject = described_class.new(Object, :price, :bigint, null: false, position: 0)
 
       case Rails::VERSION::MAJOR
       when 4
@@ -37,7 +87,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
     end
 
     it '#different_to should return false for int8 == bigint' do
-      subject = DeclareSchema::Model::FieldSpec.new(Object, :price, :integer, limit: 8, null: false, position: 0)
+      subject = described_class.new(Object, :price, :integer, limit: 8, null: false, position: 0)
 
       case Rails::VERSION::MAJOR
       when 4
@@ -52,7 +102,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
     end
 
     it '#different_to should return false for bigint == int8' do
-      subject = DeclareSchema::Model::FieldSpec.new(Object, :price, :bigint, null: false, position: 0)
+      subject = described_class.new(Object, :price, :bigint, null: false, position: 0)
 
       case Rails::VERSION::MAJOR
       when 4

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -11,28 +11,28 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
   end
 
   describe '#schema_attributes' do
-    context 'integer 4' do
+    describe 'integer 4' do
       it 'returns schema attributes' do
         subject = described_class.new(Object, :price, :integer, limit: 4, null: false, position: 0)
         expect(subject.schema_attributes).to eq(type: :integer, limit: 4, null: false)
       end
     end
 
-    context 'integer 8' do
+    describe 'integer 8' do
       it 'returns schema attributes' do
         subject = described_class.new(Object, :price, :integer, limit: 8, null: true, position: 2)
         expect(subject.schema_attributes).to eq(type: :integer, limit: 8, null: true)
       end
     end
 
-    context 'bigint' do
+    describe 'bigint' do
       it 'returns schema attributes' do
         subject = described_class.new(Object, :price, :bigint, null: false, position: 2)
         expect(subject.schema_attributes).to eq(type: :integer, limit: 8, null: false)
       end
     end
 
-    context 'string' do
+    describe 'string' do
       it 'returns schema attributes (including charset/collation iff mysql)' do
         subject = described_class.new(Object, :title, :string, limit: 100, null: true, collation: 'utf8_general_ci', position: 0)
         if defined?(Mysql2)
@@ -43,7 +43,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
       end
     end
 
-    context 'text' do
+    describe 'text' do
       it 'returns schema attributes (including charset/collation iff mysql)' do
         subject = described_class.new(Object, :title, :text, limit: 200, null: true, charset: 'utf8', position: 2)
         if defined?(Mysql2)
@@ -51,6 +51,20 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
         else
           expect(subject.schema_attributes).to eq(type: :text, limit: 200, null: true)
         end
+      end
+    end
+
+    describe 'datetime' do
+      it 'keeps type as "datetime"' do
+        subject = described_class.new(Object, :created_at, :datetime, null: false, position: 1)
+        expect(subject.schema_attributes).to eq(type: :datetime, null: false)
+      end
+    end
+
+    describe 'timestamp' do
+      it 'normalizes type to "datetime"' do
+        subject = described_class.new(Object, :created_at, :timestamp, null: true, position: 2)
+        expect(subject.schema_attributes).to eq(type: :datetime, null: true)
       end
     end
   end

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -155,24 +155,4 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
       expect(bigint.schema_attributes(col_spec)).to eq(expected_attributes)
     end
   end
-
-  describe 'class methods' do
-    describe '#col_spec_attributes' do
-      let(:col_spec) do
-        case Rails::VERSION::MAJOR
-        when 4
-          cast_type = ActiveRecord::Type::Integer.new(limit: 8)
-          ActiveRecord::ConnectionAdapters::Column.new("price", nil, cast_type, "integer(8)", false)
-        else
-          sql_type_metadata = ActiveRecord::ConnectionAdapters::SqlTypeMetadata.new(sql_type: "integer(8)", type: :integer, limit: 8)
-          ActiveRecord::ConnectionAdapters::Column.new("price", nil, sql_type_metadata, false, "adverts")
-        end
-      end
-
-      it 'returns the requested keys' do
-        subject = described_class.new(model, :price, :bigint, null: true, default: 0, position: 2)
-        expect(subject.col_spec_attributes(col_spec, [:type, :limit, :null, :default])).to eq(type: :integer, limit: 8, null: false, default: nil)
-      end
-    end
-  end
 end

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
         col = ActiveRecord::ConnectionAdapters::Column.new("price", nil, sql_type_metadata, false, "adverts")
       end
 
-      expect(subject.different_to?(subject.name, col)).to eq(false)
+      expect(subject.different_to?(col)).to eq(false)
     end
 
     it '#different_to should return false for bigint == bigint' do
@@ -97,7 +97,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
         col = ActiveRecord::ConnectionAdapters::Column.new("price", nil, sql_type_metadata, false, "adverts")
       end
 
-      expect(subject.different_to?(subject.name, col)).to eq(false)
+      expect(subject.different_to?(col)).to eq(false)
     end
 
     it '#different_to should return false for int8 == bigint' do
@@ -112,7 +112,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
         col = ActiveRecord::ConnectionAdapters::Column.new("price", nil, sql_type_metadata, false, "adverts")
       end
 
-      expect(subject.different_to?(subject.name, col)).to eq(false)
+      expect(subject.different_to?(col)).to eq(false)
     end
 
     it '#different_to should return false for bigint == int8' do
@@ -127,7 +127,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
         col = ActiveRecord::ConnectionAdapters::Column.new("price", nil, sql_type_metadata, false, "adverts")
       end
 
-      expect(subject.different_to?(subject.name, col)).to eq(false)
+      expect(subject.different_to?(col)).to eq(false)
     end
   end
 end

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -45,11 +45,20 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
 
     describe 'text' do
       it 'returns schema attributes (including charset/collation iff mysql)' do
-        subject = described_class.new(Object, :title, :text, limit: 200, null: true, charset: 'utf8', position: 2)
+        subject = described_class.new(Object, :title, :text, limit: 200, null: true, default: nil, charset: 'utf8', position: 2)
         if defined?(Mysql2)
-          expect(subject.schema_attributes).to eq(type: :text, limit: 255, null: true, charset: 'utf8', collation: 'utf8_general_ci')
+          expect(subject.schema_attributes).to eq(type: :text, limit: 255, null: true, default: nil, charset: 'utf8', collation: 'utf8_general_ci')
         else
-          expect(subject.schema_attributes).to eq(type: :text, limit: 200, null: true)
+          expect(subject.schema_attributes).to eq(type: :text, limit: 200, null: true, default: nil)
+        end
+      end
+
+      it 'allows a default to be set unless mysql' do
+        subject = described_class.new(Object, :title, :text, limit: 200, null: true, default: 'none', charset: 'utf8', position: 2)
+        if defined?(Mysql2)
+          expect { subject.schema_attributes }.to raise_exception(DeclareSchema::MysqlTextMayNotHaveDefault)
+        else
+          expect(subject.schema_attributes).to eq(type: :text, limit: 200, null: true, default: 'none')
         end
       end
     end

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -11,26 +11,27 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
   end
 
   let(:model) { double('model', table_options: {}) }
+  let(:col_spec) { double('col_spec', sql_type: 'varchar') }
 
   describe '#schema_attributes' do
     describe 'integer 4' do
       it 'returns schema attributes' do
         subject = described_class.new(model, :price, :integer, limit: 4, null: false, position: 0)
-        expect(subject.schema_attributes).to eq(type: :integer, limit: 4, null: false)
+        expect(subject.schema_attributes(col_spec)).to eq(type: :integer, limit: 4, null: false)
       end
     end
 
     describe 'integer 8' do
       it 'returns schema attributes' do
         subject = described_class.new(model, :price, :integer, limit: 8, null: true, position: 2)
-        expect(subject.schema_attributes).to eq(type: :integer, limit: 8, null: true)
+        expect(subject.schema_attributes(col_spec)).to eq(type: :integer, limit: 8, null: true)
       end
     end
 
     describe 'bigint' do
       it 'returns schema attributes' do
         subject = described_class.new(model, :price, :bigint, null: false, position: 2)
-        expect(subject.schema_attributes).to eq(type: :integer, limit: 8, null: false)
+        expect(subject.schema_attributes(col_spec)).to eq(type: :integer, limit: 8, null: false)
       end
     end
 
@@ -38,9 +39,9 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
       it 'returns schema attributes (including charset/collation iff mysql)' do
         subject = described_class.new(model, :title, :string, limit: 100, null: true, charset: 'utf8mb4', position: 0)
         if defined?(Mysql2)
-          expect(subject.schema_attributes).to eq(type: :string, limit: 100, null: true, charset: 'utf8mb4', collation: 'utf8mb4_bin')
+          expect(subject.schema_attributes(col_spec)).to eq(type: :string, limit: 100, null: true, charset: 'utf8mb4', collation: 'utf8mb4_bin')
         else
-          expect(subject.schema_attributes).to eq(type: :string, limit: 100, null: true)
+          expect(subject.schema_attributes(col_spec)).to eq(type: :string, limit: 100, null: true)
         end
       end
     end
@@ -49,9 +50,9 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
       it 'returns schema attributes (including charset/collation iff mysql)' do
         subject = described_class.new(model, :title, :text, limit: 200, null: true, default: nil, charset: 'utf8mb4', position: 2)
         if defined?(Mysql2)
-          expect(subject.schema_attributes).to eq(type: :text, limit: 255, null: true, default: nil, charset: 'utf8mb4', collation: 'utf8mb4_bin')
+          expect(subject.schema_attributes(col_spec)).to eq(type: :text, limit: 255, null: true, default: nil, charset: 'utf8mb4', collation: 'utf8mb4_bin')
         else
-          expect(subject.schema_attributes).to eq(type: :text, limit: 200, null: true, default: nil)
+          expect(subject.schema_attributes(col_spec)).to eq(type: :text, limit: 200, null: true, default: nil)
         end
       end
 
@@ -62,14 +63,14 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
           end.to raise_exception(DeclareSchema::MysqlTextMayNotHaveDefault)
         else
           subject = described_class.new(model, :title, :text, limit: 200, null: true, default: 'none', charset: 'utf8mb4', position: 2)
-          expect(subject.schema_attributes).to eq(type: :text, limit: 200, null: true, default: 'none')
+          expect(subject.schema_attributes(col_spec)).to eq(type: :text, limit: 200, null: true, default: 'none')
         end
       end
 
       describe 'decimal' do
         it 'allows precision: and scale:' do
           subject = described_class.new(model, :quantity, :decimal, precision: 8, scale: 10, null: true, position: 3)
-          expect(subject.schema_attributes).to eq(type: :decimal, precision: 8, scale: 10, null: true)
+          expect(subject.schema_attributes(col_spec)).to eq(type: :decimal, precision: 8, scale: 10, null: true)
         end
 
         it 'requires and precision:' do
@@ -107,14 +108,23 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
     describe 'datetime' do
       it 'keeps type as "datetime"' do
         subject = described_class.new(model, :created_at, :datetime, null: false, position: 1)
-        expect(subject.schema_attributes).to eq(type: :datetime, null: false)
+        expect(subject.schema_attributes(col_spec)).to eq(type: :datetime, null: false)
       end
     end
 
     describe 'timestamp' do
       it 'normalizes type to "datetime"' do
         subject = described_class.new(model, :created_at, :timestamp, null: true, position: 2)
-        expect(subject.schema_attributes).to eq(type: :datetime, null: true)
+        expect(subject.schema_attributes(col_spec)).to eq(type: :datetime, null: true)
+      end
+    end
+
+    describe 'default:' do
+      let(:col_spec) { double('col_spec', sql_type: :integer) }
+
+      it 'typecasts default value' do
+        subject = described_class.new(model, :price, :integer, limit: 4, default: '42', null: true, position: 2)
+        expect(subject.schema_attributes(col_spec)).to eq(type: :integer, limit: 4, default: 42, null: true)
       end
     end
   end

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -6,12 +6,14 @@ rescue LoadError
 end
 
 RSpec.describe DeclareSchema::Model::FieldSpec do
-  before do
-    load File.expand_path('prepare_testapp.rb', __dir__)
-  end
-
   let(:model) { double('model', table_options: {}) }
   let(:col_spec) { double('col_spec', sql_type: 'varchar') }
+
+  before do
+    load File.expand_path('prepare_testapp.rb', __dir__)
+
+    allow(col_spec).to receive(:type_cast_from_database, &:itself)
+  end
 
   describe '#schema_attributes' do
     describe 'integer 4' do
@@ -123,6 +125,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
       let(:col_spec) { double('col_spec', sql_type: :integer) }
 
       it 'typecasts default value' do
+        allow(col_spec).to receive(:type_cast_from_database) { |default| Integer(default) }
         subject = described_class.new(model, :price, :integer, limit: 4, default: '42', null: true, position: 2)
         expect(subject.schema_attributes(col_spec)).to eq(type: :integer, limit: 4, default: 42, null: true)
       end

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
     end
 
     context 'string' do
-      it 'returns schema attributes' do
-        subject = described_class.new(Object, :title, :string, limit: 100, null: true, position: 0)
+      it 'returns schema attributes (including charset/collation iff mysql)' do
+        subject = described_class.new(Object, :title, :string, limit: 100, null: true, collation: 'utf8_general_ci', position: 0)
         if defined?(Mysql2)
           expect(subject.schema_attributes).to eq(type: :string, limit: 100, null: true, charset: 'utf8', collation: 'utf8_general_ci')
         else
@@ -44,8 +44,8 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
     end
 
     context 'text' do
-      it 'returns schema attributes' do
-        subject = described_class.new(Object, :title, :text, limit: 200, null: true, position: 2)
+      it 'returns schema attributes (including charset/collation iff mysql)' do
+        subject = described_class.new(Object, :title, :text, limit: 200, null: true, charset: 'utf8', position: 2)
         if defined?(Mysql2)
           expect(subject.schema_attributes).to eq(type: :text, limit: 255, null: true, charset: 'utf8', collation: 'utf8_general_ci')
         else

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
   before do
     load File.expand_path('prepare_testapp.rb', __dir__)
 
-    allow(col_spec).to receive(:type_cast_from_database, &:itself)
+    if Rails::VERSION::MAJOR < 5
+      allow(col_spec).to receive(:type_cast_from_database, &:itself)
+    end
   end
 
   describe '#schema_attributes' do

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -10,33 +10,35 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
     load File.expand_path('prepare_testapp.rb', __dir__)
   end
 
+  let(:model) { double('model', table_options: {}) }
+
   describe '#schema_attributes' do
     describe 'integer 4' do
       it 'returns schema attributes' do
-        subject = described_class.new(Object, :price, :integer, limit: 4, null: false, position: 0)
+        subject = described_class.new(model, :price, :integer, limit: 4, null: false, position: 0)
         expect(subject.schema_attributes).to eq(type: :integer, limit: 4, null: false)
       end
     end
 
     describe 'integer 8' do
       it 'returns schema attributes' do
-        subject = described_class.new(Object, :price, :integer, limit: 8, null: true, position: 2)
+        subject = described_class.new(model, :price, :integer, limit: 8, null: true, position: 2)
         expect(subject.schema_attributes).to eq(type: :integer, limit: 8, null: true)
       end
     end
 
     describe 'bigint' do
       it 'returns schema attributes' do
-        subject = described_class.new(Object, :price, :bigint, null: false, position: 2)
+        subject = described_class.new(model, :price, :bigint, null: false, position: 2)
         expect(subject.schema_attributes).to eq(type: :integer, limit: 8, null: false)
       end
     end
 
     describe 'string' do
       it 'returns schema attributes (including charset/collation iff mysql)' do
-        subject = described_class.new(Object, :title, :string, limit: 100, null: true, collation: 'utf8_general_ci', position: 0)
+        subject = described_class.new(model, :title, :string, limit: 100, null: true, charset: 'utf8mb4', position: 0)
         if defined?(Mysql2)
-          expect(subject.schema_attributes).to eq(type: :string, limit: 100, null: true, charset: 'utf8', collation: 'utf8_general_ci')
+          expect(subject.schema_attributes).to eq(type: :string, limit: 100, null: true, charset: 'utf8mb4', collation: 'utf8mb4_bin')
         else
           expect(subject.schema_attributes).to eq(type: :string, limit: 100, null: true)
         end
@@ -45,19 +47,21 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
 
     describe 'text' do
       it 'returns schema attributes (including charset/collation iff mysql)' do
-        subject = described_class.new(Object, :title, :text, limit: 200, null: true, default: nil, charset: 'utf8', position: 2)
+        subject = described_class.new(model, :title, :text, limit: 200, null: true, default: nil, charset: 'utf8mb4', position: 2)
         if defined?(Mysql2)
-          expect(subject.schema_attributes).to eq(type: :text, limit: 255, null: true, default: nil, charset: 'utf8', collation: 'utf8_general_ci')
+          expect(subject.schema_attributes).to eq(type: :text, limit: 255, null: true, default: nil, charset: 'utf8mb4', collation: 'utf8mb4_bin')
         else
           expect(subject.schema_attributes).to eq(type: :text, limit: 200, null: true, default: nil)
         end
       end
 
       it 'allows a default to be set unless mysql' do
-        subject = described_class.new(Object, :title, :text, limit: 200, null: true, default: 'none', charset: 'utf8', position: 2)
         if defined?(Mysql2)
-          expect { subject.schema_attributes }.to raise_exception(DeclareSchema::MysqlTextMayNotHaveDefault)
+          expect do
+            described_class.new(model, :title, :text, limit: 200, null: true, default: 'none', charset: 'utf8mb4', position: 2)
+          end.to raise_exception(DeclareSchema::MysqlTextMayNotHaveDefault)
         else
+          subject = described_class.new(model, :title, :text, limit: 200, null: true, default: 'none', charset: 'utf8mb4', position: 2)
           expect(subject.schema_attributes).to eq(type: :text, limit: 200, null: true, default: 'none')
         end
       end
@@ -65,22 +69,22 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
 
     describe 'datetime' do
       it 'keeps type as "datetime"' do
-        subject = described_class.new(Object, :created_at, :datetime, null: false, position: 1)
+        subject = described_class.new(model, :created_at, :datetime, null: false, position: 1)
         expect(subject.schema_attributes).to eq(type: :datetime, null: false)
       end
     end
 
     describe 'timestamp' do
       it 'normalizes type to "datetime"' do
-        subject = described_class.new(Object, :created_at, :timestamp, null: true, position: 2)
+        subject = described_class.new(model, :created_at, :timestamp, null: true, position: 2)
         expect(subject.schema_attributes).to eq(type: :datetime, null: true)
       end
     end
   end
 
-  context 'There are no model columns to change' do
+  context 'There are no model, columns to change' do
     it '#different_to should return false for int8 == int8' do
-      subject = described_class.new(Object, :price, :integer, limit: 8, null: false, position: 0)
+      subject = described_class.new(model, :price, :integer, limit: 8, null: false, position: 0)
 
       case Rails::VERSION::MAJOR
       when 4
@@ -95,7 +99,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
     end
 
     it '#different_to should return false for bigint == bigint' do
-      subject = described_class.new(Object, :price, :bigint, null: false, position: 0)
+      subject = described_class.new(model, :price, :bigint, null: false, position: 0)
 
       case Rails::VERSION::MAJOR
       when 4
@@ -110,7 +114,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
     end
 
     it '#different_to should return false for int8 == bigint' do
-      subject = described_class.new(Object, :price, :integer, limit: 8, null: false, position: 0)
+      subject = described_class.new(model, :price, :integer, limit: 8, null: false, position: 0)
 
       case Rails::VERSION::MAJOR
       when 4
@@ -125,7 +129,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
     end
 
     it '#different_to should return false for bigint == int8' do
-      subject = described_class.new(Object, :price, :bigint, null: false, position: 0)
+      subject = described_class.new(model, :price, :bigint, null: false, position: 0)
 
       case Rails::VERSION::MAJOR
       when 4

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       expect(migrations).to(
         migrate_up(<<~EOS.strip)
           create_table :adverts, id: :bigint do |t|
-            t.string :name, limit: 250#{charset_and_collation}
+            t.string :name, limit: 250, null: true, default: nil#{charset_and_collation}
           end#{charset_alter_table}
         EOS
         .and migrate_down("drop_table :adverts")
@@ -107,8 +107,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     expect(migrate).to(
       migrate_up(<<~EOS.strip)
-        add_column :adverts, :body, :text#{text_limit}#{charset_and_collation}
-        add_column :adverts, :published_at, :datetime
+        add_column :adverts, :body, :text#{text_limit}, null: true, default: nil#{charset_and_collation}
+        add_column :adverts, :published_at, :datetime, null: true, default: nil
       EOS
       .and migrate_down(<<~EOS.strip)
         remove_column :adverts, :body

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -47,6 +47,13 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       ", id: :integer" unless Rails::VERSION::MAJOR < 5
     end
   end
+  let(:lock_version_limit) do
+    if defined?(Mysql2)
+      ", limit: 4"
+    else
+      ''
+    end
+  end
 
   # DeclareSchema - Migration Generator
   it 'generates migrations' do
@@ -469,7 +476,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       migrate_up(<<~EOS.strip)
         add_column :adverts, :created_at, :datetime, null: true
         add_column :adverts, :updated_at, :datetime, null: true
-        add_column :adverts, :lock_version, :integer, null: false, default: 1
+        add_column :adverts, :lock_version, :integer#{lock_version_limit}, null: false, default: 1
 
         #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
           "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -469,7 +469,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       migrate_up(<<~EOS.strip)
         add_column :adverts, :created_at, :datetime, null: true
         add_column :adverts, :updated_at, :datetime, null: true
-        add_column :adverts, :lock_version, :integer, limit: 4, null: false, default: 1
+        add_column :adverts, :lock_version, :integer, null: false, default: 1
 
         #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
           "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -223,16 +223,6 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       EOS
     )
 
-    # limit on a decimal column is not supported (use :scale and :precision instead)
-
-    expect do
-      class Advert < ActiveRecord::Base
-        fields do
-          price :decimal, limit: 4, null: true
-        end
-      end
-    end.to raise_exception(RuntimeError, /unsupported limit: for SQL type decimal in field Advert#price/)
-
     ActiveRecord::Migration.class_eval("remove_column :adverts, :price")
     class Advert < ActiveRecord::Base
       fields do

--- a/spec/lib/declare_schema/model/column_spec.rb
+++ b/spec/lib/declare_schema/model/column_spec.rb
@@ -9,13 +9,19 @@ RSpec.describe DeclareSchema::Model::Column do
 
   describe 'class methods' do
     describe '.native_type?' do
+      if defined?(Mysql2)
+        let(:native_types) { [:string, :text, :integer, :float, :decimal, :datetime, :time, :date, :binary, :boolean, :json] }
+      else
+        let(:native_types) { [:string, :text, :integer, :float, :decimal, :datetime, :time, :date, :binary, :boolean] }
+      end
+
       it 'is falsey for :primary_key' do
         expect(described_class.native_type?(:primary_key)).to be_falsey
       end
 
       it 'is truthy for native types' do
-        [:string, :text, :integer, :float, :decimal, :datetime, :time, :date, :binary, :boolean, :json].each do |type|
-          expect(described_class.native_type?(type)).to be_truthy
+        native_types.each do |type|
+          expect(described_class.native_type?(type)).to be_truthy, type.inspect
         end
       end
 

--- a/spec/lib/declare_schema/model/column_spec.rb
+++ b/spec/lib/declare_schema/model/column_spec.rb
@@ -106,6 +106,10 @@ RSpec.describe DeclareSchema::Model::Column do
     let(:column) { double("ActiveRecord Column",
                           name: 'count',
                           type: :integer,
+                          limit: nil,
+                          precision: nil,
+                          scale: nil,
+                          type_cast_from_database: nil,
                           null: false,
                           default: nil,
                           sql_type_metadata: {}) }
@@ -119,7 +123,7 @@ RSpec.describe DeclareSchema::Model::Column do
 
     describe '#schema_attributes' do
       it 'returns a hash with relevant key/values' do
-        expect(subject.schema_attributes).to eq(type: :integer, null: false, default: nil)
+        expect(subject.schema_attributes).to eq(type: :integer, null: false)
       end
     end
   end

--- a/spec/lib/declare_schema/model/column_spec.rb
+++ b/spec/lib/declare_schema/model/column_spec.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+require 'rails'
+
+begin
+  require 'mysql2'
+rescue LoadError
+end
+
 require_relative '../../../../lib/declare_schema/model/column'
 
 RSpec.describe DeclareSchema::Model::Column do
@@ -9,7 +16,7 @@ RSpec.describe DeclareSchema::Model::Column do
 
   describe 'class methods' do
     describe '.native_type?' do
-      if defined?(Mysql2)
+      if defined?(Mysql2) && Rails::VERSION::MAJOR >= 5
         let(:native_types) { [:string, :text, :integer, :float, :decimal, :datetime, :time, :date, :binary, :boolean, :json] }
       else
         let(:native_types) { [:string, :text, :integer, :float, :decimal, :datetime, :time, :date, :binary, :boolean] }

--- a/spec/lib/declare_schema/model/column_spec.rb
+++ b/spec/lib/declare_schema/model/column_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require_relative '../../../../lib/declare_schema/model/column'
+
+RSpec.describe DeclareSchema::Model::Column do
+  before do
+    load File.expand_path('../prepare_testapp.rb', __dir__)
+  end
+
+  describe 'class methods' do
+    describe '.native_type?' do
+      it 'is falsey for :primary_key' do
+        expect(described_class.native_type?(:primary_key)).to be_falsey
+      end
+
+      it 'is truthy for native types' do
+        [:string, :text, :integer, :float, :decimal, :datetime, :time, :date, :binary, :boolean, :json].each do |type|
+          expect(described_class.native_type?(type)).to be_truthy
+        end
+      end
+
+      it 'is falsey for other types' do
+        [:email, :url].each do |type|
+          expect(described_class.native_type?(type)).to be_falsey
+        end
+      end
+    end
+
+    describe '.native_types' do
+      subject { described_class.native_types }
+
+      it 'returns the native type for :primary_key' do
+        expect(subject[:primary_key]).to match(/auto_increment PRIMARY KEY|PRIMARY KEY AUTOINCREMENT NOT NULL/)
+      end
+
+      it 'returns the native type for :string' do
+        expect(subject.dig(:string, :name)).to eq('varchar')
+      end
+
+      it 'returns the native type for :integer' do
+        expect(subject.dig(:integer, :name)).to match(/int/)
+      end
+
+      it 'returns the native type for :datetime' do
+        expect(subject.dig(:datetime, :name)).to eq('datetime')
+      end
+    end
+
+    describe '.sql_type' do
+      it 'returns the sql type for :string' do
+        expect(described_class.sql_type(:string)).to eq(:string)
+      end
+
+      it 'returns the sql type for :integer' do
+        expect(described_class.sql_type(:integer)).to match(:integer)
+      end
+
+      it 'returns the sql type for :datetime' do
+        expect(described_class.sql_type(:datetime)).to eq(:datetime)
+      end
+
+      it 'raises UnknownSqlType' do
+        expect do
+          described_class.sql_type(:email)
+        end.to raise_exception(::DeclareSchema::UnknownSqlTypeError, /:email for type :email/)
+      end
+    end
+
+    describe '.deserialize_default_value' do
+      require 'rails'
+
+      if ::Rails::VERSION::MAJOR >= 5
+        it 'deserializes :boolean' do
+          expect(described_class.deserialize_default_value(nil, :boolean, 'true')).to eq(true)
+          expect(described_class.deserialize_default_value(nil, :boolean, 'false')).to eq(false)
+        end
+
+        it 'deserializes :integer' do
+          expect(described_class.deserialize_default_value(nil, :integer, '12')).to eq(12)
+        end
+
+        it 'deserializes :json' do
+          expect(described_class.deserialize_default_value(nil, :json, '{}')).to eq({})
+        end
+      end
+    end
+  end
+
+  describe 'instance methods' do
+    before do
+      class ColumnTestModel < ActiveRecord::Base
+        fields do
+          title :string, limit: 127, null: false
+          count :integer, null: false
+        end
+      end
+    end
+    let(:model) { ColumnTestModel }
+    let(:current_table_name) { model.table_name }
+    let(:column) { double("ActiveRecord Column",
+                          name: 'count',
+                          type: :integer,
+                          null: false,
+                          default: nil,
+                          sql_type_metadata: {}) }
+    subject { described_class.new(model, current_table_name, column) }
+
+    describe '#sql_type' do
+      it 'returns sql type' do
+        expect(subject.sql_type).to match(/int/)
+      end
+    end
+
+    describe '#schema_attributes' do
+      it 'returns a hash with relevant key/values' do
+        expect(subject.schema_attributes).to eq(type: :integer, null: false, default: nil)
+      end
+    end
+  end
+end

--- a/spec/lib/declare_schema/model/column_spec.rb
+++ b/spec/lib/declare_schema/model/column_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe DeclareSchema::Model::Column do
 
   describe 'class methods' do
     describe '.native_type?' do
-      if defined?(Mysql2) && Rails::VERSION::MAJOR >= 5
+      if Rails::VERSION::MAJOR >= 5
         let(:native_types) { [:string, :text, :integer, :float, :decimal, :datetime, :time, :date, :binary, :boolean, :json] }
       else
         let(:native_types) { [:string, :text, :integer, :float, :decimal, :datetime, :time, :date, :binary, :boolean] }

--- a/spec/lib/declare_schema/model/column_spec.rb
+++ b/spec/lib/declare_schema/model/column_spec.rb
@@ -123,7 +123,11 @@ RSpec.describe DeclareSchema::Model::Column do
 
     describe '#schema_attributes' do
       it 'returns a hash with relevant key/values' do
-        expect(subject.schema_attributes).to eq(type: :integer, null: false)
+        if defined?(Mysql2)
+          expect(subject.schema_attributes).to eq(type: :integer, null: false, limit: 4)
+        else
+          expect(subject.schema_attributes).to eq(type: :integer, null: false)
+        end
       end
     end
   end

--- a/spec/lib/generators/declare_schema/migration/migrator_spec.rb
+++ b/spec/lib/generators/declare_schema/migration/migrator_spec.rb
@@ -18,17 +18,8 @@ module Generators
         subject { described_class.new }
 
         describe 'format_options' do
-          let(:mysql_longtext_limit) { 0xffff_ffff }
-          let(:limit_option) do
-            if defined?(Mysql2)
-              ["limit: #{mysql_longtext_limit}"]
-            else
-              []
-            end
-          end
-
-          it 'returns text limits if supported' do
-            expect(subject.format_options({ limit: mysql_longtext_limit })).to eq(limit_option)
+          it 'returns an array of option .inspect strings, with symbols using the modern : hash notation' do
+            expect(subject.format_options({ limit: 4, 'key' => 'value "quoted"' })).to eq(["limit: 4", '"key" => "value \"quoted\""'])
           end
         end
 

--- a/spec/lib/generators/declare_schema/migration/migrator_spec.rb
+++ b/spec/lib/generators/declare_schema/migration/migrator_spec.rb
@@ -28,7 +28,7 @@ module Generators
           end
 
           it 'returns text limits if supported' do
-            expect(subject.format_options({ limit: mysql_longtext_limit }, :text)).to eq(limit_option)
+            expect(subject.format_options({ limit: mysql_longtext_limit })).to eq(limit_option)
           end
         end
 


### PR DESCRIPTION
## [0.7.0] - Unreleased
### Changed
- Use `schema_attributes` for generating both up and down change migrations, so they are guaranteed to be symmetrical.
  Note: Rails schema dumper is still used for the down migration to replace a model that has been dropped.