### PR TITLE
no-jira: support foreign key custom column:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.3] - UNRELEASED
+## [0.6.4] - UNRELEASED
+- Fixed a bug where the generated call to add_foreign_key() was not setting `column:`,
+  so it only worked in cases where Rails could infer the foreign key by convention.
+
+## [0.6.3] - 2020-01-21
 ### Added
 - Added `add_foreign_key` native rails call in `DeclareSchema::Model::ForeignKeyDefinition#to_add_statement`.
 
@@ -13,9 +17,6 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
   calling `DeclareSchema::Model::ForeignKeyDefinition#to_add_statement` with unused parameters.
  
 - Fixed a bug in `DeclareSchema::Migration#remove_foreign_key` where special characters would not be quoted properly.
-
-- Fixed a bug where the generated call to add_foreign_key() was not setting `column:`,
-  so it only worked in cases where Rails could infer the foreign key by convention.
 
 ## [0.6.2] - 2021-01-06
 ### Added
@@ -113,6 +114,7 @@ using the appropriate Rails configuration attributes.
 ### Added
 - Initial version from https://github.com/Invoca/hobo_fields v4.1.0.
 
+[0.6.4]: https://github.com/Invoca/declare_schema/compare/v0.6.3...v0.6.4
 [0.6.3]: https://github.com/Invoca/declare_schema/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/Invoca/declare_schema/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/Invoca/declare_schema/compare/v0.6.0...v0.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 - Fixed a bug in migration generation caused by `DeclareSchema::Migration#create_constraints`
   calling `DeclareSchema::Model::ForeignKeyDefinition#to_add_statement` with unused parameters.
  
- - Fixed a bug in `DeclareSchema::Migration#remove_foreign_key` where special characters would not be quoted properly.
+- Fixed a bug in `DeclareSchema::Migration#remove_foreign_key` where special characters would not be quoted properly.
+
+- Fixed a bug where the generated call to add_foreign_key() was not setting `column:`,
+  so it only worked in cases where Rails could infer the foreign key by convention.
 
 ## [0.6.2] - 2021-01-06
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (0.6.3)
+    declare_schema (0.6.4)
       rails (>= 4.2)
 
 GEM

--- a/lib/declare_schema/model/foreign_key_definition.rb
+++ b/lib/declare_schema/model/foreign_key_definition.rb
@@ -5,7 +5,7 @@ module DeclareSchema
     class ForeignKeyDefinition
       include Comparable
 
-      attr_reader :constraint_name, :model, :foreign_key, :options, :on_delete_cascade
+      attr_reader :constraint_name, :model, :foreign_key, :foreign_key_name, :options, :on_delete_cascade
 
       def initialize(model, foreign_key, options = {})
         @model = model

--- a/lib/declare_schema/model/foreign_key_definition.rb
+++ b/lib/declare_schema/model/foreign_key_definition.rb
@@ -65,7 +65,7 @@ module DeclareSchema
       end
 
       def <=>(rhs)
-        key <=> rhs.key
+        key <=> rhs.send(:key)
       end
 
       alias eql? ==

--- a/lib/declare_schema/model/foreign_key_definition.rb
+++ b/lib/declare_schema/model/foreign_key_definition.rb
@@ -16,10 +16,10 @@ module DeclareSchema
         @parent_table_name = options[:parent_table]&.to_s
         @foreign_key_name = options[:foreign_key]&.to_s || @foreign_key
         @index_name = options[:index_name]&.to_s || model.connection.index_name(model.table_name, column: @foreign_key_name)
-        @constraint_name = options[:constraint_name]&.to_s || @index_name&.to_s || ''
-        @on_delete_cascade = options[:dependent] == :delete
 
         # Empty constraint lets mysql generate the name
+        @constraint_name = options[:constraint_name]&.to_s || @index_name&.to_s || ''
+        @on_delete_cascade = options[:dependent] == :delete
       end
 
       class << self

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "0.6.3"
+  VERSION = "0.6.4"
 end

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -369,7 +369,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
         add_index :adverts, [:category_id], name: 'on_category_id'
 
-        #{"add_foreign_key(\"adverts\", \"categories\", name: \"index_adverts_on_category_id\")\n" if defined?(Mysql2)}
+        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" if defined?(Mysql2)}
       EOS
       .and migrate_down(<<~EOS.strip)
         remove_column :adverts, :category_id
