### PR TITLE
TECH-4814: fix migration generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - UNRELEASED
+### Fixed
+- Exclude unknown options from FieldSpec#sql_options and #schema_attributes.
+- Fixed a bug where fk_field_options were getting merged into spec_attrs after checking for equivalence,
+  leading to phantom migrations with no changes, or missing migrations when just the fk_field_options changed.
+
 ## [0.7.0] - 2020-02-14
 ### Changed
 - Use `schema_attributes` for generating both up and down change migrations, so they are guaranteed to be symmetrical.
@@ -119,6 +125,7 @@ using the appropriate Rails configuration attributes.
 ### Added
 - Initial version from https://github.com/Invoca/hobo_fields v4.1.0.
 
+[0.7.1]: https://github.com/Invoca/declare_schema/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/Invoca/declare_schema/compare/v0.6.3...v0.7.0
 [0.6.4]: https://github.com/Invoca/declare_schema/compare/v0.6.3...v0.6.4
 [0.6.3]: https://github.com/Invoca/declare_schema/compare/v0.6.2...v0.6.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (0.7.0)
+    declare_schema (0.7.1)
       rails (>= 4.2)
 
 GEM

--- a/lib/declare_schema/field_declaration_dsl.rb
+++ b/lib/declare_schema/field_declaration_dsl.rb
@@ -28,13 +28,12 @@ module DeclareSchema
       field(:lock_version, :integer, default: 1, null: false)
     end
 
-    def field(name, type, *args)
-      options = args.extract_options!
-      @model.declare_field(name, type, *(args + [@options.merge(options)]))
+    def field(name, type, *args, **options)
+      @model.declare_field(name, type, *[*args, @options.merge(options)])
     end
 
     def method_missing(name, *args)
-      field(name, args.first, *args[1..-1])
+      field(name, *args)
     end
   end
 end

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -81,8 +81,7 @@ module DeclareSchema
       # arguments. The arguments are forwarded to the #field_added
       # callback, allowing custom metadata to be added to field
       # declarations.
-      def declare_field(name, type, *args)
-        options = args.extract_options!
+      def declare_field(name, type, *args, **options)
         try(:field_added, name, type, args, options)
         add_serialize_for_field(name, type, options)
         add_formatting_for_field(name, type)

--- a/lib/declare_schema/model/column.rb
+++ b/lib/declare_schema/model/column.rb
@@ -103,14 +103,13 @@ module DeclareSchema
         end
       end
 
+      attr_reader :sql_type
+
       def initialize(model, current_table_name, column)
         @model = model or raise ArgumentError, "must pass model"
         @current_table_name = current_table_name or raise ArgumentError, "must pass current_table_name"
         @column = column or raise ArgumentError, "must pass column"
-      end
-
-      def sql_type
-        @sql_type ||= self.class.sql_type(@column.type)
+        @sql_type = self.class.sql_type(@column.type)
       end
 
       SCHEMA_KEYS = [:type, :limit, :precision, :scale, :null, :default].freeze
@@ -121,7 +120,7 @@ module DeclareSchema
           value =
             case key
             when :default
-              self.class.deserialize_default_value(@column, sql_type, @column.default)
+              self.class.deserialize_default_value(@column, @sql_type, @column.default)
             else
               col_value = @column.send(key)
               if col_value.nil? && (native_type = self.class.native_types[@column.type])

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -119,7 +119,7 @@ module DeclareSchema
       # omits name and position since those are meta-data above the schema
       # omits keys with nil values
       def schema_attributes(col_spec)
-        @options.merge(type: @type).tap do |attrs|
+        @sql_options.merge(type: @type).tap do |attrs|
           attrs[:default] = Column.deserialize_default_value(col_spec, @sql_type, attrs[:default])
         end.compact
       end

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -112,7 +112,7 @@ module DeclareSchema
 
         @options = Hash[@options.sort_by { |k, _v| OPTION_INDEXES[k] || 9999 }]
 
-        @sql_options = @options.except(*NON_SQL_OPTIONS)
+        @sql_options = @options.slice(*SQL_OPTIONS)
       end
 
       # returns the attributes for schema migrations as a Hash

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -444,12 +444,12 @@ module Generators
             spec_attrs         = spec.schema_attributes(column)
             column_declaration = ::DeclareSchema::Model::Column.new(model, current_table_name, column)
             col_attrs          = column_declaration.schema_attributes
-            if !::DeclareSchema::Model::Column.equivalent_schema_attributes?(spec_attrs, col_attrs)
-              normalized_schema_attributes = spec_attrs.merge(fk_field_options(model, col_name_to_change))
+            normalized_schema_attrs = spec_attrs.merge(fk_field_options(model, col_name_to_change))
 
-              type = normalized_schema_attributes.delete(:type) or raise "no :type found in #{normalized_schema_attributes.inspect}"
+            if !::DeclareSchema::Model::Column.equivalent_schema_attributes?(normalized_schema_attrs, col_attrs)
+              type = normalized_schema_attrs.delete(:type) or raise "no :type found in #{normalized_schema_attrs.inspect}"
               changes << ["change_column #{new_table_name.to_sym.inspect}", col_name_to_change.to_sym.inspect,
-                          type.to_sym.inspect, *format_options(normalized_schema_attributes)].join(", ")
+                          type.to_sym.inspect, *format_options(normalized_schema_attrs)].join(", ")
               undo_changes << change_column_back(model, current_table_name, orig_col_name)
             end
           end

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -163,4 +163,11 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
       expect(bigint.schema_attributes(col_spec)).to eq(expected_attributes)
     end
   end
+
+  describe '#sql_options' do
+    subject { described_class.new(model, :price, :integer, limit: 4, null: true, default: 0, position: 2, encrypt_using: ->(field) { field }) }
+    it 'excludes non-sql options' do
+      expect(subject.sql_options).to eq(limit: 4, null: true, default: 0)
+    end
+  end
 end

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -149,8 +149,8 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
       end
     end
 
-    it 'returns the attributes except name, position' do
-      subject = described_class.new(model, :price, :bigint, null: true, default: 0, position: 2)
+    it 'returns the attributes except name, position, and non-SQL options' do
+      subject = described_class.new(model, :price, :bigint, null: true, default: 0, ruby_default: -> { }, encrypt_using: -> { }, position: 2)
       expect(subject.schema_attributes(col_spec)).to eq(type: :integer, limit: 8, null: true, default: 0)
     end
 


### PR DESCRIPTION
## [0.7.1] - UNRELEASED
### Fixed
- Exclude unknown options from FieldSpec#sql_options and #schema_attributes.
- Fixed a bug where fk_field_options were getting merged into spec_attrs after checking for equivalence,
  leading to phantom migrations with no changes, or missing migrations when just the fk_field_options changed.