### PR TITLE
Tech 5115 declareschema make foreign key default null text and string limit configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - Unreleased
+### Added
+- Added configurable default settings for `default_text_limit`, `default_string_limit`, `default_null`,
+`default_generate_foreign_keys` and `default_generate_indexing` to allow developers to adhere to project conventions.
+
+### Changed
+- Moved and deprecated default settings for `default_charset` and `default_collation` from
+`Generators::DeclareSchema::Migration::Migrator`to `::DeclareSchema`
+
 ## [0.8.0] - 2021-02-22
 ### Removed
 - Removed assumption that primary key is named 'id'.
@@ -131,6 +140,7 @@ using the appropriate Rails configuration attributes.
 ### Added
 - Initial version from https://github.com/Invoca/hobo_fields v4.1.0.
 
+[0.9.0]: https://github.com/Invoca/declare_schema/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Invoca/declare_schema/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/Invoca/declare_schema/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/Invoca/declare_schema/compare/v0.6.3...v0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 ### Changed
 - Moved and deprecated default settings for `default_charset` and `default_collation` from
-`Generators::DeclareSchema::Migration::Migrator`to `::DeclareSchema`
+`Generators::DeclareSchema::Migration::Migrator` to `::DeclareSchema`
 
 ## [0.8.0] - 2021-02-22
 ### Removed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (0.8.0)
+    declare_schema (0.9.0)
       rails (>= 4.2)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ Generators::DeclareSchema::Migration::Migrator.default_generate_foreign_keys = f
 The character set and collation for all tables and fields can be set at the global level
 using the `Generators::DeclareSchema::Migrator.default_charset=` and
 `Generators::DeclareSchema::Migrator.default_collation=` configuration methods.
-    - These values default to `"utf8mb4"` and `"utf8mb4_bin"` if not set.
 
 For example, adding the following to your `config/initializers` directory will
 turn all tables into `utf8mb4` supporting tables:

--- a/README.md
+++ b/README.md
@@ -70,21 +70,89 @@ DeclareSchema::Migration::Migrator.before_generating_migration do
 end
 ```
 
-## Declaring Character Set and Collation
-_Note: This feature currently only works for MySQL database configurations._
-
-MySQL originally supported UTF-8 in the range of 1-3 bytes (`mb3` or "multi-byte 3")
-which covered the full set of Unicode code points at the time: U+0000 - U+FFFF.
-But later, Unicode was extended beyond U+FFFF to make room for emojis, and with that
-UTF-8 require 1-4 bytes (`mb4` or "multi-byte 4"). With this addition, there has
-come a need to dynamically define the character set and collation for individual
-tables and columns in the database. With `declare_schema` this can be configured
-at three separate levels
-
 ### Global Configuration
+Configurations can be set at the global level to customize default declaration for the following values:
+
+#### Text Limit
+The default text limit can be set using the `Generators::DeclareSchema::Migration::Migrator.default_text_limit=` method.
+Note that a `nil` default means that there is no default-- so every declaration must be explicit.
+This will `raise` a `limit: must be provided for field :text...` error when the default value is `nil` and there is no explicit
+declaration.
+
+For example, adding the following to your `config/initializers` directory will
+set the default `text limit` value to `0xffff_ffff`:
+ 
+**declare_schema.rb**
+```ruby
+# frozen_string_literal: true
+
+Generators::DeclareSchema::Migration::Migrator.default_text_limit = 0xffff_ffff
+```
+
+#### String Limit
+The default string limit can be set using the `Generators::DeclareSchema::Migration::Migrator.default_string_limit=` method.
+Note that a `nil` default means that there is no default-- so every declaration must be explicit.
+This will `raise` a `limit: must be provided for field :string...` error when the default value is `nil` and there is no explicit
+declaration.
+
+For example, adding the following to your `config/initializers` directory will
+set the default `string limit` value to `nil`:
+ 
+**declare_schema.rb**
+```ruby
+# frozen_string_literal: true
+
+Generators::DeclareSchema::Migration::Migrator.default_string_limit = nil
+```
+
+#### Null
+The default null value can be set using the `Generators::DeclareSchema::Migration::Migrator.default_null=` method.
+Note that a `nil` default means that there is no default-- so every declaration must be explicit.
+This will `raise` a `null: must be provided for field...` error when the default value is `nil` and there is no explicit
+declaration.
+
+For example, adding the following to your `config/initializers` directory will
+set the default `null` value to `false`:
+ 
+**declare_schema.rb**
+```ruby
+# frozen_string_literal: true
+
+Generators::DeclareSchema::Migration::Migrator.default_null = false
+```
+
+#### Generate Foreign Keys
+The default value for generate foreign keys can be set using the `Generators::DeclareSchema::Migration::Migrator.default_generate_foreign_keys=` method.
+This value defaults to `true` and can only be set at the global level.
+
+For example, adding the following to your `config/initializers` directory will
+generate foreign keys:
+ 
+**declare_schema.rb**
+```ruby
+# frozen_string_literal: true
+
+Generators::DeclareSchema::Migration::Migrator.default_generate_foreign_keys = false
+```
+
+#### Generate Indexing
+The default value for generate indexing can be set using the `Generators::DeclareSchema::Migration::Migrator.default_generate_indexing=` method.
+This value defaults to `true` and can only be set at the global level.
+
+For example, adding the following to your `config/initializers` directory will
+generate indexing:
+ 
+**declare_schema.rb**
+```ruby
+# frozen_string_literal: true
+
+Generators::DeclareSchema::Migration::Migrator.default_generate_foreign_keys = false
+```
+#### Character Set and Collation
 The character set and collation for all tables and fields can be set at the global level
 using the `Generators::DeclareSchema::Migrator.default_charset=` and
 `Generators::DeclareSchema::Migrator.default_collation=` configuration methods.
+    - These values default to `"utf8mb4"` and `"utf8mb4_bin"` if not set.
 
 For example, adding the following to your `config/initializers` directory will
 turn all tables into `utf8mb4` supporting tables:
@@ -96,6 +164,17 @@ turn all tables into `utf8mb4` supporting tables:
 Generators::DeclareSchema::Migration::Migrator.default_charset   = "utf8mb4"
 Generators::DeclareSchema::Migration::Migrator.default_collation = "utf8mb4_bin"
 ```
+
+## Declaring Character Set and Collation
+_Note: This feature currently only works for MySQL database configurations._
+
+MySQL originally supported UTF-8 in the range of 1-3 bytes (`mb3` or "multi-byte 3")
+which covered the full set of Unicode code points at the time: U+0000 - U+FFFF.
+But later, Unicode was extended beyond U+FFFF to make room for emojis, and with that
+UTF-8 require 1-4 bytes (`mb4` or "multi-byte 4"). With this addition, there has
+come a need to dynamically define the character set and collation for individual
+tables and columns in the database. With `declare_schema` this can be configured
+at three separate levels
 
 ### Table Configuration
 In order to configure a table's default character set and collation, the `charset` and
@@ -136,25 +215,6 @@ class Comment < ActiveRecord::Base
 end
 ```
 
-## Addition Project Configurations
-Additional global configurations are available to match a developer's project conventions.
-Similar to setting the `character set` and `collation` at the global level you can also configure the
-default `text limit`, `string limit`, `null`, `generate foreign keys`, and `genereate indexing`.
-
-For example, adding the following to your `config/initializers` directory will set the default project configurations:
-
-**declare_schema.rb**
-```ruby
-# frozen_string_literal: true
-
-Generators::DeclareSchema::Migration::Migrator.default_text_limit            = 0xffff_ffff
-Generators::DeclareSchema::Migration::Migrator.default_string_limit          = nil
-Generators::DeclareSchema::Migration::Migrator.default_null                  = false
-Generators::DeclareSchema::Migration::Migrator.default_generate_foreign_keys = true
-Generators::DeclareSchema::Migration::Migrator.default_generate_indexing     = true
-```
-
-Note that a `nil` default for any field specification means that there is no default-- so every declaration must be explicit.
 ## Installing
 
 Install the `DeclareSchema` gem directly:

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ DeclareSchema.default_text_limit = 0xffff
 ```
 
 #### String Limit
-The default string limit can be set using the `Generators::DeclareSchema::Migration::Migrator.default_string_limit=` method.
+The default string limit can be set using the `DeclareSchema.default_string_limit=` method.
 Note that a `nil` default means that there is no default-- so every declaration must be explicit.
 This will `raise` a `limit: must be provided for field :string...` error when the default value is `nil` and there is no explicit
 declaration.
@@ -102,11 +102,11 @@ set the default `string limit` value to `255`:
 ```ruby
 # frozen_string_literal: true
 
-Generators::DeclareSchema::Migration::Migrator.default_string_limit = 255
+DeclareSchema.default_string_limit = 255
 ```
 
 #### Null