@@ -397,8 +397,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
         add_index :adverts, [:c_id], name: 'on_c_id'
 
-        #{"add_foreign_key(\"adverts\", \"categories\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
       EOS
     )
 
@@ -417,8 +417,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       migrate_up(<<~EOS.strip)
         add_column :adverts, :category_id, :integer, limit: 8, null: false
 
-        #{"add_foreign_key(\"adverts\", \"categories\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
       EOS
     )
 
@@ -439,8 +439,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
         add_index :adverts, [:category_id], name: 'my_index'
 
-        #{"add_foreign_key(\"adverts\", \"categories\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
       EOS
     )
 
@@ -465,8 +465,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         add_column :adverts, :updated_at, :datetime
         add_column :adverts, :lock_version, :integer, null: false, default: 1
 
-        #{"add_foreign_key(\"adverts\", \"categories\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
       EOS
       .and migrate_down(<<~EOS.strip)
         remove_column :adverts, :created_at
@@ -498,8 +498,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
         add_index :adverts, [:title], name: 'on_title'
 
-        #{"add_foreign_key(\"adverts\", \"categories\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
       EOS
     )
 
@@ -519,8 +519,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
         add_index :adverts, [:title], unique: true, name: 'on_title'
 
-        #{"add_foreign_key(\"adverts\", \"categories\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
       EOS
     )
 
@@ -540,8 +540,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
         add_index :adverts, [:title], name: 'my_index'
 
-        #{"add_foreign_key(\"adverts\", \"categories\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
       EOS
     )
 
@@ -559,8 +559,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
         add_index :adverts, [:title], name: 'on_title'
 
-        #{"add_foreign_key(\"adverts\", \"categories\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
       EOS
     )
 
@@ -578,8 +578,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
         add_index :adverts, [:title], unique: true, name: 'my_index'
 
-        #{"add_foreign_key(\"adverts\", \"categories\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
       EOS
     )
 
@@ -597,8 +597,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
         add_index :adverts, [:title, :category_id], name: 'on_title_and_category_id'
 
-        #{"add_foreign_key(\"adverts\", \"categories\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
       EOS
     )
 
@@ -634,8 +634,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
             "add_index :ads, [:id], unique: true, name: 'PRIMARY'\n"
           elsif defined?(Mysql2)
             "execute \"ALTER TABLE ads DROP PRIMARY KEY, ADD PRIMARY KEY (id)\"\n\n" +
-            "add_foreign_key(\"adverts\", \"categories\", name: \"index_adverts_on_category_id\")\n" +
-            "add_foreign_key(\"adverts\", \"categories\", name: \"index_adverts_on_c_id\")"
+            "add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")"
           end}
       EOS
       .and migrate_down(<<~EOS.strip)

