### PR TITLE
TECH-4814: remove sql_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - UNRELEASED
+### Removed
+- Removed `sql_type` that was confusing because it was actually the same as `type` (ex: :string) and not
+  in fact the SQL type (ex: ``varchar(255)'`).
+
 ## [0.7.1] - 2021-02-17
 ### Fixed
 - Exclude unknown options from FieldSpec#sql_options and #schema_attributes.
@@ -125,6 +130,7 @@ using the appropriate Rails configuration attributes.
 ### Added
 - Initial version from https://github.com/Invoca/hobo_fields v4.1.0.
 
+[0.8.0]: https://github.com/Invoca/declare_schema/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/Invoca/declare_schema/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/Invoca/declare_schema/compare/v0.6.3...v0.7.0
 [0.6.4]: https://github.com/Invoca/declare_schema/compare/v0.6.3...v0.6.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (0.8.0.pre.2)
+    declare_schema (0.8.0.pre.3)
       rails (>= 4.2)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (0.8.0.pre.1)
+    declare_schema (0.8.0.pre.2)
       rails (>= 4.2)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (0.7.1)
+    declare_schema (0.8.0.pre.1)
       rails (>= 4.2)
 
 GEM

--- a/lib/declare_schema/model/column.rb
+++ b/lib/declare_schema/model/column.rb
@@ -44,6 +44,8 @@ module DeclareSchema
             if ActiveRecord::Base.connection.class.name.match?(/mysql/i)
               types[:text][:limit]    ||= 0xffff
               types[:binary][:limit]  ||= 0xffff
+
+              types[:varbinary] ||= { name: "varbinary" } # TODO: :varbinary is an Invoca addition to Rails; make it a configurable option
             end
           end
         end

--- a/lib/declare_schema/model/column.rb
+++ b/lib/declare_schema/model/column.rb
@@ -8,7 +8,7 @@ module DeclareSchema
     class Column
       class << self
         def native_type?(type)
-          type != :primary_key && native_types[type]
+          type != :primary_key && (native_types.empty? || native_types[type]) # empty will happen with NullDBAdapter used in assets:precompile
         end
 
         # MySQL example:

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -77,7 +77,7 @@ module DeclareSchema
           @options[:limit] = 8
         end
 
-        Column.native_type?(@type) or raise UnknownTypeError, "#{@type.inspect}"
+        Column.native_type?(@type) or raise UnknownTypeError, "#{@type.inspect} not found in #{Column.native_types.inspect} for adapter #{ActiveRecord::Base.connection.class.name}"
 
         if @type.in?([:string, :text, :binary, :varbinary, :integer, :enum])
           @options[:limit] ||= Column.native_types[@type][:limit]

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -80,7 +80,7 @@ module DeclareSchema
         Column.native_type?(@type) or raise UnknownTypeError, "#{@type.inspect} not found in #{Column.native_types.inspect} for adapter #{ActiveRecord::Base.connection.class.name}"
 
         if @type.in?([:string, :text, :binary, :varbinary, :integer, :enum])
-          @options[:limit] ||= Column.native_types[@type][:limit]
+          @options[:limit] ||= Column.native_types.dig(@type, :limit)
         else
           @type != :decimal && @options.has_key?(:limit) and warn("unsupported limit: for SQL type #{@type} in field #{model}##{@name}")
           @options.delete(:limit)

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "0.8.0.pre.1"
+  VERSION = "0.8.0.pre.2"
 end

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "0.8.0.pre.2"
+  VERSION = "0.8.0.pre.3"
 end

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "0.7.1"
+  VERSION = "0.8.0.pre.1"
 end

--- a/lib/generators/declare_schema/migration/migration_generator.rb
+++ b/lib/generators/declare_schema/migration/migration_generator.rb
@@ -96,7 +96,7 @@ module DeclareSchema
           end
         end
       end
-    rescue ::DeclareSchema::UnknownSqlTypeError => ex
+    rescue ::DeclareSchema::UnknownTypeError => ex
       say "Invalid field type: #{ex}"
     end
 

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -328,7 +328,7 @@ module Generators
         end
 
         def create_table(model)
-          longest_field_name       = model.field_specs.values.map { |f| f.sql_type.to_s.length }.max
+          longest_field_name       = model.field_specs.values.map { |f| f.type.to_s.length }.max
           disable_auto_increment   = model.respond_to?(:disable_auto_increment) && model.disable_auto_increment
           table_options_definition = ::DeclareSchema::Model::TableOptionsDefinition.new(model.table_name, table_options_for_model(model))
           field_definitions        = [
@@ -379,7 +379,7 @@ module Generators
         def create_field(field_spec, field_name_width)
           options = field_spec.sql_options.merge(fk_field_options(field_spec.model, field_spec.name))
           args = [field_spec.name.inspect] + format_options(options.compact)
-          format("t.%-*s %s", field_name_width, field_spec.sql_type, args.join(', '))
+          format("t.%-*s %s", field_name_width, field_spec.type, args.join(', '))
         end
 
         def change_table(model, current_table_name)
@@ -417,7 +417,7 @@ module Generators
             args =
               if (spec = model.field_specs[c])
                 options = spec.sql_options.merge(fk_field_options(model, c))
-                [":#{spec.sql_type}", *format_options(options.compact)]
+                [":#{spec.type}", *format_options(options.compact)]
               else
                 [":integer"]
               end

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -7,7 +7,7 @@ end
 
 RSpec.describe DeclareSchema::Model::FieldSpec do
   let(:model) { double('model', table_options: {}) }
-  let(:col_spec) { double('col_spec', sql_type: 'varchar') }
+  let(:col_spec) { double('col_spec', type: :string) }
 
   before do
     load File.expand_path('prepare_testapp.rb', __dir__)
@@ -127,7 +127,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
     end
 
     describe 'default:' do
-      let(:col_spec) { double('col_spec', sql_type: :integer) }
+      let(:col_spec) { double('col_spec', type: :integer) }
 
       it 'typecasts default value' do
         allow(col_spec).to receive(:type_cast_from_database) { |default| Integer(default) }

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
       subject = described_class.new(model, :price, :integer, anonymize_using: 'x', null: false, position: 0, limit: 4)
       expect(subject.options.keys).to eq([:limit, :null, :anonymize_using])
     end
+
+    it 'raises exception on unknown field type' do
+      expect do
+        described_class.new(model, :location, :lat_long, position: 0)
+      end.to raise_exception(::DeclareSchema::UnknownTypeError, /:lat_long not found in /)
+    end
   end
 
   describe '#schema_attributes' do

--- a/spec/lib/declare_schema/model/column_spec.rb
+++ b/spec/lib/declare_schema/model/column_spec.rb
@@ -59,26 +59,6 @@ RSpec.describe DeclareSchema::Model::Column do
       end
     end
 
-    describe '.sql_type' do
-      it 'returns the sql type for :string' do
-        expect(described_class.sql_type(:string)).to eq(:string)
-      end
-
-      it 'returns the sql type for :integer' do
-        expect(described_class.sql_type(:integer)).to match(:integer)
-      end
-
-      it 'returns the sql type for :datetime' do
-        expect(described_class.sql_type(:datetime)).to eq(:datetime)
-      end
-
-      it 'raises UnknownSqlType' do
-        expect do
-          described_class.sql_type(:email)
-        end.to raise_exception(::DeclareSchema::UnknownSqlTypeError, /:email for type :email/)
-      end
-    end
-
     describe '.deserialize_default_value' do
       require 'rails'
 
@@ -109,10 +89,11 @@ RSpec.describe DeclareSchema::Model::Column do
       end
     end
     let(:model) { ColumnTestModel }
+    let(:type) { :integer }
     let(:current_table_name) { model.table_name }
     let(:column) { double("ActiveRecord Column",
                           name: 'count',
-                          type: :integer,
+                          type: type,
                           limit: nil,
                           precision: nil,
                           scale: nil,
@@ -122,9 +103,9 @@ RSpec.describe DeclareSchema::Model::Column do
                           sql_type_metadata: {}) }
     subject { described_class.new(model, current_table_name, column) }
 
-    describe '#sql_type' do
-      it 'returns sql type' do
-        expect(subject.sql_type).to match(/int/)
+    describe '#type' do
+      it 'returns type' do
+        expect(subject.type).to eq(type)
       end
     end
 

--- a/spec/lib/declare_schema/model/column_spec.rb
+++ b/spec/lib/declare_schema/model/column_spec.rb
@@ -37,6 +37,11 @@ RSpec.describe DeclareSchema::Model::Column do
           expect(described_class.native_type?(type)).to be_falsey
         end
       end
+
+      it "is truthy when there's a NullDbAdapter (like for assets:precompile) that doesn't have any native types" do
+        allow(described_class).to receive(:native_types).and_return({})
+        expect(described_class.native_type?(:integer)).to be_truthy
+      end
     end
 
     describe '.native_types' do


### PR DESCRIPTION
I decided to add this as a rider when I realized we'd been wasting time with the `sql_type` that wasn't significantly different from `type`. I'm guessing it might have been left over from Hobo Fields supporting custom field types like `Email` that were really just a `:string` field with a different validator.

## [0.8.0] - UNRELEASED
### Removed
- Removed `sql_type` that was confusing because it was actually the same as `type` (ex: :string) and not
  in fact the SQL type (ex: ``varchar(255)'`).