-The default null value can be set using the `Generators::DeclareSchema::Migration::Migrator.default_null=` method.
+The default null value can be set using the `DeclareSchema.default_null=` method.
 Note that a `nil` default means that there is no default-- so every declaration must be explicit.
 This will `raise` a `null: must be provided for field...` error when the default value is `nil` and there is no explicit
 declaration.
@@ -118,11 +118,11 @@ set the default `null` value to `true`:
 ```ruby
 # frozen_string_literal: true
 
-Generators::DeclareSchema::Migration::Migrator.default_null = true
+DeclareSchema.default_null = true
 ```
 
 #### Generate Foreign Keys
-The default value for generate foreign keys can be set using the `Generators::DeclareSchema::Migration::Migrator.default_generate_foreign_keys=` method.
+The default value for generate foreign keys can be set using the `DeclareSchema.default_generate_foreign_keys=` method.
 This value defaults to `true` and can only be set at the global level.
 
 For example, adding the following to your `config/initializers` directory will set
@@ -132,11 +132,11 @@ the default `generate foreign keys` value to `false`:
 ```ruby
 # frozen_string_literal: true
 
-Generators::DeclareSchema::Migration::Migrator.default_generate_foreign_keys = false
+DeclareSchema.default_generate_foreign_keys = false
 ```
 
 #### Generate Indexing
-The default value for generate indexing can be set using the `Generators::DeclareSchema::Migration::Migrator.default_generate_indexing=` method.
+The default value for generate indexing can be set using the `DeclareSchema.default_generate_indexing=` method.
 This value defaults to `true` and can only be set at the global level.
 
 For example, adding the following to your `config/initializers` directory will
@@ -146,7 +146,7 @@ set the default `generate indexing` value to `false`:
 ```ruby
 # frozen_string_literal: true
 
-Generators::DeclareSchema::Migration::Migrator.default_generate_indexing = false
+DeclareSchema.default_generate_indexing = false
 ```
 #### Character Set and Collation
 The character set and collation for all tables and fields can be set at the global level
@@ -160,8 +160,8 @@ turn all tables into `utf8mb4` supporting tables:
 ```ruby
 # frozen_string_literal: true
 
-Generators::DeclareSchema::Migration::Migrator.default_charset   = "utf8mb4"
-Generators::DeclareSchema::Migration::Migrator.default_collation = "utf8mb4_bin"
+DeclareSchema.default_charset   = "utf8mb4"
+DeclareSchema.default_collation = "utf8mb4_bin"
 ```
 
 ## Declaring Character Set and Collation

--- a/README.md
+++ b/README.md
@@ -136,6 +136,25 @@ class Comment < ActiveRecord::Base
 end
 ```
 
+## Addition Project Configurations
+Additional global configurations are available to match a developer's project conventions.
+Similar to setting the `character set` and `collation` at the global level you can also configure the
+default `text limit`, `string limit`, `null`, `generate foreign keys`, and `genereate indexing`.
+
+For example, adding the following to your `config/initializers` directory will set the default project configurations:
+
+**declare_schema.rb**
+```ruby
+# frozen_string_literal: true
+
+Generators::DeclareSchema::Migration::Migrator.default_text_limit            = 0xffff_ffff
+Generators::DeclareSchema::Migration::Migrator.default_string_limit          = nil
+Generators::DeclareSchema::Migration::Migrator.default_null                  = false
+Generators::DeclareSchema::Migration::Migrator.default_generate_foreign_keys = true
+Generators::DeclareSchema::Migration::Migrator.default_generate_indexing     = true
+```
+
+Note that a `nil` default for any field specification means that there is no default-- so every declaration must be explicit.
 ## Installing
 
 Install the `DeclareSchema` gem directly:

--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ This will `raise` a `limit: must be provided for field :text...` error when the 
 declaration.
 
 For example, adding the following to your `config/initializers` directory will
-set the default `text limit` value to `0xffff_ffff`:
+set the default `text limit` value to `0xffff`:
  
 **declare_schema.rb**
 ```ruby
 # frozen_string_literal: true
 
-Generators::DeclareSchema::Migration::Migrator.default_text_limit = 0xffff_ffff
+Generators::DeclareSchema::Migration::Migrator.default_text_limit = 0xffff
 ```
 
 #### String Limit
@@ -96,13 +96,13 @@ This will `raise` a `limit: must be provided for field :string...` error when th
 declaration.
 
 For example, adding the following to your `config/initializers` directory will
-set the default `string limit` value to `nil`:
+set the default `string limit` value to `255`:
  
 **declare_schema.rb**
 ```ruby
 # frozen_string_literal: true
 
-Generators::DeclareSchema::Migration::Migrator.default_string_limit = nil
+Generators::DeclareSchema::Migration::Migrator.default_string_limit = 255
 ```
 
 #### Null
@@ -112,21 +112,21 @@ This will `raise` a `null: must be provided for field...` error when the default
 declaration.
 
 For example, adding the following to your `config/initializers` directory will
-set the default `null` value to `false`:
+set the default `null` value to `true`:
  
 **declare_schema.rb**
 ```ruby
 # frozen_string_literal: true
 
-Generators::DeclareSchema::Migration::Migrator.default_null = false
+Generators::DeclareSchema::Migration::Migrator.default_null = true
 ```
 
 #### Generate Foreign Keys
 The default value for generate foreign keys can be set using the `Generators::DeclareSchema::Migration::Migrator.default_generate_foreign_keys=` method.
 This value defaults to `true` and can only be set at the global level.
 
-For example, adding the following to your `config/initializers` directory will
-generate foreign keys:
+For example, adding the following to your `config/initializers` directory will set
+the default `generate foreign keys` value to `false`:
  
 **declare_schema.rb**
 ```ruby
@@ -140,13 +140,13 @@ The default value for generate indexing can be set using the `Generators::Declar
 This value defaults to `true` and can only be set at the global level.
 
 For example, adding the following to your `config/initializers` directory will
-generate indexing:
+set the default `generate indexing` value to `false`:
  
 **declare_schema.rb**
 ```ruby
 # frozen_string_literal: true
 
-Generators::DeclareSchema::Migration::Migrator.default_generate_foreign_keys = false
+Generators::DeclareSchema::Migration::Migrator.default_generate_indexing = false
 ```
 #### Character Set and Collation
 The character set and collation for all tables and fields can be set at the global level

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ end
 Configurations can be set at the global level to customize default declaration for the following values:
 
 #### Text Limit
-The default text limit can be set using the `Generators::DeclareSchema::Migration::Migrator.default_text_limit=` method.
+The default text limit can be set using the `DeclareSchema.default_text_limit=` method.
 Note that a `nil` default means that there is no default-- so every declaration must be explicit.
 This will `raise` a `limit: must be provided for field :text...` error when the default value is `nil` and there is no explicit
 declaration.
@@ -86,7 +86,7 @@ set the default `text limit` value to `0xffff`:
 ```ruby
 # frozen_string_literal: true
 