--- a/spec/lib/declare_schema/model/foreign_key_definition_spec.rb
+++ b/spec/lib/declare_schema/model/foreign_key_definition_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require_relative '../../../../lib/declare_schema/model/foreign_key_definition'
+
+RSpec.describe DeclareSchema::Model::ForeignKeyDefinition do
+  before do
+    load File.expand_path('../prepare_testapp.rb', __dir__)
+
+    class Network < ActiveRecord::Base
+      fields do
+        name :string, limit: 127, index: true
+
+        timestamps
+      end
+    end
+  end
+
+  let(:model_class) { Network }
+
+  describe 'instance methods' do
+    describe '#initialize' do
+      let(:connection) { instance_double(ActiveRecord::Base.connection.class) }
+      let(:model) { instance_double('Model', table_name: 'models', connection: connection) }
+      let(:foreign_key) { :network_id }
+      let(:options) { {} }
+      subject { described_class.new(model, foreign_key, options)}
+      before do
+        allow(connection).to receive(:index_name).with('models', column: :network_id) { }
+      end
+
+      it 'normalizes symbols to strings' do
+        expect(subject.foreign_key).to eq('network_id')
+        expect(subject.parent_table_name).to eq('networks')
+      end
+
+      context 'when most options passed' do
+        let(:options) { { parent_table: :networks, foreign_key: :the_network_id, index_name: :index_on_network_id } }
+
+        it 'normalizes symbols to strings' do
+          expect(subject.foreign_key).to eq('network_id')
+          expect(subject.foreign_key_name).to eq('the_network_id')
+          expect(subject.parent_table_name).to eq('networks')
+          expect(subject.foreign_key).to eq('network_id')
+          expect(subject.constraint_name).to eq('index_on_network_id')
+          expect(subject.on_delete_cascade).to be_falsey
+        end
+      end
+
+      context 'when all options passed' do
+        let(:foreign_key) { nil }
+        let(:options) { { parent_table: :networks, foreign_key: :the_network_id, index_name: :index_on_network_id,
+                          constraint_name: :constraint_1, dependent: :delete } }
+
+        it 'normalizes symbols to strings' do
+          expect(subject.foreign_key).to be_nil
+          expect(subject.foreign_key_name).to eq('the_network_id')
+          expect(subject.parent_table_name).to eq('networks')
+          expect(subject.constraint_name).to eq('constraint_1')
+          expect(subject.on_delete_cascade).to be_truthy
+        end
+      end
+    end
+  end
+
+  describe 'class << self' do
+    let(:connection) { instance_double(ActiveRecord::Base.connection.class) }
+    let(:model) { instance_double('Model', table_name: 'models', connection: connection) }
+    let(:old_table_name) { 'networks' }
+    before do
+      allow(connection).to receive(:quote_table_name).with('networks') { 'networks' }
+      allow(connection).to receive(:select_rows) { [['CONSTRAINT `constraint` FOREIGN KEY (`network_id`) REFERENCES `networks` (`id`)']] }
+      allow(connection).to receive(:index_name).with('models', column: 'network_id') { }
+    end
+
+    describe '.for_model' do
+      subject { described_class.for_model(model, old_table_name) }
+
+      it 'returns new object' do
+        expect(subject.size).to eq(1), subject.inspect
+        expect(subject.first).to be_kind_of(described_class)
+        expect(subject.first.foreign_key).to eq('network_id')
+      end
+    end
+  end
+  # TODO: fill out remaining tests
+end

--- a/spec/lib/declare_schema/model/foreign_key_definition_spec.rb
+++ b/spec/lib/declare_schema/model/foreign_key_definition_spec.rb
@@ -18,16 +18,17 @@ RSpec.describe DeclareSchema::Model::ForeignKeyDefinition do
   let(:model_class) { Network }
 
   describe 'instance methods' do
-    describe '#initialize' do
-      let(:connection) { instance_double(ActiveRecord::Base.connection.class) }
-      let(:model) { instance_double('Model', table_name: 'models', connection: connection) }
-      let(:foreign_key) { :network_id }
-      let(:options) { {} }
-      subject { described_class.new(model, foreign_key, options)}
-      before do
-        allow(connection).to receive(:index_name).with('models', column: :network_id) { }
-      end
+    let(:connection) { instance_double(ActiveRecord::Base.connection.class) }
+    let(:model) { instance_double('Model', table_name: 'models', connection: connection) }
+    let(:foreign_key) { :network_id }
+    let(:options) { {} }
+    subject { described_class.new(model, foreign_key, options)}
 
+    before do
+      allow(connection).to receive(:index_name).with('models', column: 'network_id') { 'on_network_id' }
+    end
+
+    describe '#initialize' do
       it 'normalizes symbols to strings' do
         expect(subject.foreign_key).to eq('network_id')
         expect(subject.parent_table_name).to eq('networks')
@@ -58,6 +59,12 @@ RSpec.describe DeclareSchema::Model::ForeignKeyDefinition do
           expect(subject.constraint_name).to eq('constraint_1')
           expect(subject.on_delete_cascade).to be_truthy
         end
+      end
+    end
+
+    describe '#to_add_statement' do
+      it 'returns add_foreign_key command' do
+        expect(subject.to_add_statement).to eq('add_foreign_key("models", "networks", column: "network_id", name: "on_network_id")')
       end
     end
   end


### PR DESCRIPTION
- Fixed a bug where the generated call to add_foreign_key() was not setting `column:`,
  so it only worked in cases where Rails could infer the foreign key by convention.
- Added missing spec for `ForeignKeyDeclaration`.