-Generators::DeclareSchema::Migration::Migrator.default_text_limit = 0xffff
+DeclareSchema.default_text_limit = 0xffff
 ```
 
 #### String Limit

--- a/lib/declare_schema.rb
+++ b/lib/declare_schema.rb
@@ -21,10 +21,17 @@ module DeclareSchema
     text:     String
   }.freeze
 
-  @default_text_limit = 0xffff_ffff
+  @default_charset               = "utf8mb4"
+  @default_collation             = "utf8mb4_bin"
+  @default_text_limit            = 0xffff_ffff
+  @default_string_limit          = nil
+  @default_null                  = false
+  @default_generate_foreign_keys = true
+  @default_generate_indexing     = true
 
   class << self
-    attr_reader :default_text_limit
+    attr_reader :default_charset, :default_collation, :default_text_limit, :default_string_limit, :default_null,
+                :default_generate_foreign_keys, :default_generate_indexing
 
     def to_class(type)
       case type
@@ -37,9 +44,39 @@ module DeclareSchema
       end
     end
 
+    def default_charset=(charset)
+      charset.is_a?(String) or raise ArgumentError, "charset must be a string (got #{charset.inspect})"
+      @default_charset = charset
+    end
+
+    def default_collation=(collation)
+      collation.is_a?(String) or raise ArgumentError, "collation must be a string (got #{collation.inspect})"
+      @default_collation = collation
+    end
+
     def default_text_limit=(text_limit)
       text_limit.nil? or text_limit.is_a?(Integer) or raise ArgumentError, "text limit must be an integer or nil (got #{text_limit.inspect})"
       @default_text_limit = text_limit
+    end
+
+    def default_string_limit=(string_limit)
+      string_limit.nil? or string_limit.is_a?(Integer) or raise ArgumentError, "string limit must be an integer or nil (got #{string_limit.inspect})"
+      @default_string_limit = string_limit
+    end
+
+    def default_null=(null)
+      null.in?([true, false, nil]) or raise ArgumentError, "null must be either true, false, or nil (got #{null.inspect})"
+      @default_null = null
+    end
+
+    def default_generate_foreign_keys=(generate_foreign_keys)
+      generate_foreign_keys.in?([true, false]) or raise ArgumentError, "generate_foreign_keys must be either true or false (got #{generate_foreign_keys.inspect})"
+      @default_generate_foreign_keys = generate_foreign_keys
+    end
+
+    def default_generate_indexing=(generate_indexing)
+      [true, false].include?(generate_indexing) or raise ArgumentError, "generate_indexing must be either true or false (got #{generate_indexing.inspect})"
+      @default_generate_indexing = generate_indexing
     end
   end
 end

--- a/lib/declare_schema.rb
+++ b/lib/declare_schema.rb
@@ -21,7 +21,11 @@ module DeclareSchema
     text:     String
   }.freeze
 
+  @default_text_limit = 0xffff_ffff
+
   class << self
+    attr_reader :default_text_limit
+
     def to_class(type)
       case type
       when Class
@@ -31,6 +35,11 @@ module DeclareSchema
       else
         raise ArgumentError, "expected Class or Symbol or String: got #{type.inspect}"
       end
+    end
+
+    def default_text_limit=(text_limit)
+      text_limit.nil? or text_limit.is_a?(Integer) or raise ArgumentError, "text limit must be an integer or nil (got #{text_limit.inspect})"
+      @default_text_limit = text_limit
     end
   end
 end

--- a/lib/declare_schema.rb
+++ b/lib/declare_schema.rb
@@ -75,7 +75,7 @@ module DeclareSchema
     end
 
     def default_generate_indexing=(generate_indexing)
-      [true, false].include?(generate_indexing) or raise ArgumentError, "generate_indexing must be either true or false (got #{generate_indexing.inspect})"
+      generate_indexing.in?([true, false]) or raise ArgumentError, "generate_indexing must be either true or false (got #{generate_indexing.inspect})"
       @default_generate_indexing = generate_indexing
     end
   end

--- a/lib/declare_schema/extensions/active_record/fields_declaration.rb
+++ b/lib/declare_schema/extensions/active_record/fields_declaration.rb
@@ -15,7 +15,7 @@ module DeclareSchema
       @table_options        = table_options
 
       if block
-        dsl = DeclareSchema::FieldDeclarationDsl.new(self, null: false)
+        dsl = DeclareSchema::FieldDeclarationDsl.new(self)
         if block.arity == 1
           yield dsl
         else

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -67,7 +67,7 @@ module DeclareSchema
             @options[:default].nil? or raise MysqlTextMayNotHaveDefault, "when using MySQL, non-nil default may not be given for :text field #{model}##{@name}"
             @options[:limit] = self.class.round_up_mysql_text_limit(
               @options[:limit] ||
-              Generators::DeclareSchema::Migration::Migrator.default_text_limit ||
+              Generators::DeclareSchema::Migration::Migrator.default_text_limit or
               raise("limit: must be provided for :text field #{model}##{@name}: #{@options.inspect} since Generators::DeclareSchema::Migration::Migrator#default_text_limit is set to 'nil'; do you want `limit: 0xffff_ffff`?"))
           else
             @options.delete(:limit)

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -65,10 +65,9 @@ module DeclareSchema
         when :text
           if self.class.mysql_text_limits?
             @options[:default].nil? or raise MysqlTextMayNotHaveDefault, "when using MySQL, non-nil default may not be given for :text field #{model}##{@name}"
-            @options[:limit] = self.class.round_up_mysql_text_limit(
-              @options[:limit] ||
-              Generators::DeclareSchema::Migration::Migrator.default_text_limit ||
-              raise("limit: must be provided for :text field #{model}##{@name}: #{@options.inspect} since Generators::DeclareSchema::Migration::Migrator#default_text_limit is set to 'nil'; do you want `limit: 0xffff_ffff`?"))
+            @options[:limit] ||= Generators::DeclareSchema::Migration::Migrator.default_text_limit or
+                  raise("limit: must be provided for :text field #{model}##{@name}: #{@options.inspect} since Generators::DeclareSchema::Migration::Migrator#default_text_limit is set to 'nil'; do you want `limit: 0xffff_ffff`?")
+            @options[:limit] = self.class.round_up_mysql_text_limit(@options[:limit])
           else
             @options.delete(:limit)
           end

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -67,7 +67,7 @@ module DeclareSchema
             @options[:default].nil? or raise MysqlTextMayNotHaveDefault, "when using MySQL, non-nil default may not be given for :text field #{model}##{@name}"
             @options[:limit] = self.class.round_up_mysql_text_limit(
               @options[:limit] ||
-              Generators::DeclareSchema::Migration::Migrator.default_text_limit or
+              Generators::DeclareSchema::Migration::Migrator.default_text_limit ||
               raise("limit: must be provided for :text field #{model}##{@name}: #{@options.inspect} since Generators::DeclareSchema::Migration::Migrator#default_text_limit is set to 'nil'; do you want `limit: 0xffff_ffff`?"))
           else
             @options.delete(:limit)

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -104,7 +104,7 @@ module DeclareSchema
           end
         else
           @options[:charset]   and warn("charset may only given for :string and :text fields for SQL type #{@type} in field #{model}##{@name}")
-          @options[:collation] and warne("collation may only given for :string and :text fields for SQL type #{@type} in field #{model}##{@name}")
+          @options[:collation] and warn("collation may only given for :string and :text fields for SQL type #{@type} in field #{model}##{@name}")
         end
 
         @options = Hash[@options.sort_by { |k, _v| OPTION_INDEXES[k] || 9999 }]

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -73,7 +73,7 @@ module DeclareSchema
             @options.delete(:limit)
           end
         when :string
-          @options[:limit] ||= Generators::DeclareSchema::Migration::Migrator.default_string_limit or raise "limit: must be given for :string field #{model}##{@name}: #{@options.inspect}; do you want `limit: 255`?"
+          @options[:limit] ||= Generators::DeclareSchema::Migration::Migrator.default_string_limit or raise "limit: must be provided for :string field #{model}##{@name}: #{@options.inspect} since Generators::DeclareSchema::Migration::Migrator#default_string_limit is set to 'nil'; do you want `limit: 255`?"
         when :bigint
           @type = :integer
           @options[:limit] = 8

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -69,7 +69,7 @@ module DeclareSchema
             @options.delete(:limit)
           end
         when :string
-          @options[:limit] or raise "limit: must be given for :string field #{model}##{@name}: #{@options.inspect}; do you want `limit: 255`?"
+          @options[:limit] ||= Generators::DeclareSchema::Migration::Migrator.default_string_limit or raise "limit: must be given for :string field #{model}##{@name}: #{@options.inspect}; do you want `limit: 255`?"
         when :bigint
           @type = :integer
           @options[:limit] = 8

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -58,7 +58,7 @@ module DeclareSchema
         @position = position
         @options = options.dup
 
-        @options.has_key?(:null) or Generators::DeclareSchema::Migration::Migrator.default_null
+        @options.has_key?(:null) or @options[:null] = Generators::DeclareSchema::Migration::Migrator.default_null
 
         case @type
         when :text

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -64,7 +64,7 @@ module DeclareSchema
         when :text
           if self.class.mysql_text_limits?
             @options[:default].nil? or raise MysqlTextMayNotHaveDefault, "when using MySQL, non-nil default may not be given for :text field #{model}##{@name}"
-            @options[:limit] = self.class.round_up_mysql_text_limit(@options[:limit] || MYSQL_LONGTEXT_LIMIT)
+            @options[:limit] = self.class.round_up_mysql_text_limit(@options[:limit] || Generators::DeclareSchema::Migration::Migrator.default_text_limit)
           else
             @options.delete(:limit)
           end

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -59,6 +59,7 @@ module DeclareSchema
         @options = options.dup
 
         @options.has_key?(:null) or @options[:null] = Generators::DeclareSchema::Migration::Migrator.default_null
+        @options[:null].nil? and raise "null: must be provided for field #{model}##{@name}: #{@options.inspect} since Generators::DeclareSchema::Migration::Migrator.default_null is set to 'nil'; do you want `null: false`?"
 
         case @type
         when :text

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -59,13 +59,16 @@ module DeclareSchema
         @options = options.dup
 
         @options.has_key?(:null) or @options[:null] = Generators::DeclareSchema::Migration::Migrator.default_null
-        @options[:null].nil? and raise "null: must be provided for field #{model}##{@name}: #{@options.inspect} since Generators::DeclareSchema::Migration::Migrator.default_null is set to 'nil'; do you want `null: false`?"
+        @options[:null].nil? and raise "null: must be provided for field #{model}##{@name}: #{@options.inspect} since Generators::DeclareSchema::Migration::Migrator#default_null is set to 'nil'; do you want `null: false`?"
 
         case @type
         when :text
           if self.class.mysql_text_limits?
             @options[:default].nil? or raise MysqlTextMayNotHaveDefault, "when using MySQL, non-nil default may not be given for :text field #{model}##{@name}"
-            @options[:limit] = self.class.round_up_mysql_text_limit(@options[:limit] || Generators::DeclareSchema::Migration::Migrator.default_text_limit)
+            @options[:limit] = self.class.round_up_mysql_text_limit(
+              @options[:limit] ||
+              Generators::DeclareSchema::Migration::Migrator.default_text_limit ||
+              raise("limit: must be provided for field #{model}##{@name}: #{@options.inspect} since Generators::DeclareSchema::Migration::Migrator#default_text_limit is set to 'nil'; do you want `limit: 0xffff_ffff`?"))
           else
             @options.delete(:limit)
           end

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -58,7 +58,7 @@ module DeclareSchema
         @position = position
         @options = options.dup
 
-        @options.has_key?(:null) or @options[:null] = false
+        @options.has_key?(:null) or Generators::DeclareSchema::Migration::Migrator.default_null
 
         case @type
         when :text

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -58,8 +58,8 @@ module DeclareSchema
         @position = position
         @options = options.dup
 
-        @options.has_key?(:null) or @options[:null] = Generators::DeclareSchema::Migration::Migrator.default_null
-        @options[:null].nil? and raise "null: must be provided for field #{model}##{@name}: #{@options.inspect} since Generators::DeclareSchema::Migration::Migrator#default_null is set to 'nil'; do you want `null: false`?"
+        @options.has_key?(:null) or @options[:null] = ::DeclareSchema.default_null
+        @options[:null].nil? and raise "null: must be provided for field #{model}##{@name}: #{@options.inspect} since ::DeclareSchema#default_null is set to 'nil'; do you want `null: false`?"
 
         case @type
         when :text
@@ -72,7 +72,7 @@ module DeclareSchema
             @options.delete(:limit)
           end
         when :string
-          @options[:limit] ||= Generators::DeclareSchema::Migration::Migrator.default_string_limit or raise "limit: must be provided for :string field #{model}##{@name}: #{@options.inspect} since Generators::DeclareSchema::Migration::Migrator#default_string_limit is set to 'nil'; do you want `limit: 255`?"
+          @options[:limit] ||= ::DeclareSchema.default_string_limit or raise "limit: must be provided for :string field #{model}##{@name}: #{@options.inspect} since ::DeclareSchema#default_string_limit is set to 'nil'; do you want `limit: 255`?"
         when :bigint
           @type = :integer
           @options[:limit] = 8
@@ -99,8 +99,8 @@ module DeclareSchema
 
         if @type.in?([:text, :string])
           if ActiveRecord::Base.connection.class.name.match?(/mysql/i)
-            @options[:charset]   ||= model.table_options[:charset]   || Generators::DeclareSchema::Migration::Migrator.default_charset
-            @options[:collation] ||= model.table_options[:collation] || Generators::DeclareSchema::Migration::Migrator.default_collation
+            @options[:charset]   ||= model.table_options[:charset]   || ::DeclareSchema.default_charset
+            @options[:collation] ||= model.table_options[:collation] || ::DeclareSchema.default_collation
           else
             @options.delete(:charset)
             @options.delete(:collation)

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -68,7 +68,7 @@ module DeclareSchema
             @options[:limit] = self.class.round_up_mysql_text_limit(
               @options[:limit] ||
               Generators::DeclareSchema::Migration::Migrator.default_text_limit ||
-              raise("limit: must be provided for field #{model}##{@name}: #{@options.inspect} since Generators::DeclareSchema::Migration::Migrator#default_text_limit is set to 'nil'; do you want `limit: 0xffff_ffff`?"))
+              raise("limit: must be provided for :text field #{model}##{@name}: #{@options.inspect} since Generators::DeclareSchema::Migration::Migrator#default_text_limit is set to 'nil'; do you want `limit: 0xffff_ffff`?"))
           else
             @options.delete(:limit)
           end

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -65,8 +65,8 @@ module DeclareSchema
         when :text
           if self.class.mysql_text_limits?
             @options[:default].nil? or raise MysqlTextMayNotHaveDefault, "when using MySQL, non-nil default may not be given for :text field #{model}##{@name}"
-            @options[:limit] ||= Generators::DeclareSchema::Migration::Migrator.default_text_limit or
-                  raise("limit: must be provided for :text field #{model}##{@name}: #{@options.inspect} since Generators::DeclareSchema::Migration::Migrator#default_text_limit is set to 'nil'; do you want `limit: 0xffff_ffff`?")
+            @options[:limit] ||= ::DeclareSchema.default_text_limit or
+                  raise("limit: must be provided for :text field #{model}##{@name}: #{@options.inspect} since ::DeclareSchema#default_text_limit is set to 'nil'; do you want `limit: 0xffff_ffff`?")
             @options[:limit] = self.class.round_up_mysql_text_limit(@options[:limit])
           else
             @options.delete(:limit)

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "0.8.0"
+  VERSION = "0.9.0"
 end

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -15,6 +15,7 @@ module Generators
         DEFAULT_STRING_LIMIT          = nil
         DEFAULT_NULL                  = false
         DEFAULT_GENERATE_FOREIGN_KEYS = true
+        DEFAULT_GENERATE_INDEXING     = true
 
         @ignore_models                        = []
         @ignore_tables                        = []
@@ -26,11 +27,12 @@ module Generators
         @default_string_limit                 = DEFAULT_STRING_LIMIT
         @default_null                         = DEFAULT_NULL
         @default_generate_foreign_keys        = DEFAULT_GENERATE_FOREIGN_KEYS
+        @default_generate_indexing            = DEFAULT_GENERATE_INDEXING
 
         class << self
           attr_accessor :ignore_models, :ignore_tables, :disable_indexing, :disable_constraints
           attr_reader :active_record_class, :default_charset, :default_collation, :default_text_limit, :default_string_limit, :default_null,
-                      :default_generate_foreign_keys, :before_generating_migration_callback
+                      :default_generate_foreign_keys, :default_generate_indexing, :before_generating_migration_callback
 
           def default_charset=(charset)
             charset.is_a?(String) or raise ArgumentError, "charset must be a string (got #{charset.inspect})"
@@ -63,8 +65,18 @@ module Generators
             toggle_disable_constraints
           end
 
+          def default_generate_indexing=(generate_indexing)
+            [true, false].include? generate_indexing or raise ArgumentError, "generate_indexing must be either true or false (got #{generate_indexing.inspect})"
+            @default_generate_indexing = generate_indexing
+            toggle_disable_indexing
+          end
+
           def toggle_disable_constraints
             @disable_constraints = !@default_generate_foreign_keys
+          end
+
+          def toggle_disable_indexing
+            @disable_indexing = !@default_generate_indexing
           end
 
           def active_record_class

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -12,6 +12,7 @@ module Generators
         DEFAULT_CHARSET       = "utf8mb4"
         DEFAULT_COLLATION     = "utf8mb4_bin"
         DEFAULT_TEXT_LIMIT    = 0xffff_ffff
+        DEFAULT_STRING_LIMIT  = nil
 
         @ignore_models                        = []
         @ignore_tables                        = []
@@ -20,11 +21,12 @@ module Generators
         @default_charset                      = DEFAULT_CHARSET
         @default_collation                    = DEFAULT_COLLATION
         @default_text_limit                   = DEFAULT_TEXT_LIMIT
+        @default_string_limit                 = DEFAULT_STRING_LIMIT
 
 
         class << self
           attr_accessor :ignore_models, :ignore_tables, :disable_indexing, :disable_constraints
-          attr_reader :active_record_class, :default_charset, :default_collation, :default_text_limit, :before_generating_migration_callback
+          attr_reader :active_record_class, :default_charset, :default_collation, :default_text_limit, :default_string_limit, :before_generating_migration_callback
 
           def default_charset=(charset)
             charset.is_a?(String) or raise ArgumentError, "charset must be a string (got #{charset.inspect})"
@@ -39,6 +41,11 @@ module Generators
           def default_text_limit=(text_limit)
             text_limit.is_a?(Integer) or raise ArgumentError, "text limit must be an integer (got #{text_limit.inspect})"
             @default_text_limit = text_limit
+          end
+
+          def default_string_limit=(string_limit)
+            string_limit.nil? or string_limit.is_a?(Integer) or raise ArgumentError, "string limit must be an integer (got #{string_limit.inspect})"
+            @default_string_limit = string_limit
           end
 
           def active_record_class

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -9,8 +9,9 @@ module Generators
       class Migrator
         class Error < RuntimeError; end
 
-        DEFAULT_CHARSET   = "utf8mb4"
-        DEFAULT_COLLATION = "utf8mb4_bin"
+        DEFAULT_CHARSET       = "utf8mb4"
+        DEFAULT_COLLATION     = "utf8mb4_bin"
+        DEFAULT_TEXT_LIMIT    = 0xffff_ffff
 
         @ignore_models                        = []
         @ignore_tables                        = []
@@ -18,10 +19,12 @@ module Generators
         @active_record_class                  = ActiveRecord::Base
         @default_charset                      = DEFAULT_CHARSET
         @default_collation                    = DEFAULT_COLLATION
+        @default_text_limit                   = DEFAULT_TEXT_LIMIT
+
 
         class << self
           attr_accessor :ignore_models, :ignore_tables, :disable_indexing, :disable_constraints
-          attr_reader :active_record_class, :default_charset, :default_collation, :before_generating_migration_callback
+          attr_reader :active_record_class, :default_charset, :default_collation, :default_text_limit, :before_generating_migration_callback
 
           def default_charset=(charset)
             charset.is_a?(String) or raise ArgumentError, "charset must be a string (got #{charset.inspect})"
@@ -31,6 +34,11 @@ module Generators
           def default_collation=(collation)
             collation.is_a?(String) or raise ArgumentError, "collation must be a string (got #{collation.inspect})"
             @default_collation = collation
+          end
+
+          def default_text_limit=(text_limit)
+            text_limit.is_a?(Integer) or raise ArgumentError, "text limit must be an integer (got #{text_limit.inspect})"
+            @default_text_limit = text_limit
           end
 
           def active_record_class

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -15,7 +15,6 @@ module Generators
         @active_record_class                  = ActiveRecord::Base
         @default_charset                      = "utf8mb4"
         @default_collation                    = "utf8mb4_bin"
-        @default_text_limit                   = 0xffff_ffff
         @default_string_limit                 = nil
         @default_null                         = false
         @default_generate_foreign_keys        = true
@@ -23,7 +22,7 @@ module Generators
 
         class << self
           attr_accessor :ignore_models, :ignore_tables
-          attr_reader :active_record_class, :default_charset, :default_collation, :default_text_limit, :default_string_limit, :default_null,
+          attr_reader :active_record_class, :default_charset, :default_collation, :default_string_limit, :default_null,
                       :default_generate_foreign_keys, :default_generate_indexing, :before_generating_migration_callback
 
           def default_charset=(charset)
@@ -34,11 +33,6 @@ module Generators
           def default_collation=(collation)
             collation.is_a?(String) or raise ArgumentError, "collation must be a string (got #{collation.inspect})"
             @default_collation = collation
-          end
-
-          def default_text_limit=(text_limit)
-            text_limit.nil? or text_limit.is_a?(Integer) or raise ArgumentError, "text limit must be an integer or nil (got #{text_limit.inspect})"
-            @default_text_limit = text_limit
           end
 
           def default_string_limit=(string_limit)

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -55,17 +55,17 @@ module Generators
           end
 
           def default_null=(null)
-            [true, false, nil].include? null or raise ArgumentError, "null must be either true, false, or nil (got #{null.inspect})"
+            [true, false, nil].include?(null) or raise ArgumentError, "null must be either true, false, or nil (got #{null.inspect})"
             @default_null = null
           end
 
           def default_generate_foreign_keys=(generate_foreign_keys)
-            [true, false].include? generate_foreign_keys or raise ArgumentError, "generate_foreign_keys must be either true or false (got #{generate_foreign_keys.inspect})"
+            [true, false].include?(generate_foreign_keys) or raise ArgumentError, "generate_foreign_keys must be either true or false (got #{generate_foreign_keys.inspect})"
             @default_generate_foreign_keys = generate_foreign_keys
           end
 
           def default_generate_indexing=(generate_indexing)
-            [true, false].include? generate_indexing or raise ArgumentError, "generate_indexing must be either true or false (got #{generate_indexing.inspect})"
+            [true, false].include?(generate_indexing) or raise ArgumentError, "generate_indexing must be either true or false (got #{generate_indexing.inspect})"
             @default_generate_indexing = generate_indexing
           end
 

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -47,12 +47,12 @@ module Generators
           end
 
           def default_null=(null)
-            [true, false, nil].include?(null) or raise ArgumentError, "null must be either true, false, or nil (got #{null.inspect})"
+            null.in?([true, false, nil]) or raise ArgumentError, "null must be either true, false, or nil (got #{null.inspect})"
             @default_null = null
           end
 
           def default_generate_foreign_keys=(generate_foreign_keys)
-            [true, false].include?(generate_foreign_keys) or raise ArgumentError, "generate_foreign_keys must be either true or false (got #{generate_foreign_keys.inspect})"
+            generate_foreign_keys.in?([true, false]) or raise ArgumentError, "generate_foreign_keys must be either true or false (got #{generate_foreign_keys.inspect})"
             @default_generate_foreign_keys = generate_foreign_keys
           end
 

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -55,7 +55,7 @@ module Generators
           end
 
           def default_null=(null)
-            [true, false].include? null or raise ArgumentError, "null must be either true, false, or nil (got #{null.inspect})"
+            [true, false, nil].include? null or raise ArgumentError, "null must be either true, false, or nil (got #{null.inspect})"
             @default_null = null
           end
 

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -309,7 +309,7 @@ module Generators
 
             #{table_options_definition.alter_table_statement unless ActiveRecord::Base.connection.class.name.match?(/SQLite3Adapter/)}
             #{create_indexes(model).join("\n")               unless Migrator.disable_indexing}
-            #{create_constraints(model).join("\n")           unless Migrator.disable_indexing}
+            #{create_constraints(model).join("\n")           unless Migrator.disable_constraints}
           EOS
         end
 
@@ -444,7 +444,7 @@ module Generators
         end
 
         def change_indexes(model, old_table_name, to_remove)
-          Migrator.disable_constraints and return [[], []]
+          Migrator.disable_indexing and return [[], []]
 
           new_table_name = model.table_name
           existing_indexes = ::DeclareSchema::Model::IndexDefinition.for_model(model, old_table_name)
@@ -485,7 +485,7 @@ module Generators
 
         def change_foreign_key_constraints(model, old_table_name)
           ActiveRecord::Base.connection.class.name.match?(/SQLite3Adapter/) and raise ArgumentError, 'SQLite does not support foreign keys'
-          Migrator.disable_indexing and return [[], []]
+          Migrator.disable_constraints and return [[], []]
 
           new_table_name = model.table_name
           existing_fks = ::DeclareSchema::Model::ForeignKeyDefinition.for_model(model, old_table_name)

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -13,6 +13,7 @@ module Generators
         DEFAULT_COLLATION     = "utf8mb4_bin"
         DEFAULT_TEXT_LIMIT    = 0xffff_ffff
         DEFAULT_STRING_LIMIT  = nil
+        DEFAULT_NULL          = false
 
         @ignore_models                        = []
         @ignore_tables                        = []
@@ -22,11 +23,11 @@ module Generators
         @default_collation                    = DEFAULT_COLLATION
         @default_text_limit                   = DEFAULT_TEXT_LIMIT
         @default_string_limit                 = DEFAULT_STRING_LIMIT
-
+        @default_null                         = DEFAULT_NULL
 
         class << self
           attr_accessor :ignore_models, :ignore_tables, :disable_indexing, :disable_constraints
-          attr_reader :active_record_class, :default_charset, :default_collation, :default_text_limit, :default_string_limit, :before_generating_migration_callback
+          attr_reader :active_record_class, :default_charset, :default_collation, :default_text_limit, :default_string_limit, :default_null, :before_generating_migration_callback
 
           def default_charset=(charset)
             charset.is_a?(String) or raise ArgumentError, "charset must be a string (got #{charset.inspect})"
@@ -46,6 +47,11 @@ module Generators
           def default_string_limit=(string_limit)
             string_limit.nil? or string_limit.is_a?(Integer) or raise ArgumentError, "string limit must be an integer (got #{string_limit.inspect})"
             @default_string_limit = string_limit
+          end
+
+          def default_null=(null)
+            [true, false].include? null or raise ArgumentError, "null must be either true, false, or nil (got #{null.inspect})"
+            @default_null = null
           end
 
           def active_record_class

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -13,22 +13,10 @@ module Generators
         @ignore_tables                        = []
         @before_generating_migration_callback = nil
         @active_record_class                  = ActiveRecord::Base
-        @default_charset                      = "utf8mb4"
-        @default_collation                    = "utf8mb4_bin"
 
         class << self
           attr_accessor :ignore_models, :ignore_tables
-          attr_reader :active_record_class, :default_charset, :default_collation, :before_generating_migration_callback
-
-          def default_charset=(charset)
-            charset.is_a?(String) or raise ArgumentError, "charset must be a string (got #{charset.inspect})"
-            @default_charset = charset
-          end
-
-          def default_collation=(collation)
-            collation.is_a?(String) or raise ArgumentError, "collation must be a string (got #{collation.inspect})"
-            @default_collation = collation
-          end
+          attr_reader :active_record_class, :before_generating_migration_callback
 
           def active_record_class
             @active_record_class.is_a?(Class) or @active_record_class = @active_record_class.to_s.constantize
@@ -55,6 +43,9 @@ module Generators
             block or raise ArgumentError, 'A block is required when setting the before_generating_migration callback'
             @before_generating_migration_callback = block
           end
+
+          delegate :default_charset=, :default_collation=, :default_charset, :default_collation, to: ::DeclareSchema
+          deprecate :default_charset=, :default_collation=, :default_charset, :default_collation, deprecator: ActiveSupport::Deprecation.new('1.0', 'declare_schema')
         end
 
         def initialize(ambiguity_resolver = {})

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -9,25 +9,17 @@ module Generators
       class Migrator
         class Error < RuntimeError; end
 
-        DEFAULT_CHARSET               = "utf8mb4"
-        DEFAULT_COLLATION             = "utf8mb4_bin"
-        DEFAULT_TEXT_LIMIT            = 0xffff_ffff
-        DEFAULT_STRING_LIMIT          = nil
-        DEFAULT_NULL                  = false
-        DEFAULT_GENERATE_FOREIGN_KEYS = true
-        DEFAULT_GENERATE_INDEXING     = true
-
         @ignore_models                        = []
         @ignore_tables                        = []
         @before_generating_migration_callback = nil
         @active_record_class                  = ActiveRecord::Base
-        @default_charset                      = DEFAULT_CHARSET
-        @default_collation                    = DEFAULT_COLLATION
-        @default_text_limit                   = DEFAULT_TEXT_LIMIT
-        @default_string_limit                 = DEFAULT_STRING_LIMIT
-        @default_null                         = DEFAULT_NULL
-        @default_generate_foreign_keys        = DEFAULT_GENERATE_FOREIGN_KEYS
-        @default_generate_indexing            = DEFAULT_GENERATE_INDEXING
+        @default_charset                      = "utf8mb4"
+        @default_collation                    = "utf8mb4_bin"
+        @default_text_limit                   = 0xffff_ffff
+        @default_string_limit                 = nil
+        @default_null                         = false
+        @default_generate_foreign_keys        = true
+        @default_generate_indexing            = true
 
         class << self
           attr_accessor :ignore_models, :ignore_tables

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -9,11 +9,12 @@ module Generators
       class Migrator
         class Error < RuntimeError; end
 
-        DEFAULT_CHARSET       = "utf8mb4"
-        DEFAULT_COLLATION     = "utf8mb4_bin"
-        DEFAULT_TEXT_LIMIT    = 0xffff_ffff
-        DEFAULT_STRING_LIMIT  = nil
-        DEFAULT_NULL          = false
+        DEFAULT_CHARSET               = "utf8mb4"
+        DEFAULT_COLLATION             = "utf8mb4_bin"
+        DEFAULT_TEXT_LIMIT            = 0xffff_ffff
+        DEFAULT_STRING_LIMIT          = nil
+        DEFAULT_NULL                  = false
+        DEFAULT_GENERATE_FOREIGN_KEYS = true
 
         @ignore_models                        = []
         @ignore_tables                        = []
@@ -24,10 +25,12 @@ module Generators
         @default_text_limit                   = DEFAULT_TEXT_LIMIT
         @default_string_limit                 = DEFAULT_STRING_LIMIT
         @default_null                         = DEFAULT_NULL
+        @default_generate_foreign_keys        = DEFAULT_GENERATE_FOREIGN_KEYS
 
         class << self
           attr_accessor :ignore_models, :ignore_tables, :disable_indexing, :disable_constraints
-          attr_reader :active_record_class, :default_charset, :default_collation, :default_text_limit, :default_string_limit, :default_null, :before_generating_migration_callback
+          attr_reader :active_record_class, :default_charset, :default_collation, :default_text_limit, :default_string_limit, :default_null,
+                      :default_generate_foreign_keys, :before_generating_migration_callback
 
           def default_charset=(charset)
             charset.is_a?(String) or raise ArgumentError, "charset must be a string (got #{charset.inspect})"
@@ -52,6 +55,11 @@ module Generators
           def default_null=(null)
             [true, false].include? null or raise ArgumentError, "null must be either true, false, or nil (got #{null.inspect})"
             @default_null = null
+          end
+
+          def default_generate_foreign_keys=(generate_foreign_keys)
+            [true, false].include? generate_foreign_keys or raise ArgumentError, "generate_foreign_keys must be either true or false (got #{generate_foreign_keys.inspect})"
+            @default_generate_foreign_keys = generate_foreign_keys
           end
 
           def active_record_class

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -45,12 +45,12 @@ module Generators
           end
 
           def default_text_limit=(text_limit)
-            text_limit.is_a?(Integer) or raise ArgumentError, "text limit must be an integer (got #{text_limit.inspect})"
+            text_limit.nil? or text_limit.is_a?(Integer) or raise ArgumentError, "text limit must be an integer or nil (got #{text_limit.inspect})"
             @default_text_limit = text_limit
           end
 
           def default_string_limit=(string_limit)
-            string_limit.nil? or string_limit.is_a?(Integer) or raise ArgumentError, "string limit must be an integer (got #{string_limit.inspect})"
+            string_limit.nil? or string_limit.is_a?(Integer) or raise ArgumentError, "string limit must be an integer or nil (got #{string_limit.inspect})"
             @default_string_limit = string_limit
           end
 

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -60,6 +60,11 @@ module Generators
           def default_generate_foreign_keys=(generate_foreign_keys)
             [true, false].include? generate_foreign_keys or raise ArgumentError, "generate_foreign_keys must be either true or false (got #{generate_foreign_keys.inspect})"
             @default_generate_foreign_keys = generate_foreign_keys
+            toggle_disable_constraints
+          end
+
+          def toggle_disable_constraints
+            @disable_constraints = !@default_generate_foreign_keys
           end
 
           def active_record_class

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
 
       it 'raises error when default_string_limit option is nil when not explicitly set in field spec' do
         if defined?(Mysql2)
-          expect(Generators::DeclareSchema::Migration::Migrator).to receive(:default_string_limit) { nil }
+          expect(::DeclareSchema).to receive(:default_string_limit) { nil }
           expect do
             described_class.new(model, :title, :string, null: true, charset: 'utf8mb4', position: 0)
           end.to raise_error(/limit: must be provided for :string field/)
@@ -122,7 +122,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
 
     describe 'limit' do
       it 'uses default_text_limit option when not explicitly set in field spec' do
-        allow(DeclareSchema).to receive(:default_text_limit) { 100 }
+        allow(::DeclareSchema).to receive(:default_text_limit) { 100 }
         subject = described_class.new(model, :title, :text, null: true, charset: 'utf8mb4', position: 2)
         if defined?(Mysql2)
           expect(subject.schema_attributes(col_spec)).to eq(type: :text, limit: 255, null: true, charset: 'utf8mb4', collation: 'utf8mb4_bin')
@@ -222,7 +222,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
       end
 
       it 'raises error if default_null is set to nil when not explicitly set in field spec' do
-        expect(Generators::DeclareSchema::Migration::Migrator).to receive(:default_null) { nil }
+        expect(::DeclareSchema).to receive(:default_null) { nil }
         expect { subject.sql_options }.to raise_error(/null: must be provided for field/)
       end
     end

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -184,5 +184,17 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
     it 'excludes non-sql options' do
       expect(subject.sql_options).to eq(limit: 4, null: true, default: 0)
     end
+
+    context ':null' do
+      subject { described_class.new(model, :price, :integer, limit: 4, default: 0, position: 2, encrypt_using: ->(field) { field }) }
+      it 'uses DEFAULT_NULL option when not explicitly set in field spec' do
+        expect(subject.sql_options).to eq(limit: 4, null: false, default: 0)
+      end
+
+      it 'raises error if DEFAULT_NULL is set to nil when not explicitly set in field spec' do
+        expect(Generators::DeclareSchema::Migration::Migrator).to receive(:default_null) { nil }
+        expect { subject.sql_options }.to raise_error(/null: must be provided for field/)
+      end
+    end
   end
 end

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -61,6 +61,15 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
           expect(subject.schema_attributes(col_spec)).to eq(type: :string, limit: 100, null: true)
         end
       end
+
+      it 'raises error when DEFAULT_STRING_LIMIT option is nil when not explicitly set in field spec' do
+        if defined?(Mysql2)
+          expect(Generators::DeclareSchema::Migration::Migrator).to receive(:default_string_limit) { nil }
+          expect do
+            described_class.new(model, :title, :string, null: true, charset: 'utf8mb4', position: 0)
+          end.to raise_error(/limit: must be given for :string field/)
+        end
+      end
     end
 
     describe 'text' do

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
 
     describe 'limit' do
       it 'uses default_text_limit option when not explicitly set in field spec' do
-        allow(Generators::DeclareSchema::Migration::Migrator).to receive(:default_text_limit) { 100 }
+        allow(DeclareSchema).to receive(:default_text_limit) { 100 }
         subject = described_class.new(model, :title, :text, null: true, charset: 'utf8mb4', position: 2)
         if defined?(Mysql2)
           expect(subject.schema_attributes(col_spec)).to eq(type: :text, limit: 255, null: true, charset: 'utf8mb4', collation: 'utf8mb4_bin')
@@ -133,7 +133,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
 
       it 'raises error when default_text_limit option is nil when not explicitly set in field spec' do
         if defined?(Mysql2)
-          expect(Generators::DeclareSchema::Migration::Migrator).to receive(:default_text_limit) { nil }
+          expect(::DeclareSchema).to receive(:default_text_limit) { nil }
           expect do
             described_class.new(model, :title, :text, null: true, charset: 'utf8mb4', position: 2)
           end.to raise_error(/limit: must be provided for :text field/)

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
         end
       end
 
-      it 'raises error when DEFAULT_STRING_LIMIT option is nil when not explicitly set in field spec' do
+      it 'raises error when default_string_limit option is nil when not explicitly set in field spec' do
         if defined?(Mysql2)
           expect(Generators::DeclareSchema::Migration::Migrator).to receive(:default_string_limit) { nil }
           expect do
@@ -121,7 +121,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
     end
 
     describe 'limit' do
-      it 'uses DEFAULT_TEXT_LIMIT option when not explicitly set in field spec' do
+      it 'uses default_text_limit option when not explicitly set in field spec' do
         allow(Generators::DeclareSchema::Migration::Migrator).to receive(:default_text_limit) { 100 }
         subject = described_class.new(model, :title, :text, null: true, charset: 'utf8mb4', position: 2)
         if defined?(Mysql2)
@@ -131,12 +131,12 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
         end
       end
 
-      it 'raises error when DEFAULT_TEXT_LIMIT option is nil when not explicitly set in field spec' do
-        allow(Generators::DeclareSchema::Migration::Migrator).to receive(:default_text_limit) { nil }
+      it 'raises error when default_text_limit option is nil when not explicitly set in field spec' do
         if defined?(Mysql2)
+          expect(Generators::DeclareSchema::Migration::Migrator).to receive(:default_text_limit) { nil }
           expect do
             described_class.new(model, :title, :text, null: true, charset: 'utf8mb4', position: 2)
-          end.to raise_error(/limit: must be provided for field/)
+          end.to raise_error(/limit: must be provided for :text field/)
         end
       end
     end
@@ -217,11 +217,11 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
 
     describe 'null' do
       subject { described_class.new(model, :price, :integer, limit: 4, default: 0, position: 2, encrypt_using: ->(field) { field }) }
-      it 'uses DEFAULT_NULL option when not explicitly set in field spec' do
+      it 'uses default_null option when not explicitly set in field spec' do
         expect(subject.sql_options).to eq(limit: 4, null: false, default: 0)
       end
 
-      it 'raises error if DEFAULT_NULL is set to nil when not explicitly set in field spec' do
+      it 'raises error if default_null is set to nil when not explicitly set in field spec' do
         expect(Generators::DeclareSchema::Migration::Migrator).to receive(:default_null) { nil }
         expect { subject.sql_options }.to raise_error(/null: must be provided for field/)
       end

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
           expect(Generators::DeclareSchema::Migration::Migrator).to receive(:default_string_limit) { nil }
           expect do
             described_class.new(model, :title, :string, null: true, charset: 'utf8mb4', position: 0)
-          end.to raise_error(/limit: must be given for :string field/)
+          end.to raise_error(/limit: must be provided for :string field/)
         end
       end
     end

--- a/spec/lib/declare_schema_spec.rb
+++ b/spec/lib/declare_schema_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe DeclareSchema do
+  describe '#default_text_limit' do
+    subject { described_class.default_text_limit }
+
+    context 'when not explicitly set' do
+      it { should eq(0xffff_ffff) }
+    end
+
+    context 'when explicitly set' do
+      before { described_class.default_text_limit = 0xffff }
+      after  { described_class.default_text_limit = 0xffff_ffff }
+      it     { should eq(0xffff) }
+    end
+  end
+end

--- a/spec/lib/declare_schema_spec.rb
+++ b/spec/lib/declare_schema_spec.rb
@@ -1,6 +1,34 @@
 # frozen_string_literal: true
 
 RSpec.describe DeclareSchema do
+  describe '#default_charset' do
+    subject { described_class.default_charset }
+
+    context 'when not explicitly set' do
+      it { should eq("utf8mb4") }
+    end
+
+    context 'when explicitly set' do
+      before { described_class.default_charset = "utf8" }
+      after  { described_class.default_charset = "utf8mb4" }
+      it     { should eq("utf8") }
+    end
+  end
+
+  describe '#default_collation' do
+    subject { described_class.default_collation }
+
+    context 'when not explicitly set' do
+      it { should eq("utf8mb4_bin") }
+    end
+
+    context 'when explicitly set' do
+      before { described_class.default_collation = "utf8mb4_general_ci" }
+      after  { described_class.default_collation = "utf8mb4_bin" }
+      it     { should eq("utf8mb4_general_ci") }
+    end
+  end
+
   describe '#default_text_limit' do
     subject { described_class.default_text_limit }
 
@@ -12,6 +40,62 @@ RSpec.describe DeclareSchema do
       before { described_class.default_text_limit = 0xffff }
       after  { described_class.default_text_limit = 0xffff_ffff }
       it     { should eq(0xffff) }
+    end
+  end
+
+  describe '#default_string_limit' do
+    subject { described_class.default_string_limit }
+
+    context 'when not explicitly set' do
+      it { should eq(nil) }
+    end
+
+    context 'when explicitly set' do
+      before { described_class.default_string_limit = 225 }
+      after  { described_class.default_string_limit = nil }
+      it     { should eq(225) }
+    end
+  end
+
+  describe '#default_null' do
+    subject { described_class.default_null }
+
+    context 'when not explicitly set' do
+      it { should eq(false) }
+    end
+
+    context 'when explicitly set' do
+      before { described_class.default_null = true }
+      after  { described_class.default_null = false }
+      it     { should eq(true) }
+    end
+  end
+
+  describe '#default_generate_foreign_keys' do
+    subject { described_class.default_generate_foreign_keys }
+
+    context 'when not explicitly set' do
+      it { should eq(true) }
+    end
+
+    context 'when explicitly set' do
+      before { described_class.default_generate_foreign_keys = false }
+      after  { described_class.default_generate_foreign_keys = true }
+      it     { should eq(false) }
+    end
+  end
+
+  describe '#default_generate_indexing' do
+    subject { described_class.default_generate_indexing }
+
+    context 'when not explicitly set' do
+      it { should eq(true) }
+    end
+
+    context 'when explicitly set' do
+      before { described_class.default_generate_indexing = false }
+      after  { described_class.default_generate_indexing = true }
+      it     { should eq(false) }
     end
   end
 end

--- a/spec/lib/generators/declare_schema/migration/migrator_spec.rb
+++ b/spec/lib/generators/declare_schema/migration/migrator_spec.rb
@@ -57,20 +57,6 @@ module Generators
           end
         end
 
-        describe '#default_text_limit' do
-          subject { described_class.default_text_limit }
-
-          context 'when not explicitly set' do
-            it { should eq(0xffff_ffff) }
-          end
-
-          context 'when explicitly set' do
-            before { described_class.default_text_limit = 0xffff }
-            after  { described_class.default_text_limit = 0xffff_ffff }
-            it     { should eq(0xffff) }
-          end
-        end
-
         describe '#default_string_limit' do
           subject { described_class.default_string_limit }
 

--- a/spec/lib/generators/declare_schema/migration/migrator_spec.rb
+++ b/spec/lib/generators/declare_schema/migration/migrator_spec.rb
@@ -57,62 +57,6 @@ module Generators
           end
         end
 
-        describe '#default_string_limit' do
-          subject { described_class.default_string_limit }
-
-          context 'when not explicitly set' do
-            it { should eq(nil) }
-          end
-
-          context 'when explicitly set' do
-            before { described_class.default_string_limit = 225 }
-            after  { described_class.default_string_limit = nil }
-            it     { should eq(225) }
-          end
-        end
-
-        describe '#default_null' do
-          subject { described_class.default_null }
-
-          context 'when not explicitly set' do
-            it { should eq(false) }
-          end
-
-          context 'when explicitly set' do
-            before { described_class.default_null = true }
-            after  { described_class.default_null = false }
-            it     { should eq(true) }
-          end
-        end
-
-        describe '#default_generate_foreign_keys' do
-          subject { described_class.default_generate_foreign_keys }
-
-          context 'when not explicitly set' do
-            it { should eq(true) }
-          end
-
-          context 'when explicitly set' do
-            before { described_class.default_generate_foreign_keys = false }
-            after  { described_class.default_generate_foreign_keys = true }
-            it     { should eq(false) }
-          end
-        end
-
-        describe '#default_generate_indexing' do
-          subject { described_class.default_generate_indexing }
-
-          context 'when not explicitly set' do
-            it { should eq(true) }
-          end
-
-          context 'when explicitly set' do
-            before { described_class.default_generate_indexing = false }
-            after  { described_class.default_generate_indexing = true }
-            it     { should eq(false) }
-          end
-        end
-
         describe 'load_rails_models' do
           before do
             expect(Rails.application).to receive(:eager_load!)

--- a/spec/lib/generators/declare_schema/migration/migrator_spec.rb
+++ b/spec/lib/generators/declare_schema/migration/migrator_spec.rb
@@ -41,6 +41,11 @@ module Generators
             after  { described_class.default_charset = "utf8mb4" }
             it     { should eq("utf8") }
           end
+
+          it 'should output deprecation warning' do
+            expect { described_class.default_charset = "utf8mb4" }.to output(/DEPRECATION WARNING: default_charset= is deprecated/).to_stderr
+            expect { subject }.to output(/DEPRECATION WARNING: default_charset is deprecated/).to_stderr
+          end
         end
 
         describe '#default_collation' do
@@ -54,6 +59,11 @@ module Generators
             before { described_class.default_collation = "utf8mb4_general_ci" }
             after  { described_class.default_collation = "utf8mb4_bin" }
             it     { should eq("utf8mb4_general_ci") }
+          end
+
+          it 'should output deprecation warning' do
+            expect { described_class.default_collation = "utf8mb4_bin" }.to output(/DEPRECATION WARNING: default_collation= is deprecated/).to_stderr
+            expect { subject }.to output(/DEPRECATION WARNING: default_collation is deprecated/).to_stderr
           end
         end
 

--- a/spec/lib/generators/declare_schema/migration/migrator_spec.rb
+++ b/spec/lib/generators/declare_schema/migration/migrator_spec.rb
@@ -85,6 +85,20 @@ module Generators
           end
         end
 
+        describe '#default_null' do
+          subject { described_class.default_null }
+
+          context 'when not explicitly set' do
+            it { should eq(false) }
+          end
+
+          context 'when explicitly set' do
+            before { described_class.default_null = true }
+            after  { described_class.default_null = described_class::DEFAULT_NULL }
+            it     { should eq(true) }
+          end
+        end
+
         describe 'load_rails_models' do
           before do
             expect(Rails.application).to receive(:eager_load!)

--- a/spec/lib/generators/declare_schema/migration/migrator_spec.rb
+++ b/spec/lib/generators/declare_schema/migration/migrator_spec.rb
@@ -99,6 +99,20 @@ module Generators
           end
         end
 
+        describe '#default_generate_foreign_keys' do
+          subject { described_class.default_generate_foreign_keys }
+
+          context 'when not explicitly set' do
+            it { should eq(true) }
+          end
+
+          context 'when explicitly set' do
+            before { described_class.default_generate_foreign_keys = false }
+            after  { described_class.default_generate_foreign_keys = described_class::DEFAULT_GENERATE_FOREIGN_KEYS }
+            it     { should eq(false) }
+          end
+        end
+
         describe 'load_rails_models' do
           before do
             expect(Rails.application).to receive(:eager_load!)

--- a/spec/lib/generators/declare_schema/migration/migrator_spec.rb
+++ b/spec/lib/generators/declare_schema/migration/migrator_spec.rb
@@ -71,6 +71,20 @@ module Generators
           end
         end
 
+        describe '#default_string_limit' do
+          subject { described_class.default_string_limit }
+
+          context 'when not explicitly set' do
+            it { should eq(nil) }
+          end
+
+          context 'when explicitly set' do
+            before { described_class.default_string_limit = 225 }
+            after  { described_class.default_string_limit = described_class::DEFAULT_STRING_LIMIT }
+            it     { should eq(225) }
+          end
+        end
+
         describe 'load_rails_models' do
           before do
             expect(Rails.application).to receive(:eager_load!)

--- a/spec/lib/generators/declare_schema/migration/migrator_spec.rb
+++ b/spec/lib/generators/declare_schema/migration/migrator_spec.rb
@@ -113,6 +113,20 @@ module Generators
           end
         end
 
+        describe '#default_generate_indexing' do
+          subject { described_class.default_generate_indexing }
+
+          context 'when not explicitly set' do
+            it { should eq(true) }
+          end
+
+          context 'when explicitly set' do
+            before { described_class.default_generate_indexing = false }
+            after  { described_class.default_generate_indexing = described_class::DEFAULT_GENERATE_INDEXING }
+            it     { should eq(false) }
+          end
+        end
+
         describe 'load_rails_models' do
           before do
             expect(Rails.application).to receive(:eager_load!)

--- a/spec/lib/generators/declare_schema/migration/migrator_spec.rb
+++ b/spec/lib/generators/declare_schema/migration/migrator_spec.rb
@@ -57,6 +57,20 @@ module Generators
           end
         end
 
+        describe '#default_text_limit' do
+          subject { described_class.default_text_limit }
+
+          context 'when not explicitly set' do
+            it { should eq(0xffff_ffff) }
+          end
+
+          context 'when explicitly set' do
+            before { described_class.default_text_limit = 0xffff }
+            after  { described_class.default_text_limit = described_class::DEFAULT_TEXT_LIMIT }
+            it     { should eq(0xffff) }
+          end
+        end
+
         describe 'load_rails_models' do
           before do
             expect(Rails.application).to receive(:eager_load!)

--- a/spec/lib/generators/declare_schema/migration/migrator_spec.rb
+++ b/spec/lib/generators/declare_schema/migration/migrator_spec.rb
@@ -38,7 +38,7 @@ module Generators
 
           context 'when explicitly set' do
             before { described_class.default_charset = "utf8" }
-            after  { described_class.default_charset = described_class::DEFAULT_CHARSET }
+            after  { described_class.default_charset = "utf8mb4" }
             it     { should eq("utf8") }
           end
         end
@@ -52,7 +52,7 @@ module Generators
 
           context 'when explicitly set' do
             before { described_class.default_collation = "utf8mb4_general_ci" }
-            after  { described_class.default_collation = described_class::DEFAULT_COLLATION }
+            after  { described_class.default_collation = "utf8mb4_bin" }
             it     { should eq("utf8mb4_general_ci") }
           end
         end
@@ -66,7 +66,7 @@ module Generators
 
           context 'when explicitly set' do
             before { described_class.default_text_limit = 0xffff }
-            after  { described_class.default_text_limit = described_class::DEFAULT_TEXT_LIMIT }
+            after  { described_class.default_text_limit = 0xffff_ffff }
             it     { should eq(0xffff) }
           end
         end
@@ -80,7 +80,7 @@ module Generators
 
           context 'when explicitly set' do
             before { described_class.default_string_limit = 225 }
-            after  { described_class.default_string_limit = described_class::DEFAULT_STRING_LIMIT }
+            after  { described_class.default_string_limit = nil }
             it     { should eq(225) }
           end
         end
@@ -94,7 +94,7 @@ module Generators
 
           context 'when explicitly set' do
             before { described_class.default_null = true }
-            after  { described_class.default_null = described_class::DEFAULT_NULL }
+            after  { described_class.default_null = false }
             it     { should eq(true) }
           end
         end
@@ -108,7 +108,7 @@ module Generators
 
           context 'when explicitly set' do
             before { described_class.default_generate_foreign_keys = false }
-            after  { described_class.default_generate_foreign_keys = described_class::DEFAULT_GENERATE_FOREIGN_KEYS }
+            after  { described_class.default_generate_foreign_keys = true }
             it     { should eq(false) }
           end
         end
@@ -122,7 +122,7 @@ module Generators
 
           context 'when explicitly set' do
             before { described_class.default_generate_indexing = false }
-            after  { described_class.default_generate_indexing = described_class::DEFAULT_GENERATE_INDEXING }
+            after  { described_class.default_generate_indexing = true }
             it     { should eq(false) }
           end
         end


### PR DESCRIPTION
Create configurable defaults for:
- generate foreign key: true
- null: false
- text limit: 0xffff_ffff
- string limit: nil 


 

## Changelog
## [0.9.0] - Unreleased
### Added
- Added configurable default settings for `default_text_limit`, `default_string_limit`, `default_null`,
`default_generate_foreign_keys` and `default_generate_indexing` to allow developers to adhere to project conventions.

### Changed
- Moved and deprecated default settings for `default_charset` and `default_collation` from `Generators::DeclareSchema::Migration::Migrator` to `::DeclareSchema`
