### PR TITLE
Tech 5112 create declare schema block dsl

### DIFF
--- a/.github/workflows/declare_schema_build.yml
+++ b/.github/workflows/declare_schema_build.yml
@@ -57,4 +57,4 @@ jobs:
           git config --global user.email "dummy@example.com"
           git config --global user.name "dummy"
           MYSQL_PORT=3306 bundle exec rake test:prepare_testapp[force]
-          bundle exec rake test:all < test_responses.txt
+          bundle exec rake test:all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - Unreleased
+### Deprecated
+- The `fields` dsl method is being deprecated.
+
+### Added
+- Added the `declare_schema` method to replace `fields`. We now expect a column's type to come before the name
+i.e. `declare schema { string :title }`. Otherwise, there is no difference between `fields` and `declare_schema`.
+
 ## [0.9.0] - 2021-03-01
 ### Added
 - Added configurable default settings for `default_text_limit`, `default_string_limit`, `default_null`,
@@ -140,6 +148,7 @@ using the appropriate Rails configuration attributes.
 ### Added
 - Initial version from https://github.com/Invoca/hobo_fields v4.1.0.
 
+[0.10.0]: https://github.com/Invoca/declare_schema/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/Invoca/declare_schema/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Invoca/declare_schema/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/Invoca/declare_schema/compare/v0.7.0...v0.7.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (0.9.0)
+    declare_schema (0.10.0.pre.dc.1)
       rails (>= 4.2)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Declare your Rails/active_record model schemas and have database migrations gene
 
 ## Example
 
-Make a model and declare your schema within a `declare_schema do ... end` block:
+Make a model and declare your schema within a `fields do ... end` block:
 ```ruby
 class Company < ActiveRecord::Base
-  declare_schema do
+  fields do
     company_name :string, limit: 100
     ticker_symbol :string, limit: 4, null: true, index: true, unique: true
     employee_count :integer
@@ -129,7 +129,7 @@ look like the following:
 # frozen_string_literal: true
 
 class Comment < ActiveRecord::Base
-  declare_schema do
+  fields do
     subject :string, limit: 255
     context :text,   limit: 0xffff_ffff, charset: "utf8mb4", collation: "utf8mb4_bin"
   end

--- a/README.md
+++ b/README.md
@@ -150,5 +150,5 @@ or add it to your `bundler` Gemfile:
 To run tests:
 ```
 rake test:prepare_testapp[force]
-rake test:all < test_responses.txt
+rake test:all
 ```

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Declare your Rails/active_record model schemas and have database migrations gene
 
 ## Example
 
-Make a model and declare your schema within a `fields do ... end` block:
+Make a model and declare your schema within a `declare_schema do ... end` block:
 ```ruby
 class Company < ActiveRecord::Base
-  fields do
+  declare_schema do
     company_name :string, limit: 100
     ticker_symbol :string, limit: 4, null: true, index: true, unique: true
     employee_count :integer
@@ -129,7 +129,7 @@ look like the following:
 # frozen_string_literal: true
 
 class Comment < ActiveRecord::Base
-  fields do
+  declare_schema do
     subject :string, limit: 255
     context :text,   limit: 0xffff_ffff, charset: "utf8mb4", collation: "utf8mb4_bin"
   end

--- a/lib/declare_schema/dsl.rb
+++ b/lib/declare_schema/dsl.rb
@@ -28,8 +28,7 @@ module DeclareSchema
       field(:lock_version, :integer, default: 1, null: false)
     end
 
-    def field(name, type, *args)
-      options = args.extract_options!
+    def field(name, type, *args, **options)
       @model.declare_field(name, type, *(args + [@options.merge(options)]))
     end
 

--- a/lib/declare_schema/dsl.rb
+++ b/lib/declare_schema/dsl.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'active_support/proxy_object'
+
+module DeclareSchema
+  class Dsl < BasicObject # avoid Object because that gets extended by lots of gems
+    include ::Kernel      # but we need the basic class methods
+
+    instance_methods.each do |m|
+      unless m.to_s.starts_with?('__') || m.in?([:object_id, :instance_eval])
+        undef_method(m)
+      end
+    end
+
+    def initialize(model, options = {})
+      @model = model
+      @options = options
+    end
+
+    attr_reader :model
+
+    def timestamps
+      field(:created_at, :datetime, null: true)
+      field(:updated_at, :datetime, null: true)
+    end
+
+    def optimistic_lock
+      field(:lock_version, :integer, default: 1, null: false)
+    end
+
+    def field(name, type, *args)
+      options = args.extract_options!
+      @model.declare_field(name, type, *(args + [@options.merge(options)]))
+    end
+
+    def method_missing(type, name, *args)
+      field(name, type, *args)
+    end
+  end
+end

--- a/lib/declare_schema/extensions/active_record/fields_declaration.rb
+++ b/lib/declare_schema/extensions/active_record/fields_declaration.rb
@@ -7,8 +7,6 @@ require 'declare_schema/field_declaration_dsl'
 
 module DeclareSchema
   module Macros
-    deprecate :fields, deprecator: ActiveSupport::Deprecation.new('1.0', 'DeclareSchema')
-
     def fields(table_options = {}, &block)
       # Any model that calls 'fields' gets DeclareSchema::Model behavior
       DeclareSchema::Model.mix_in(self)
@@ -25,6 +23,7 @@ module DeclareSchema
         end
       end
     end
+    deprecate :fields, deprecator: ActiveSupport::Deprecation.new('1.0', 'DeclareSchema')
 
     def declare_schema(table_options = {}, &block)
       # Any model that calls 'fields' gets DeclareSchema::Model behavior

--- a/lib/declare_schema/extensions/active_record/fields_declaration.rb
+++ b/lib/declare_schema/extensions/active_record/fields_declaration.rb
@@ -26,7 +26,7 @@ module DeclareSchema
       end
     end
 
-      def declare_schema(table_options = {}, &block)
+    def declare_schema(table_options = {}, &block)
       # Any model that calls 'fields' gets DeclareSchema::Model behavior
       DeclareSchema::Model.mix_in(self)
 

--- a/lib/declare_schema/extensions/active_record/fields_declaration.rb
+++ b/lib/declare_schema/extensions/active_record/fields_declaration.rb
@@ -6,6 +6,8 @@ require 'declare_schema/field_declaration_dsl'
 
 module DeclareSchema
   module FieldsDsl
+    deprecate :fields, deprecator: ActiveSupport::Deprecation.new('1.0', 'DeclareSchema')
+
     def fields(table_options = {}, &block)
       # Any model that calls 'fields' gets DeclareSchema::Model behavior
       DeclareSchema::Model.mix_in(self)

--- a/lib/declare_schema/extensions/active_record/fields_declaration.rb
+++ b/lib/declare_schema/extensions/active_record/fields_declaration.rb
@@ -9,21 +9,7 @@ module DeclareSchema
     deprecate :fields, deprecator: ActiveSupport::Deprecation.new('1.0', 'DeclareSchema')
 
     def fields(table_options = {}, &block)
-      # Any model that calls 'fields' gets DeclareSchema::Model behavior
-      DeclareSchema::Model.mix_in(self)
-
-      # @include_in_migration = false #||= options.fetch(:include_in_migration, true); options.delete(:include_in_migration)
-      @include_in_migration = true
-      @table_options        = table_options
-
-      if block
-        dsl = DeclareSchema::FieldDeclarationDsl.new(self, null: false)
-        if block.arity == 1
-          yield dsl
-        else
-          dsl.instance_eval(&block)
-        end
-      end
+      declare_schema(table_options, &block)
     end
 
     def declare_schema(table_options = {}, &block)

--- a/lib/declare_schema/extensions/active_record/fields_declaration.rb
+++ b/lib/declare_schema/extensions/active_record/fields_declaration.rb
@@ -1,22 +1,18 @@
 # frozen_string_literal: true
 
 require 'active_record'
+require 'declare_schema/dsl'
 require 'declare_schema/model'
 require 'declare_schema/field_declaration_dsl'
 
 module DeclareSchema
-  module FieldsDsl
+  module Macros
     deprecate :fields, deprecator: ActiveSupport::Deprecation.new('1.0', 'DeclareSchema')
 
     def fields(table_options = {}, &block)
-      declare_schema(table_options, &block)
-    end
-
-    def declare_schema(table_options = {}, &block)
       # Any model that calls 'fields' gets DeclareSchema::Model behavior
       DeclareSchema::Model.mix_in(self)
 
-      # @include_in_migration = false #||= options.fetch(:include_in_migration, true); options.delete(:include_in_migration)
       @include_in_migration = true
       @table_options        = table_options
 
@@ -29,7 +25,25 @@ module DeclareSchema
         end
       end
     end
+
+      def declare_schema(table_options = {}, &block)
+      # Any model that calls 'fields' gets DeclareSchema::Model behavior
+      DeclareSchema::Model.mix_in(self)
+
+      # @include_in_migration = false #||= options.fetch(:include_in_migration, true); options.delete(:include_in_migration)
+      @include_in_migration = true # TODO: Add back or delete the include_in_migration feature
+      @table_options        = table_options
+
+      if block
+        dsl = DeclareSchema::Dsl.new(self, null: false)
+        if block.arity == 1
+          yield dsl
+        else
+          dsl.instance_eval(&block)
+        end
+      end
+    end
   end
 end
 
-ActiveRecord::Base.singleton_class.prepend DeclareSchema::FieldsDsl
+ActiveRecord::Base.singleton_class.prepend DeclareSchema::Macros

--- a/lib/declare_schema/extensions/active_record/fields_declaration.rb
+++ b/lib/declare_schema/extensions/active_record/fields_declaration.rb
@@ -25,6 +25,24 @@ module DeclareSchema
         end
       end
     end
+
+    def declare_schema(table_options = {}, &block)
+      # Any model that calls 'fields' gets DeclareSchema::Model behavior
+      DeclareSchema::Model.mix_in(self)
+
+      # @include_in_migration = false #||= options.fetch(:include_in_migration, true); options.delete(:include_in_migration)
+      @include_in_migration = true
+      @table_options        = table_options
+
+      if block
+        dsl = DeclareSchema::FieldDeclarationDsl.new(self, null: false)
+        if block.arity == 1
+          yield dsl
+        else
+          dsl.instance_eval(&block)
+        end
+      end
+    end
   end
 end
 

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -41,7 +41,7 @@ module DeclareSchema
           eval <<~EOS
             def self.inherited(klass)
               unless klass.field_specs.has_key?(inheritance_column)
-                fields do |f|
+                declare_schema do |f|
                   f.field(inheritance_column, :string, limit: 255, null: true)
                 end
                 index(inheritance_column)

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -39,7 +39,7 @@ module DeclareSchema
           eval %(
             def self.inherited(klass)
               unless klass.field_specs.has_key?(inheritance_column)
-                declare_schema do |f|
+                fields do |f|
                   f.field(inheritance_column, :string, limit: 255, null: true)
                 end
                 index(inheritance_column)

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -39,7 +39,7 @@ module DeclareSchema
           eval %(
             def self.inherited(klass)
               unless klass.field_specs.has_key?(inheritance_column)
-                fields do |f|
+                declare_schema do |f|
                   f.field(inheritance_column, :string, limit: 255, null: true)
                 end
                 index(inheritance_column)

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "0.9.0"
+  VERSION = "0.10.0.pre.dc.1"
 end

--- a/lib/generators/declare_schema/support/model.rb
+++ b/lib/generators/declare_schema/support/model.rb
@@ -69,7 +69,7 @@ module DeclareSchema
             def declare_model_fields_and_associations
               buffer = ::DeclareSchema::Support::IndentedBuffer.new(indent: 2)
               buffer.newline!
-              buffer << 'declare_schema do'
+              buffer << 'fields do'
               buffer.indent! do
                 field_attributes.each do |attribute|
                   decl = "%-#{max_attribute_length}s" % attribute.name + ' ' +

--- a/lib/generators/declare_schema/support/model.rb
+++ b/lib/generators/declare_schema/support/model.rb
@@ -69,7 +69,7 @@ module DeclareSchema
             def declare_model_fields_and_associations
               buffer = ::DeclareSchema::Support::IndentedBuffer.new(indent: 2)
               buffer.newline!
-              buffer << 'fields do'
+              buffer << 'declare_schema do'
               buffer.indent! do
                 field_attributes.each do |attribute|
                   decl = "%-#{max_attribute_length}s" % attribute.name + ' ' +

--- a/lib/generators/declare_schema/support/model.rb
+++ b/lib/generators/declare_schema/support/model.rb
@@ -69,11 +69,11 @@ module DeclareSchema
             def declare_model_fields_and_associations
               buffer = ::DeclareSchema::Support::IndentedBuffer.new(indent: 2)
               buffer.newline!
-              buffer << 'fields do'
+              buffer << 'declare_schema do'
               buffer.indent! do
                 field_attributes.each do |attribute|
-                  decl = "%-#{max_attribute_length}s" % attribute.name + ' ' +
-                    attribute.type.to_sym.inspect +
+                  decl = "%-#{max_attribute_length}s" % attribute.type + ' ' +
+                    attribute.name.to_sym.inspect +
                     case attribute.type.to_s
                     when 'string'
                       ', limit: 255'
@@ -113,7 +113,7 @@ module DeclareSchema
             end
 
             def max_attribute_length
-              attributes.map { |attribute| attribute.name.length }.max
+              attributes.map { |attribute| attribute.type.length }.max
             end
 
             def field_attributes

--- a/spec/lib/declare_schema/api_spec.rb
+++ b/spec/lib/declare_schema/api_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'DeclareSchema API' do
       expect_model_definition_to_eq('advert', <<~EOS)
         class Advert < #{active_record_base_class}
 
-          fields do
+          declare_schema do
             title :string, limit: 255
             body  :text
           end
@@ -91,7 +91,7 @@ RSpec.describe 'DeclareSchema API' do
       class AdvertWithRequiredTitle < ActiveRecord::Base
         self.table_name = 'adverts'
 
-        fields do
+        declare_schema do
           title :string, :required, limit: 255
         end
       end
@@ -110,7 +110,7 @@ RSpec.describe 'DeclareSchema API' do
       class AdvertWithUniqueTitle < ActiveRecord::Base
         self.table_name = 'adverts'
 
-        fields do
+        declare_schema do
           title :string, :unique, limit: 255
         end
       end

--- a/spec/lib/declare_schema/api_spec.rb
+++ b/spec/lib/declare_schema/api_spec.rb
@@ -8,117 +8,236 @@ RSpec.describe 'DeclareSchema API' do
     load File.expand_path('prepare_testapp.rb', __dir__)
   end
 
-  describe 'example models' do
-    it 'generates a model' do
-      generate_model 'advert', 'title:string', 'body:text'
+  context 'Using fields' do
+    describe 'example models' do
+      it 'generates a model' do
+        generate_model 'advert', 'title:string', 'body:text'
 
-      # The above will generate the test, fixture and a model file like this:
-      # model_declaration = Rails::Generators.invoke('declare_schema:model', ['advert2', 'title:string', 'body:text'])
-      # expect(model_declaration.first).to eq([["Advert"], nil, "app/models/advert.rb", nil,
-      #                                       [["AdvertTest"], "test/models/advert_test.rb", nil, "test/fixtures/adverts.yml"]])
+        # The above will generate the test, fixture and a model file like this:
+        # model_declaration = Rails::Generators.invoke('declare_schema:model', ['advert2', 'title:string', 'body:text'])
+        # expect(model_declaration.first).to eq([["Advert"], nil, "app/models/advert.rb", nil,
+        #                                       [["AdvertTest"], "test/models/advert_test.rb", nil, "test/fixtures/adverts.yml"]])
 
-      expect_model_definition_to_eq('advert', <<~EOS)
-        class Advert < #{active_record_base_class}
+        expect_model_definition_to_eq('advert', <<~EOS)
+          class Advert < #{active_record_base_class}
+  
+            fields do
+              title :string, limit: 255
+              body  :text
+            end
+  
+          end
+        EOS
+
+        clean_up_model('advert2')
+
+        # The migration generator uses this information to create a migration.
+        # The following creates and runs the migration:
+
+        expect(system("bundle exec rails generate declare_schema:migration -n -m")).to be_truthy
+
+        # We're now ready to start demonstrating the API
+
+        load_models
+
+        if Rails::VERSION::MAJOR == 5
+          # TODO: get this to work on Travis for Rails 6
+          generate_migrations '-n', '-m'
+        end
+
+        require 'advert'
+
+        ## The Basics
+
+        # The main feature of DeclareSchema, aside from the migration generator, is the ability to declare rich types for your fields. For example, you can declare that a field is an email address, and the field will be automatically validated for correct email address syntax.
+
+        ### Field Types
+
+        # Field values are returned as the type you specify.
+
+        Advert.destroy_all
+
+        a = Advert.new(body: "This is the body", id: 1, title: "title")
+        expect(a.body).to eq("This is the body")
+
+        # This also works after a round-trip to the database
+
+        a.save!
+        expect(a.reload.body).to eq("This is the body")
+
+        ## Names vs. Classes
+
+        ## Model extensions
+
+        # DeclareSchema adds a few features to your models.
+
+        ### `Model.attr_type`
+
+        # Returns the type (i.e. class) declared for a given field or attribute
+
+        Advert.connection.schema_cache.clear!
+        Advert.reset_column_information
+
+        expect(Advert.attr_type(:title)).to eq(String)
+        expect(Advert.attr_type(:body)).to eq(String)
+
+        ## Field validations
+
+        # DeclareSchema gives you some shorthands for declaring some common validations right in the field declaration
+
+        ### Required fields
+
+        # The `:required` argument to a field gives a `validates_presence_of`:
+
+        class AdvertWithRequiredTitle < ActiveRecord::Base
+          self.table_name = 'adverts'
 
           fields do
-            title :string, limit: 255
-            body  :text
+            title :string, :required, limit: 255
           end
-
         end
-      EOS
 
-      clean_up_model('advert2')
+        a = AdvertWithRequiredTitle.new
+        expect(a.valid? || a.errors.full_messages).to eq(["Title can't be blank"])
+        a.id = 2
+        a.body = "hello"
+        a.title = "Jimbo"
+        a.save!
 
-      # The migration generator uses this information to create a migration.
-      # The following creates and runs the migration:
+        ### Unique fields
 
-      expect(system("bundle exec rails generate declare_schema:migration -n -m")).to be_truthy
+        # The `:unique` argument in a field declaration gives `validates_uniqueness_of`:
 
-      # We're now ready to start demonstrating the API
+        class AdvertWithUniqueTitle < ActiveRecord::Base
+          self.table_name = 'adverts'
 
-      load_models
-
-      if Rails::VERSION::MAJOR == 5
-        # TODO: get this to work on Travis for Rails 6
-        generate_migrations '-n', '-m'
-      end
-
-      require 'advert'
-
-      ## The Basics
-
-      # The main feature of DeclareSchema, aside from the migration generator, is the ability to declare rich types for your fields. For example, you can declare that a field is an email address, and the field will be automatically validated for correct email address syntax.
-
-      ### Field Types
-
-      # Field values are returned as the type you specify.
-
-      Advert.destroy_all
-
-      a = Advert.new(body: "This is the body", id: 1, title: "title")
-      expect(a.body).to eq("This is the body")
-
-      # This also works after a round-trip to the database
-
-      a.save!
-      expect(a.reload.body).to eq("This is the body")
-
-      ## Names vs. Classes
-
-      ## Model extensions
-
-      # DeclareSchema adds a few features to your models.
-
-      ### `Model.attr_type`
-
-      # Returns the type (i.e. class) declared for a given field or attribute
-
-      Advert.connection.schema_cache.clear!
-      Advert.reset_column_information
-
-      expect(Advert.attr_type(:title)).to eq(String)
-      expect(Advert.attr_type(:body)).to eq(String)
-
-      ## Field validations
-
-      # DeclareSchema gives you some shorthands for declaring some common validations right in the field declaration
-
-      ### Required fields
-
-      # The `:required` argument to a field gives a `validates_presence_of`:
-
-      class AdvertWithRequiredTitle < ActiveRecord::Base
-        self.table_name = 'adverts'
-
-        fields do
-          title :string, :required, limit: 255
+          fields do
+            title :string, :unique, limit: 255
+          end
         end
+
+        a = AdvertWithUniqueTitle.new :title => "Jimbo", id: 3, body: "hello"
+        expect(a.valid? || a.errors.full_messages).to eq(["Title has already been taken"])
+        a.title = "Sambo"
+        a.save!
       end
+    end
+  end
 
-      a = AdvertWithRequiredTitle.new
-      expect(a.valid? || a.errors.full_messages).to eq(["Title can't be blank"])
-      a.id = 2
-      a.body = "hello"
-      a.title = "Jimbo"
-      a.save!
+  context 'Using declare_schema' do
+    describe 'example models' do
+      # TODO: Unskip these tests after updating the generator to use declare_schema
+      xit 'generates a model' do
+        generate_model 'advert', 'string:title', 'text:body'
 
-      ### Unique fields
+        # The above will generate the test, fixture and a model file like this:
+        # model_declaration = Rails::Generators.invoke('declare_schema:model', ['advert2', 'title:string', 'body:text'])
+        # expect(model_declaration.first).to eq([["Advert"], nil, "app/models/advert.rb", nil,
+        #                                       [["AdvertTest"], "test/models/advert_test.rb", nil, "test/fixtures/adverts.yml"]])
 
-      # The `:unique` argument in a field declaration gives `validates_uniqueness_of`:
+        expect_model_definition_to_eq('advert', <<~EOS)
+          class Advert < #{active_record_base_class}
 
-      class AdvertWithUniqueTitle < ActiveRecord::Base
-        self.table_name = 'adverts'
+            declare_schema do
+              string :title, limit: 255
+              text   :body
+            end
 
-        fields do
-          title :string, :unique, limit: 255
+          end
+        EOS
+
+        clean_up_model('advert2')
+
+        # The migration generator uses this information to create a migration.
+        # The following creates and runs the migration:
+
+        expect(system("bundle exec rails generate declare_schema:migration -n -m")).to be_truthy
+
+        # We're now ready to start demonstrating the API
+
+        load_models
+
+        if Rails::VERSION::MAJOR == 5
+          # TODO: get this to work on Travis for Rails 6
+          generate_migrations '-n', '-m'
         end
-      end
 
-      a = AdvertWithUniqueTitle.new :title => "Jimbo", id: 3, body: "hello"
-      expect(a.valid? || a.errors.full_messages).to eq(["Title has already been taken"])
-      a.title = "Sambo"
-      a.save!
+        require 'advert'
+
+        ## The Basics
+
+        # The main feature of DeclareSchema, aside from the migration generator, is the ability to declare rich types for your fields. For example, you can declare that a field is an email address, and the field will be automatically validated for correct email address syntax.
+
+        ### Field Types
+
+        # Field values are returned as the type you specify.
+
+        Advert.destroy_all
+
+        a = Advert.new(body: "This is the body", id: 1, title: "title")
+        expect(a.body).to eq("This is the body")
+
+        # This also works after a round-trip to the database
+
+        a.save!
+        expect(a.reload.body).to eq("This is the body")
+
+        ## Names vs. Classes
+
+        ## Model extensions
+
+        # DeclareSchema adds a few features to your models.
+
+        ### `Model.attr_type`
+
+        # Returns the type (i.e. class) declared for a given field or attribute
+
+        Advert.connection.schema_cache.clear!
+        Advert.reset_column_information
+
+        expect(Advert.attr_type(:title)).to eq(String)
+        expect(Advert.attr_type(:body)).to eq(String)
+
+        ## Field validations
+
+        # DeclareSchema gives you some shorthands for declaring some common validations right in the field declaration
+
+        ### Required fields
+
+        # The `:required` argument to a field gives a `validates_presence_of`:
+
+        class AdvertWithRequiredTitle < ActiveRecord::Base
+          self.table_name = 'adverts'
+
+          declare_schema do
+            string :title, :required, limit: 255
+          end
+        end
+
+        a = AdvertWithRequiredTitle.new
+        expect(a.valid? || a.errors.full_messages).to eq(["Title can't be blank"])
+        a.id = 2
+        a.body = "hello"
+        a.title = "Jimbo"
+        a.save!
+
+        ### Unique fields
+
+        # The `:unique` argument in a field declaration gives `validates_uniqueness_of`:
+
+        class AdvertWithUniqueTitle < ActiveRecord::Base
+          self.table_name = 'adverts'
+
+          declare_schema do
+            string :title, :unique, limit: 255
+          end
+        end
+
+        a = AdvertWithUniqueTitle.new :title => "Jimbo", id: 3, body: "hello"
+        expect(a.valid? || a.errors.full_messages).to eq(["Title has already been taken"])
+        a.title = "Sambo"
+        a.save!
+      end
     end
   end
 end

--- a/spec/lib/declare_schema/api_spec.rb
+++ b/spec/lib/declare_schema/api_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'DeclareSchema API' do
       expect_model_definition_to_eq('advert', <<~EOS)
         class Advert < #{active_record_base_class}
 
-          declare_schema do
+          fields do
             title :string, limit: 255
             body  :text
           end
@@ -91,7 +91,7 @@ RSpec.describe 'DeclareSchema API' do
       class AdvertWithRequiredTitle < ActiveRecord::Base
         self.table_name = 'adverts'
 
-        declare_schema do
+        fields do
           title :string, :required, limit: 255
         end
       end
@@ -110,7 +110,7 @@ RSpec.describe 'DeclareSchema API' do
       class AdvertWithUniqueTitle < ActiveRecord::Base
         self.table_name = 'adverts'
 
-        declare_schema do
+        fields do
           title :string, :unique, limit: 255
         end
       end

--- a/spec/lib/declare_schema/api_spec.rb
+++ b/spec/lib/declare_schema/api_spec.rb
@@ -8,236 +8,117 @@ RSpec.describe 'DeclareSchema API' do
     load File.expand_path('prepare_testapp.rb', __dir__)
   end
 
-  context 'Using fields' do
-    describe 'example models' do
-      it 'generates a model' do
-        generate_model 'advert', 'title:string', 'body:text'
-
-        # The above will generate the test, fixture and a model file like this:
-        # model_declaration = Rails::Generators.invoke('declare_schema:model', ['advert2', 'title:string', 'body:text'])
-        # expect(model_declaration.first).to eq([["Advert"], nil, "app/models/advert.rb", nil,
-        #                                       [["AdvertTest"], "test/models/advert_test.rb", nil, "test/fixtures/adverts.yml"]])
-
-        expect_model_definition_to_eq('advert', <<~EOS)
-          class Advert < #{active_record_base_class}
-  
-            fields do
-              title :string, limit: 255
-              body  :text
-            end
-  
-          end
-        EOS
-
-        clean_up_model('advert2')
-
-        # The migration generator uses this information to create a migration.
-        # The following creates and runs the migration:
-
-        expect(system("bundle exec rails generate declare_schema:migration -n -m")).to be_truthy
-
-        # We're now ready to start demonstrating the API
-
-        load_models
-
-        if Rails::VERSION::MAJOR == 5
-          # TODO: get this to work on Travis for Rails 6
-          generate_migrations '-n', '-m'
-        end
-
-        require 'advert'
-
-        ## The Basics
-
-        # The main feature of DeclareSchema, aside from the migration generator, is the ability to declare rich types for your fields. For example, you can declare that a field is an email address, and the field will be automatically validated for correct email address syntax.
-
-        ### Field Types
-
-        # Field values are returned as the type you specify.
-
-        Advert.destroy_all
-
-        a = Advert.new(body: "This is the body", id: 1, title: "title")
-        expect(a.body).to eq("This is the body")
-
-        # This also works after a round-trip to the database
-
-        a.save!
-        expect(a.reload.body).to eq("This is the body")
-
-        ## Names vs. Classes
-
-        ## Model extensions
-
-        # DeclareSchema adds a few features to your models.
-
-        ### `Model.attr_type`
-
-        # Returns the type (i.e. class) declared for a given field or attribute
-
-        Advert.connection.schema_cache.clear!
-        Advert.reset_column_information
-
-        expect(Advert.attr_type(:title)).to eq(String)
-        expect(Advert.attr_type(:body)).to eq(String)
-
-        ## Field validations
-
-        # DeclareSchema gives you some shorthands for declaring some common validations right in the field declaration
-
-        ### Required fields
-
-        # The `:required` argument to a field gives a `validates_presence_of`:
-
-        class AdvertWithRequiredTitle < ActiveRecord::Base
-          self.table_name = 'adverts'
-
-          fields do
-            title :string, :required, limit: 255
-          end
-        end
-
-        a = AdvertWithRequiredTitle.new
-        expect(a.valid? || a.errors.full_messages).to eq(["Title can't be blank"])
-        a.id = 2
-        a.body = "hello"
-        a.title = "Jimbo"
-        a.save!
-
-        ### Unique fields
-
-        # The `:unique` argument in a field declaration gives `validates_uniqueness_of`:
-
-        class AdvertWithUniqueTitle < ActiveRecord::Base
-          self.table_name = 'adverts'
-
-          fields do
-            title :string, :unique, limit: 255
-          end
-        end
-
-        a = AdvertWithUniqueTitle.new :title => "Jimbo", id: 3, body: "hello"
-        expect(a.valid? || a.errors.full_messages).to eq(["Title has already been taken"])
-        a.title = "Sambo"
-        a.save!
-      end
-    end
-  end
-
-  context 'Using declare_schema' do
-    describe 'example models' do
-      # TODO: Unskip these tests after updating the generator to use declare_schema
-      xit 'generates a model' do
-        generate_model 'advert', 'string:title', 'text:body'
-
-        # The above will generate the test, fixture and a model file like this:
-        # model_declaration = Rails::Generators.invoke('declare_schema:model', ['advert2', 'title:string', 'body:text'])
-        # expect(model_declaration.first).to eq([["Advert"], nil, "app/models/advert.rb", nil,
-        #                                       [["AdvertTest"], "test/models/advert_test.rb", nil, "test/fixtures/adverts.yml"]])
-
-        expect_model_definition_to_eq('advert', <<~EOS)
-          class Advert < #{active_record_base_class}
-
-            declare_schema do
-              string :title, limit: 255
-              text   :body
-            end
-
-          end
-        EOS
-
-        clean_up_model('advert2')
-
-        # The migration generator uses this information to create a migration.
-        # The following creates and runs the migration:
-
-        expect(system("bundle exec rails generate declare_schema:migration -n -m")).to be_truthy
-
-        # We're now ready to start demonstrating the API
-
-        load_models
-
-        if Rails::VERSION::MAJOR == 5
-          # TODO: get this to work on Travis for Rails 6
-          generate_migrations '-n', '-m'
-        end
-
-        require 'advert'
-
-        ## The Basics
-
-        # The main feature of DeclareSchema, aside from the migration generator, is the ability to declare rich types for your fields. For example, you can declare that a field is an email address, and the field will be automatically validated for correct email address syntax.
-
-        ### Field Types
-
-        # Field values are returned as the type you specify.
-
-        Advert.destroy_all
-
-        a = Advert.new(body: "This is the body", id: 1, title: "title")
-        expect(a.body).to eq("This is the body")
-
-        # This also works after a round-trip to the database
-
-        a.save!
-        expect(a.reload.body).to eq("This is the body")
-
-        ## Names vs. Classes
-
-        ## Model extensions
-
-        # DeclareSchema adds a few features to your models.
-
-        ### `Model.attr_type`
-
-        # Returns the type (i.e. class) declared for a given field or attribute
-
-        Advert.connection.schema_cache.clear!
-        Advert.reset_column_information
-
-        expect(Advert.attr_type(:title)).to eq(String)
-        expect(Advert.attr_type(:body)).to eq(String)
-
-        ## Field validations
-
-        # DeclareSchema gives you some shorthands for declaring some common validations right in the field declaration
-
-        ### Required fields
-
-        # The `:required` argument to a field gives a `validates_presence_of`:
-
-        class AdvertWithRequiredTitle < ActiveRecord::Base
-          self.table_name = 'adverts'
+  describe 'example models' do
+    it 'generates a model' do
+      generate_model 'advert', 'title:string', 'body:text'
+
+      # The above will generate the test, fixture and a model file like this:
+      # model_declaration = Rails::Generators.invoke('declare_schema:model', ['advert2', 'title:string', 'body:text'])
+      # expect(model_declaration.first).to eq([["Advert"], nil, "app/models/advert.rb", nil,
+      #                                       [["AdvertTest"], "test/models/advert_test.rb", nil, "test/fixtures/adverts.yml"]])
+
+      expect_model_definition_to_eq('advert', <<~EOS)
+        class Advert < #{active_record_base_class}
 
           declare_schema do
-            string :title, :required, limit: 255
+            string :title, limit: 255
+            text   :body
           end
+
         end
+      EOS
 
-        a = AdvertWithRequiredTitle.new
-        expect(a.valid? || a.errors.full_messages).to eq(["Title can't be blank"])
-        a.id = 2
-        a.body = "hello"
-        a.title = "Jimbo"
-        a.save!
+      clean_up_model('advert2')
 
-        ### Unique fields
+      # The migration generator uses this information to create a migration.
+      # The following creates and runs the migration:
 
-        # The `:unique` argument in a field declaration gives `validates_uniqueness_of`:
+      expect(system("bundle exec rails generate declare_schema:migration -n -m")).to be_truthy
 
-        class AdvertWithUniqueTitle < ActiveRecord::Base
-          self.table_name = 'adverts'
+      # We're now ready to start demonstrating the API
 
-          declare_schema do
-            string :title, :unique, limit: 255
-          end
-        end
+      load_models
 
-        a = AdvertWithUniqueTitle.new :title => "Jimbo", id: 3, body: "hello"
-        expect(a.valid? || a.errors.full_messages).to eq(["Title has already been taken"])
-        a.title = "Sambo"
-        a.save!
+      if Rails::VERSION::MAJOR == 5
+        # TODO: get this to work on Travis for Rails 6
+        generate_migrations '-n', '-m'
       end
+
+      require 'advert'
+
+      ## The Basics
+
+      # The main feature of DeclareSchema, aside from the migration generator, is the ability to declare rich types for your fields. For example, you can declare that a field is an email address, and the field will be automatically validated for correct email address syntax.
+
+      ### Field Types
+
+      # Field values are returned as the type you specify.
+
+      Advert.destroy_all
+
+      a = Advert.new(body: "This is the body", id: 1, title: "title")
+      expect(a.body).to eq("This is the body")
+
+      # This also works after a round-trip to the database
+
+      a.save!
+      expect(a.reload.body).to eq("This is the body")
+
+      ## Names vs. Classes
+
+      ## Model extensions
+
+      # DeclareSchema adds a few features to your models.
+
+      ### `Model.attr_type`
+
+      # Returns the type (i.e. class) declared for a given field or attribute
+
+      Advert.connection.schema_cache.clear!
+      Advert.reset_column_information
+
+      expect(Advert.attr_type(:title)).to eq(String)
+      expect(Advert.attr_type(:body)).to eq(String)
+
+      ## Field validations
+
+      # DeclareSchema gives you some shorthands for declaring some common validations right in the field declaration
+
+      ### Required fields
+
+      # The `:required` argument to a field gives a `validates_presence_of`:
+
+      class AdvertWithRequiredTitle < ActiveRecord::Base
+        self.table_name = 'adverts'
+
+        declare_schema do
+          string :title, :required, limit: 255
+        end
+      end
+
+      a = AdvertWithRequiredTitle.new
+      expect(a.valid? || a.errors.full_messages).to eq(["Title can't be blank"])
+      a.id = 2
+      a.body = "hello"
+      a.title = "Jimbo"
+      a.save!
+
+      ### Unique fields
+
+      # The `:unique` argument in a field declaration gives `validates_uniqueness_of`:
+
+      class AdvertWithUniqueTitle < ActiveRecord::Base
+        self.table_name = 'adverts'
+
+        declare_schema do
+          string :title, :unique, limit: 255
+        end
+      end
+
+      a = AdvertWithUniqueTitle.new :title => "Jimbo", id: 3, body: "hello"
+      expect(a.valid? || a.errors.full_messages).to eq(["Title has already been taken"])
+      a.title = "Sambo"
+      a.save!
     end
   end
 end

--- a/spec/lib/declare_schema/field_declaration_dsl_spec.rb
+++ b/spec/lib/declare_schema/field_declaration_dsl_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe DeclareSchema::FieldDeclarationDsl do
     load File.expand_path('prepare_testapp.rb', __dir__)
 
     class TestModel < ActiveRecord::Base
-      fields do
+      declare_schema do
         name :string, limit: 127
 
         timestamps

--- a/spec/lib/declare_schema/field_declaration_dsl_spec.rb
+++ b/spec/lib/declare_schema/field_declaration_dsl_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe DeclareSchema::FieldDeclarationDsl do
     load File.expand_path('prepare_testapp.rb', __dir__)
 
     class TestModel < ActiveRecord::Base
-      declare_schema do
+      fields do
         name :string, limit: 127
 
         timestamps

--- a/spec/lib/declare_schema/field_declaration_dsl_spec.rb
+++ b/spec/lib/declare_schema/field_declaration_dsl_spec.rb
@@ -3,29 +3,55 @@
 require_relative '../../../lib/declare_schema/field_declaration_dsl'
 
 RSpec.describe DeclareSchema::FieldDeclarationDsl do
-  before do
-    load File.expand_path('prepare_testapp.rb', __dir__)
-
-    class TestModel < ActiveRecord::Base
-      fields do
-        name :string, limit: 127
-
-        timestamps
-      end
-    end
-  end
-
   let(:model) { TestModel.new }
   subject { declared_class.new(model) }
 
-  it 'has fields' do
-    expect(TestModel.field_specs).to be_kind_of(Hash)
-    expect(TestModel.field_specs.keys).to eq(['name', 'created_at', 'updated_at'])
-    expect(TestModel.field_specs.values.map(&:type)).to eq([:string, :datetime, :datetime])
+  context 'Using fields' do
+    before do
+      load File.expand_path('prepare_testapp.rb', __dir__)
+
+      class TestModel < ActiveRecord::Base
+        fields do
+          name :string, limit: 127
+
+          timestamps
+        end
+      end
+    end
+
+    it 'has fields' do
+      expect(TestModel.field_specs).to be_kind_of(Hash)
+      expect(TestModel.field_specs.keys).to eq(['name', 'created_at', 'updated_at'])
+      expect(TestModel.field_specs.values.map(&:type)).to eq([:string, :datetime, :datetime])
+    end
+
+    it 'stores limits' do
+      expect(TestModel.field_specs['name'].limit).to eq(127), TestModel.field_specs['name'].inspect
+    end
   end
 
-  it 'stores limits' do
-    expect(TestModel.field_specs['name'].limit).to eq(127), TestModel.field_specs['name'].inspect
+  context 'Using declare_schema' do
+    before do
+      load File.expand_path('prepare_testapp.rb', __dir__)
+
+      class TestModel < ActiveRecord::Base
+        declare_schema do
+          string :name, limit: 127
+
+          timestamps
+        end
+      end
+    end
+
+    it 'has fields' do
+      expect(TestModel.field_specs).to be_kind_of(Hash)
+      expect(TestModel.field_specs.keys).to eq(['name', 'created_at', 'updated_at'])
+      expect(TestModel.field_specs.values.map(&:type)).to eq([:string, :datetime, :datetime])
+    end
+
+    it 'stores limits' do
+      expect(TestModel.field_specs['name'].limit).to eq(127), TestModel.field_specs['name'].inspect
+    end
   end
 
   # TODO: fill out remaining tests

--- a/spec/lib/declare_schema/generator_spec.rb
+++ b/spec/lib/declare_schema/generator_spec.rb
@@ -5,109 +5,220 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     load File.expand_path('prepare_testapp.rb', __dir__)
   end
 
-  it "generates nested models" do
-    generate_model 'alpha/beta', 'one:string', 'two:integer'
+  context 'Using fields' do
+    it "generates nested models" do
+      generate_model 'alpha/beta', 'one:string', 'two:integer'
 
-    expect_model_definition_to_eq('alpha/beta', <<~EOS)
-      class Alpha::Beta < #{active_record_base_class}
-
-        fields do
-          one :string, limit: 255
-          two :integer
+      expect_model_definition_to_eq('alpha/beta', <<~EOS)
+        class Alpha::Beta < #{active_record_base_class}
+  
+          fields do
+            one :string, limit: 255
+            two :integer
+          end
+  
         end
+      EOS
 
+      expect_model_definition_to_eq('alpha', <<~EOS)
+        module Alpha
+          def self.table_name_prefix
+            'alpha_'
+          end
+        end
+      EOS
+
+      case Rails::VERSION::MAJOR
+      when 4, 5
+        expect_test_definition_to_eq('alpha/beta', <<~EOS)
+          require "test_helper"
+  
+          class Alpha::BetaTest < ActiveSupport::TestCase
+            # test "the truth" do
+            #   assert true
+            # end
+          end
+        EOS
+      else
+        expect_test_definition_to_eq('alpha/beta', <<~EOS)
+          require "test_helper"
+  
+          class Alpha::BetaTest < ActiveSupport::TestCase
+            # test "the truth" do
+            #   assert true
+            # end
+          end
+        EOS
       end
-    EOS
 
-    expect_model_definition_to_eq('alpha', <<~EOS)
-      module Alpha
-        def self.table_name_prefix
-          'alpha_'
-        end
+      case Rails::VERSION::MAJOR
+      when 4
+        expect_test_fixture_to_eq('alpha/beta', <<~EOS)
+          # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+  
+          # This model initially had no columns defined.  If you add columns to the
+          # model remove the '{}' from the fixture names and add the columns immediately
+          # below each fixture, per the syntax in the comments below
+          #
+          one: {}
+          # column: value
+          #
+          two: {}
+          #  column: value
+        EOS
+      when 5
+        expect_test_fixture_to_eq('alpha/beta', <<~EOS)
+          # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+  
+          # This model initially had no columns defined. If you add columns to the
+          # model remove the '{}' from the fixture names and add the columns immediately
+          # below each fixture, per the syntax in the comments below
+          #
+          one: {}
+          # column: value
+          #
+          two: {}
+          # column: value
+        EOS
+      when 6
+        expect_test_fixture_to_eq('alpha/beta', <<~EOS)
+          # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+  
+          # This model initially had no columns defined. If you add columns to the
+          # model remove the '{}' from the fixture names and add the columns immediately
+          # below each fixture, per the syntax in the comments below
+          #
+          one: {}
+          # column: value
+          #
+          two: {}
+          # column: value
+        EOS
       end
-    EOS
 
-    case Rails::VERSION::MAJOR
-    when 4, 5
-      expect_test_definition_to_eq('alpha/beta', <<~EOS)
-        require "test_helper"
+      $LOAD_PATH << "#{TESTAPP_PATH}/app/models"
 
-        class Alpha::BetaTest < ActiveSupport::TestCase
-          # test "the truth" do
-          #   assert true
-          # end
+      expect(system("bundle exec rails generate declare_schema:migration -n -m")).to be_truthy
+
+      expect(File.exist?('db/schema.rb')).to be_truthy
+
+      if defined?(SQLite3)
+        expect(File.exist?("db/development.sqlite3") || File.exist?("db/test.sqlite3")).to be_truthy
+      end
+
+      module Alpha; end
+      require 'alpha/beta'
+
+      expect { Alpha::Beta }.to_not raise_exception
+    end
+  end
+
+  context 'Using declare_schema' do
+    # TODO: Unskip these tests after updating the generator to use declare_schema
+    xit "generates nested models" do
+      generate_model 'alpha/beta', 'string:one', 'integer:two'
+
+      expect_model_definition_to_eq('alpha/beta', <<~EOS)
+        class Alpha::Beta < #{active_record_base_class}
+  
+          declare_schema do
+            string :one, limit: 255
+            integer :two
+          end
+  
         end
       EOS
-    else
-      expect_test_definition_to_eq('alpha/beta', <<~EOS)
-        require "test_helper"
 
-        class Alpha::BetaTest < ActiveSupport::TestCase
-          # test "the truth" do
-          #   assert true
-          # end
+      expect_model_definition_to_eq('alpha', <<~EOS)
+        module Alpha
+          def self.table_name_prefix
+            'alpha_'
+          end
         end
       EOS
+
+      case Rails::VERSION::MAJOR
+      when 4, 5
+        expect_test_definition_to_eq('alpha/beta', <<~EOS)
+          require "test_helper"
+  
+          class Alpha::BetaTest < ActiveSupport::TestCase
+            # test "the truth" do
+            #   assert true
+            # end
+          end
+        EOS
+      else
+        expect_test_definition_to_eq('alpha/beta', <<~EOS)
+          require "test_helper"
+  
+          class Alpha::BetaTest < ActiveSupport::TestCase
+            # test "the truth" do
+            #   assert true
+            # end
+          end
+        EOS
+      end
+
+      case Rails::VERSION::MAJOR
+      when 4
+        expect_test_fixture_to_eq('alpha/beta', <<~EOS)
+          # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+  
+          # This model initially had no columns defined.  If you add columns to the
+          # model remove the '{}' from the fixture names and add the columns immediately
+          # below each fixture, per the syntax in the comments below
+          #
+          one: {}
+          # column: value
+          #
+          two: {}
+          #  column: value
+        EOS
+      when 5
+        expect_test_fixture_to_eq('alpha/beta', <<~EOS)
+          # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+  
+          # This model initially had no columns defined. If you add columns to the
+          # model remove the '{}' from the fixture names and add the columns immediately
+          # below each fixture, per the syntax in the comments below
+          #
+          one: {}
+          # column: value
+          #
+          two: {}
+          # column: value
+        EOS
+      when 6
+        expect_test_fixture_to_eq('alpha/beta', <<~EOS)
+          # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+  
+          # This model initially had no columns defined. If you add columns to the
+          # model remove the '{}' from the fixture names and add the columns immediately
+          # below each fixture, per the syntax in the comments below
+          #
+          one: {}
+          # column: value
+          #
+          two: {}
+          # column: value
+        EOS
+      end
+
+      $LOAD_PATH << "#{TESTAPP_PATH}/app/models"
+
+      expect(system("bundle exec rails generate declare_schema:migration -n -m")).to be_truthy
+
+      expect(File.exist?('db/schema.rb')).to be_truthy
+
+      if defined?(SQLite3)
+        expect(File.exist?("db/development.sqlite3") || File.exist?("db/test.sqlite3")).to be_truthy
+      end
+
+      module Alpha; end
+      require 'alpha/beta'
+
+      expect { Alpha::Beta }.to_not raise_exception
     end
-
-    case Rails::VERSION::MAJOR
-    when 4
-      expect_test_fixture_to_eq('alpha/beta', <<~EOS)
-        # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-        # This model initially had no columns defined.  If you add columns to the
-        # model remove the '{}' from the fixture names and add the columns immediately
-        # below each fixture, per the syntax in the comments below
-        #
-        one: {}
-        # column: value
-        #
-        two: {}
-        #  column: value
-      EOS
-    when 5
-      expect_test_fixture_to_eq('alpha/beta', <<~EOS)
-        # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-        # This model initially had no columns defined. If you add columns to the
-        # model remove the '{}' from the fixture names and add the columns immediately
-        # below each fixture, per the syntax in the comments below
-        #
-        one: {}
-        # column: value
-        #
-        two: {}
-        # column: value
-      EOS
-    when 6
-      expect_test_fixture_to_eq('alpha/beta', <<~EOS)
-        # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-        # This model initially had no columns defined. If you add columns to the
-        # model remove the '{}' from the fixture names and add the columns immediately
-        # below each fixture, per the syntax in the comments below
-        #
-        one: {}
-        # column: value
-        #
-        two: {}
-        # column: value
-      EOS
-    end
-
-    $LOAD_PATH << "#{TESTAPP_PATH}/app/models"
-
-    expect(system("bundle exec rails generate declare_schema:migration -n -m")).to be_truthy
-
-    expect(File.exist?('db/schema.rb')).to be_truthy
-
-    if defined?(SQLite3)
-      expect(File.exist?("db/development.sqlite3") || File.exist?("db/test.sqlite3")).to be_truthy
-    end
-
-    module Alpha; end
-    require 'alpha/beta'
-
-    expect { Alpha::Beta }.to_not raise_exception
   end
 end

--- a/spec/lib/declare_schema/generator_spec.rb
+++ b/spec/lib/declare_schema/generator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     expect_model_definition_to_eq('alpha/beta', <<~EOS)
       class Alpha::Beta < #{active_record_base_class}
 
-        fields do
+        declare_schema do
           one :string, limit: 255
           two :integer
         end

--- a/spec/lib/declare_schema/generator_spec.rb
+++ b/spec/lib/declare_schema/generator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     expect_model_definition_to_eq('alpha/beta', <<~EOS)
       class Alpha::Beta < #{active_record_base_class}
 
-        declare_schema do
+        fields do
           one :string, limit: 255
           two :integer
         end

--- a/spec/lib/declare_schema/generator_spec.rb
+++ b/spec/lib/declare_schema/generator_spec.rb
@@ -5,220 +5,109 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     load File.expand_path('prepare_testapp.rb', __dir__)
   end
 
-  context 'Using fields' do
-    it "generates nested models" do
-      generate_model 'alpha/beta', 'one:string', 'two:integer'
+  it "generates nested models" do
+    generate_model 'alpha/beta', 'one:string', 'two:integer'
 
-      expect_model_definition_to_eq('alpha/beta', <<~EOS)
-        class Alpha::Beta < #{active_record_base_class}
-  
-          fields do
-            one :string, limit: 255
-            two :integer
-          end
-  
+    expect_model_definition_to_eq('alpha/beta', <<~EOS)
+      class Alpha::Beta < #{active_record_base_class}
+
+        declare_schema do
+          string  :one, limit: 255
+          integer :two
+        end
+
+      end
+    EOS
+
+    expect_model_definition_to_eq('alpha', <<~EOS)
+      module Alpha
+        def self.table_name_prefix
+          'alpha_'
+        end
+      end
+    EOS
+
+    case Rails::VERSION::MAJOR
+    when 4, 5
+      expect_test_definition_to_eq('alpha/beta', <<~EOS)
+        require "test_helper"
+
+        class Alpha::BetaTest < ActiveSupport::TestCase
+          # test "the truth" do
+          #   assert true
+          # end
         end
       EOS
+    else
+      expect_test_definition_to_eq('alpha/beta', <<~EOS)
+        require "test_helper"
 
-      expect_model_definition_to_eq('alpha', <<~EOS)
-        module Alpha
-          def self.table_name_prefix
-            'alpha_'
-          end
+        class Alpha::BetaTest < ActiveSupport::TestCase
+          # test "the truth" do
+          #   assert true
+          # end
         end
       EOS
-
-      case Rails::VERSION::MAJOR
-      when 4, 5
-        expect_test_definition_to_eq('alpha/beta', <<~EOS)
-          require "test_helper"
-  
-          class Alpha::BetaTest < ActiveSupport::TestCase
-            # test "the truth" do
-            #   assert true
-            # end
-          end
-        EOS
-      else
-        expect_test_definition_to_eq('alpha/beta', <<~EOS)
-          require "test_helper"
-  
-          class Alpha::BetaTest < ActiveSupport::TestCase
-            # test "the truth" do
-            #   assert true
-            # end
-          end
-        EOS
-      end
-
-      case Rails::VERSION::MAJOR
-      when 4
-        expect_test_fixture_to_eq('alpha/beta', <<~EOS)
-          # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-  
-          # This model initially had no columns defined.  If you add columns to the
-          # model remove the '{}' from the fixture names and add the columns immediately
-          # below each fixture, per the syntax in the comments below
-          #
-          one: {}
-          # column: value
-          #
-          two: {}
-          #  column: value
-        EOS
-      when 5
-        expect_test_fixture_to_eq('alpha/beta', <<~EOS)
-          # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-  
-          # This model initially had no columns defined. If you add columns to the
-          # model remove the '{}' from the fixture names and add the columns immediately
-          # below each fixture, per the syntax in the comments below
-          #
-          one: {}
-          # column: value
-          #
-          two: {}
-          # column: value
-        EOS
-      when 6
-        expect_test_fixture_to_eq('alpha/beta', <<~EOS)
-          # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-  
-          # This model initially had no columns defined. If you add columns to the
-          # model remove the '{}' from the fixture names and add the columns immediately
-          # below each fixture, per the syntax in the comments below
-          #
-          one: {}
-          # column: value
-          #
-          two: {}
-          # column: value
-        EOS
-      end
-
-      $LOAD_PATH << "#{TESTAPP_PATH}/app/models"
-
-      expect(system("bundle exec rails generate declare_schema:migration -n -m")).to be_truthy
-
-      expect(File.exist?('db/schema.rb')).to be_truthy
-
-      if defined?(SQLite3)
-        expect(File.exist?("db/development.sqlite3") || File.exist?("db/test.sqlite3")).to be_truthy
-      end
-
-      module Alpha; end
-      require 'alpha/beta'
-
-      expect { Alpha::Beta }.to_not raise_exception
     end
-  end
 
-  context 'Using declare_schema' do
-    # TODO: Unskip these tests after updating the generator to use declare_schema
-    xit "generates nested models" do
-      generate_model 'alpha/beta', 'string:one', 'integer:two'
+    case Rails::VERSION::MAJOR
+    when 4
+      expect_test_fixture_to_eq('alpha/beta', <<~EOS)
+        # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-      expect_model_definition_to_eq('alpha/beta', <<~EOS)
-        class Alpha::Beta < #{active_record_base_class}
-  
-          declare_schema do
-            string :one, limit: 255
-            integer :two
-          end
-  
-        end
+        # This model initially had no columns defined.  If you add columns to the
+        # model remove the '{}' from the fixture names and add the columns immediately
+        # below each fixture, per the syntax in the comments below
+        #
+        one: {}
+        # column: value
+        #
+        two: {}
+        #  column: value
       EOS
+    when 5
+      expect_test_fixture_to_eq('alpha/beta', <<~EOS)
+        # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-      expect_model_definition_to_eq('alpha', <<~EOS)
-        module Alpha
-          def self.table_name_prefix
-            'alpha_'
-          end
-        end
+        # This model initially had no columns defined. If you add columns to the
+        # model remove the '{}' from the fixture names and add the columns immediately
+        # below each fixture, per the syntax in the comments below
+        #
+        one: {}
+        # column: value
+        #
+        two: {}
+        # column: value
       EOS
+    when 6
+      expect_test_fixture_to_eq('alpha/beta', <<~EOS)
+        # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-      case Rails::VERSION::MAJOR
-      when 4, 5
-        expect_test_definition_to_eq('alpha/beta', <<~EOS)
-          require "test_helper"
-  
-          class Alpha::BetaTest < ActiveSupport::TestCase
-            # test "the truth" do
-            #   assert true
-            # end
-          end
-        EOS
-      else
-        expect_test_definition_to_eq('alpha/beta', <<~EOS)
-          require "test_helper"
-  
-          class Alpha::BetaTest < ActiveSupport::TestCase
-            # test "the truth" do
-            #   assert true
-            # end
-          end
-        EOS
-      end
-
-      case Rails::VERSION::MAJOR
-      when 4
-        expect_test_fixture_to_eq('alpha/beta', <<~EOS)
-          # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-  
-          # This model initially had no columns defined.  If you add columns to the
-          # model remove the '{}' from the fixture names and add the columns immediately
-          # below each fixture, per the syntax in the comments below
-          #
-          one: {}
-          # column: value
-          #
-          two: {}
-          #  column: value
-        EOS
-      when 5
-        expect_test_fixture_to_eq('alpha/beta', <<~EOS)
-          # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-  
-          # This model initially had no columns defined. If you add columns to the
-          # model remove the '{}' from the fixture names and add the columns immediately
-          # below each fixture, per the syntax in the comments below
-          #
-          one: {}
-          # column: value
-          #
-          two: {}
-          # column: value
-        EOS
-      when 6
-        expect_test_fixture_to_eq('alpha/beta', <<~EOS)
-          # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-  
-          # This model initially had no columns defined. If you add columns to the
-          # model remove the '{}' from the fixture names and add the columns immediately
-          # below each fixture, per the syntax in the comments below
-          #
-          one: {}
-          # column: value
-          #
-          two: {}
-          # column: value
-        EOS
-      end
-
-      $LOAD_PATH << "#{TESTAPP_PATH}/app/models"
-
-      expect(system("bundle exec rails generate declare_schema:migration -n -m")).to be_truthy
-
-      expect(File.exist?('db/schema.rb')).to be_truthy
-
-      if defined?(SQLite3)
-        expect(File.exist?("db/development.sqlite3") || File.exist?("db/test.sqlite3")).to be_truthy
-      end
-
-      module Alpha; end
-      require 'alpha/beta'
-
-      expect { Alpha::Beta }.to_not raise_exception
+        # This model initially had no columns defined. If you add columns to the
+        # model remove the '{}' from the fixture names and add the columns immediately
+        # below each fixture, per the syntax in the comments below
+        #
+        one: {}
+        # column: value
+        #
+        two: {}
+        # column: value
+      EOS
     end
+
+    $LOAD_PATH << "#{TESTAPP_PATH}/app/models"
+
+    expect(system("bundle exec rails generate declare_schema:migration -n -m")).to be_truthy
+
+    expect(File.exist?('db/schema.rb')).to be_truthy
+
+    if defined?(SQLite3)
+      expect(File.exist?("db/development.sqlite3") || File.exist?("db/test.sqlite3")).to be_truthy
+    end
+
+    module Alpha; end
+    require 'alpha/beta'
+
+    expect { Alpha::Beta }.to_not raise_exception
   end
 end

--- a/spec/lib/declare_schema/interactive_primary_key_spec.rb
+++ b/spec/lib/declare_schema/interactive_primary_key_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
   end
 
   context 'Using fields' do
-    xit "allows alternate primary keys" do
+    it "allows alternate primary keys" do
       class Foo < ActiveRecord::Base
         fields do
         end
@@ -30,7 +30,7 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
         self.primary_key = "id"
       end
 
-      puts "\n\e[45m Please enter 'id' (no quotes) at the next prompt \e[0m"
+      allow_any_instance_of(DeclareSchema::Support::ThorShell).to receive(:ask).with(/one of the rename choices or press enter to keep/) { 'id' }
       generate_migrations '-n', '-m'
       expect(Foo._defined_primary_key).to eq('id')
 
@@ -46,7 +46,7 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
           self.primary_key = "foo_id"
         end
 
-        puts "\n\e[45m Please enter 'drop id' (no quotes) at the next prompt \e[0m"
+        allow_any_instance_of(DeclareSchema::Support::ThorShell).to receive(:ask).with(/one of the rename choices or press enter to keep/) { 'drop id' }
         generate_migrations '-n', '-m'
         expect(Foo._defined_primary_key).to eq('foo_id')
 
@@ -79,6 +79,7 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
       end
 
       puts "\n\e[45m Please enter 'id' (no quotes) at the next prompt \e[0m"
+      allow_any_instance_of(DeclareSchema::Support::ThorShell).to receive(:ask).with(/one of the rename choices or press enter to keep/) { 'id' }
       generate_migrations '-n', '-m'
       expect(Foo.primary_key).to eq('id')
 
@@ -95,6 +96,7 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
         end
 
         puts "\n\e[45m Please enter 'drop id' (no quotes) at the next prompt \e[0m"
+        allow_any_instance_of(DeclareSchema::Support::ThorShell).to receive(:ask).with(/one of the rename choices or press enter to keep/) { 'drop id' }
         generate_migrations '-n', '-m'
         expect(Foo.primary_key).to eq('foo_id')
 

--- a/spec/lib/declare_schema/interactive_primary_key_spec.rb
+++ b/spec/lib/declare_schema/interactive_primary_key_spec.rb
@@ -12,51 +12,51 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
   end
 
   context 'Using fields' do
-  it "allows alternate primary keys" do
-    class Foo < ActiveRecord::Base
-      fields do
-      end
-      self.primary_key = "foo_id"
-    end
-
-    generate_migrations '-n', '-m'
-    expect(Foo._defined_primary_key).to eq('foo_id')
-
-    ### migrate from
-    # rename from custom primary_key
-    class Foo < ActiveRecord::Base
-      fields do
-      end
-      self.primary_key = "id"
-    end
-
-    puts "\n\e[45m Please enter 'id' (no quotes) at the next prompt \e[0m"
-    generate_migrations '-n', '-m'
-    expect(Foo._defined_primary_key).to eq('id')
-
-    nuke_model_class(Foo)
-
-    ### migrate to
-
-    if Rails::VERSION::MAJOR >= 5 && !defined?(Mysql2) # TODO TECH-4814 Put this test back for Mysql2
-      # replace custom primary_key
+    it "allows alternate primary keys" do
       class Foo < ActiveRecord::Base
         fields do
         end
         self.primary_key = "foo_id"
       end
 
-      puts "\n\e[45m Please enter 'drop id' (no quotes) at the next prompt \e[0m"
       generate_migrations '-n', '-m'
       expect(Foo._defined_primary_key).to eq('foo_id')
 
-      ### ensure it doesn't cause further migrations
+      ### migrate from
+      # rename from custom primary_key
+      class Foo < ActiveRecord::Base
+        fields do
+        end
+        self.primary_key = "id"
+      end
 
-      # check no further migrations
-      up = Generators::DeclareSchema::Migration::Migrator.run.first
-      expect(up).to eq("")
+      puts "\n\e[45m Please enter 'id' (no quotes) at the next prompt \e[0m"
+      generate_migrations '-n', '-m'
+      expect(Foo._defined_primary_key).to eq('id')
+
+      nuke_model_class(Foo)
+
+      ### migrate to
+
+      if Rails::VERSION::MAJOR >= 5 && !defined?(Mysql2) # TODO TECH-4814 Put this test back for Mysql2
+        # replace custom primary_key
+        class Foo < ActiveRecord::Base
+          fields do
+          end
+          self.primary_key = "foo_id"
+        end
+
+        puts "\n\e[45m Please enter 'drop id' (no quotes) at the next prompt \e[0m"
+        generate_migrations '-n', '-m'
+        expect(Foo._defined_primary_key).to eq('foo_id')
+
+        ### ensure it doesn't cause further migrations
+
+        # check no further migrations
+        up = Generators::DeclareSchema::Migration::Migrator.run.first
+        expect(up).to eq("")
+      end
     end
-  end
   end
 
   context 'Using declare_schema' do

--- a/spec/lib/declare_schema/interactive_primary_key_spec.rb
+++ b/spec/lib/declare_schema/interactive_primary_key_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
 
   it "allows alternate primary keys" do
     class Foo < ActiveRecord::Base
-      declare_schema do
+      fields do
       end
       self.primary_key = "foo_id"
     end
@@ -24,7 +24,7 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
     ### migrate from
     # rename from custom primary_key
     class Foo < ActiveRecord::Base
-      declare_schema do
+      fields do
       end
       self.primary_key = "id"
     end
@@ -40,7 +40,7 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
     if Rails::VERSION::MAJOR >= 5 && !defined?(Mysql2) # TODO TECH-4814 Put this test back for Mysql2
       # replace custom primary_key
       class Foo < ActiveRecord::Base
-        declare_schema do
+        fields do
         end
         self.primary_key = "foo_id"
       end

--- a/spec/lib/declare_schema/interactive_primary_key_spec.rb
+++ b/spec/lib/declare_schema/interactive_primary_key_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
   end
 
   context 'Using fields' do
-    it "allows alternate primary keys" do
+    xit "allows alternate primary keys" do
       class Foo < ActiveRecord::Base
         fields do
         end

--- a/spec/lib/declare_schema/interactive_primary_key_spec.rb
+++ b/spec/lib/declare_schema/interactive_primary_key_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
       generate_migrations '-n', '-m'
       expect(Foo._defined_primary_key).to eq('id')
 
-      nuke_model_class(Foo)
-
       ### migrate to
 
       if Rails::VERSION::MAJOR >= 5 && !defined?(Mysql2) # TODO TECH-4814 Put this test back for Mysql2
+        nuke_model_class(Foo)
+
         # replace custom primary_key
         class Foo < ActiveRecord::Base
           fields do
@@ -82,11 +82,11 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
       generate_migrations '-n', '-m'
       expect(Foo.primary_key).to eq('id')
 
-      nuke_model_class(Foo)
-
       ### migrate to
 
       if Rails::VERSION::MAJOR >= 5 && !defined?(Mysql2) # TODO TECH-4814 Put this test back for Mysql2
+        nuke_model_class(Foo)
+
         # replace custom primary_key
         class Foo < ActiveRecord::Base
           declare_schema do

--- a/spec/lib/declare_schema/interactive_primary_key_spec.rb
+++ b/spec/lib/declare_schema/interactive_primary_key_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
 
   it "allows alternate primary keys" do
     class Foo < ActiveRecord::Base
-      fields do
+      declare_schema do
       end
       self.primary_key = "foo_id"
     end
@@ -24,7 +24,7 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
     ### migrate from
     # rename from custom primary_key
     class Foo < ActiveRecord::Base
-      fields do
+      declare_schema do
       end
       self.primary_key = "id"
     end
@@ -40,7 +40,7 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
     if Rails::VERSION::MAJOR >= 5 && !defined?(Mysql2) # TODO TECH-4814 Put this test back for Mysql2
       # replace custom primary_key
       class Foo < ActiveRecord::Base
-        fields do
+        declare_schema do
         end
         self.primary_key = "foo_id"
       end

--- a/spec/lib/declare_schema/interactive_primary_key_spec.rb
+++ b/spec/lib/declare_schema/interactive_primary_key_spec.rb
@@ -11,49 +11,100 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
     load File.expand_path('prepare_testapp.rb', __dir__)
   end
 
-  it "allows alternate primary keys" do
-    class Foo < ActiveRecord::Base
-      fields do
-      end
-      self.primary_key = "foo_id"
-    end
-
-    generate_migrations '-n', '-m'
-    expect(Foo.primary_key).to eq('foo_id')
-
-    ### migrate from
-    # rename from custom primary_key
-    class Foo < ActiveRecord::Base
-      fields do
-      end
-      self.primary_key = "id"
-    end
-
-    puts "\n\e[45m Please enter 'id' (no quotes) at the next prompt \e[0m"
-    generate_migrations '-n', '-m'
-    expect(Foo.primary_key).to eq('id')
-
-    nuke_model_class(Foo)
-
-    ### migrate to
-
-    if Rails::VERSION::MAJOR >= 5 && !defined?(Mysql2) # TODO TECH-4814 Put this test back for Mysql2
-      # replace custom primary_key
+  context 'Using fields' do
+    it "allows alternate primary keys" do
       class Foo < ActiveRecord::Base
         fields do
         end
         self.primary_key = "foo_id"
       end
 
-      puts "\n\e[45m Please enter 'drop id' (no quotes) at the next prompt \e[0m"
       generate_migrations '-n', '-m'
       expect(Foo.primary_key).to eq('foo_id')
 
-      ### ensure it doesn't cause further migrations
+      ### migrate from
+      # rename from custom primary_key
+      class Foo < ActiveRecord::Base
+        fields do
+        end
+        self.primary_key = "id"
+      end
 
-      # check no further migrations
-      up = Generators::DeclareSchema::Migration::Migrator.run.first
-      expect(up).to eq("")
+      puts "\n\e[45m Please enter 'id' (no quotes) at the next prompt \e[0m"
+      generate_migrations '-n', '-m'
+      expect(Foo.primary_key).to eq('id')
+
+      nuke_model_class(Foo)
+
+      ### migrate to
+
+      if Rails::VERSION::MAJOR >= 5 && !defined?(Mysql2) # TODO TECH-4814 Put this test back for Mysql2
+        # replace custom primary_key
+        class Foo < ActiveRecord::Base
+          fields do
+          end
+          self.primary_key = "foo_id"
+        end
+
+        puts "\n\e[45m Please enter 'drop id' (no quotes) at the next prompt \e[0m"
+        generate_migrations '-n', '-m'
+        expect(Foo.primary_key).to eq('foo_id')
+
+        ### ensure it doesn't cause further migrations
+
+        # check no further migrations
+        up = Generators::DeclareSchema::Migration::Migrator.run.first
+        expect(up).to eq("")
+      end
+    end
+  end
+
+  context 'Using declare_schema' do
+    # TODO: Unskip these tests after updating the generator to use declare_schema
+    xit "allows alternate primary keys" do
+      class Foo < ActiveRecord::Base
+        declare_schema do
+        end
+        self.primary_key = "foo_id"
+      end
+
+      generate_migrations '-n', '-m'
+      expect(Foo.primary_key).to eq('foo_id')
+
+      ### migrate from
+      # rename from custom primary_key
+      class Foo < ActiveRecord::Base
+        declare_schema do
+        end
+        self.primary_key = "id"
+      end
+
+      puts "\n\e[45m Please enter 'id' (no quotes) at the next prompt \e[0m"
+      generate_migrations '-n', '-m'
+      expect(Foo.primary_key).to eq('id')
+
+      nuke_model_class(Foo)
+
+      ### migrate to
+
+      if Rails::VERSION::MAJOR >= 5 && !defined?(Mysql2) # TODO TECH-4814 Put this test back for Mysql2
+        # replace custom primary_key
+        class Foo < ActiveRecord::Base
+          declare_schema do
+          end
+          self.primary_key = "foo_id"
+        end
+
+        puts "\n\e[45m Please enter 'drop id' (no quotes) at the next prompt \e[0m"
+        generate_migrations '-n', '-m'
+        expect(Foo.primary_key).to eq('foo_id')
+
+        ### ensure it doesn't cause further migrations
+
+        # check no further migrations
+        up = Generators::DeclareSchema::Migration::Migrator.run.first
+        expect(up).to eq("")
+      end
     end
   end
 end

--- a/spec/lib/declare_schema/interactive_primary_key_spec.rb
+++ b/spec/lib/declare_schema/interactive_primary_key_spec.rb
@@ -7,7 +7,7 @@ rescue LoadError
 end
 
 RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
-  before :all do
+  before do
     load File.expand_path('prepare_testapp.rb', __dir__)
   end
 
@@ -34,11 +34,11 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
       generate_migrations '-n', '-m'
       expect(Foo._defined_primary_key).to eq('id')
 
+      nuke_model_class(Foo)
+
       ### migrate to
 
       if Rails::VERSION::MAJOR >= 5 && !defined?(Mysql2) # TODO TECH-4814 Put this test back for Mysql2
-        nuke_model_class(Foo)
-
         # replace custom primary_key
         class Foo < ActiveRecord::Base
           fields do
@@ -82,11 +82,11 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
       generate_migrations '-n', '-m'
       expect(Foo.primary_key).to eq('id')
 
+      nuke_model_class(Foo)
+
       ### migrate to
 
       if Rails::VERSION::MAJOR >= 5 && !defined?(Mysql2) # TODO TECH-4814 Put this test back for Mysql2
-        nuke_model_class(Foo)
-
         # replace custom primary_key
         class Foo < ActiveRecord::Base
           declare_schema do

--- a/spec/lib/declare_schema/interactive_primary_key_spec.rb
+++ b/spec/lib/declare_schema/interactive_primary_key_spec.rb
@@ -7,7 +7,7 @@ rescue LoadError
 end
 
 RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
-  before do
+  before :all do
     load File.expand_path('prepare_testapp.rb', __dir__)
   end
 
@@ -60,8 +60,7 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
   end
 
   context 'Using declare_schema' do
-    # TODO: Unskip these tests after updating the generator to use declare_schema
-    xit "allows alternate primary keys" do
+    it "allows alternate primary keys" do
       class Foo < ActiveRecord::Base
         declare_schema do
         end

--- a/spec/lib/declare_schema/interactive_primary_key_spec.rb
+++ b/spec/lib/declare_schema/interactive_primary_key_spec.rb
@@ -12,51 +12,51 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
   end
 
   context 'Using fields' do
-    it "allows alternate primary keys" do
+  it "allows alternate primary keys" do
+    class Foo < ActiveRecord::Base
+      fields do
+      end
+      self.primary_key = "foo_id"
+    end
+
+    generate_migrations '-n', '-m'
+    expect(Foo.primary_key).to eq('foo_id')
+
+    ### migrate from
+    # rename from custom primary_key
+    class Foo < ActiveRecord::Base
+      fields do
+      end
+      self.primary_key = "id"
+    end
+
+    puts "\n\e[45m Please enter 'id' (no quotes) at the next prompt \e[0m"
+    generate_migrations '-n', '-m'
+    expect(Foo.primary_key).to eq('id')
+
+    nuke_model_class(Foo)
+
+    ### migrate to
+
+    if Rails::VERSION::MAJOR >= 5 && !defined?(Mysql2) # TODO TECH-4814 Put this test back for Mysql2
+      # replace custom primary_key
       class Foo < ActiveRecord::Base
         fields do
         end
         self.primary_key = "foo_id"
       end
 
+      puts "\n\e[45m Please enter 'drop id' (no quotes) at the next prompt \e[0m"
       generate_migrations '-n', '-m'
       expect(Foo.primary_key).to eq('foo_id')
 
-      ### migrate from
-      # rename from custom primary_key
-      class Foo < ActiveRecord::Base
-        fields do
-        end
-        self.primary_key = "id"
-      end
+      ### ensure it doesn't cause further migrations
 
-      puts "\n\e[45m Please enter 'id' (no quotes) at the next prompt \e[0m"
-      generate_migrations '-n', '-m'
-      expect(Foo.primary_key).to eq('id')
-
-      nuke_model_class(Foo)
-
-      ### migrate to
-
-      if Rails::VERSION::MAJOR >= 5 && !defined?(Mysql2) # TODO TECH-4814 Put this test back for Mysql2
-        # replace custom primary_key
-        class Foo < ActiveRecord::Base
-          fields do
-          end
-          self.primary_key = "foo_id"
-        end
-
-        puts "\n\e[45m Please enter 'drop id' (no quotes) at the next prompt \e[0m"
-        generate_migrations '-n', '-m'
-        expect(Foo.primary_key).to eq('foo_id')
-
-        ### ensure it doesn't cause further migrations
-
-        # check no further migrations
-        up = Generators::DeclareSchema::Migration::Migrator.run.first
-        expect(up).to eq("")
-      end
+      # check no further migrations
+      up = Generators::DeclareSchema::Migration::Migrator.run.first
+      expect(up).to eq("")
     end
+  end
   end
 
   context 'Using declare_schema' do

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     Advert.reset_column_information
 
     class Advert < ActiveRecord::Base
-      declare_schema do
+      fields do
         name :string, limit: 250, null: true
       end
     end
@@ -102,7 +102,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     end
 
     class Advert < ActiveRecord::Base
-      declare_schema do
+      fields do
         name :string, limit: 250, null: true
         body :text, null: true
         published_at :datetime, null: true
@@ -125,7 +125,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     Advert.field_specs.clear # not normally needed
     class Advert < ActiveRecord::Base
-      declare_schema do
+      fields do
         name :string, limit: 250, null: true
         body :text, null: true
       end
@@ -139,7 +139,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     nuke_model_class(Advert)
     class Advert < ActiveRecord::Base
-      declare_schema do
+      fields do
         title :string, limit: 250, null: true
         body :text, null: true
       end
@@ -165,7 +165,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     migrate
 
     class Advert < ActiveRecord::Base
-      declare_schema do
+      fields do
         title :text, null: true
         body :text, null: true
       end
@@ -178,7 +178,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     )
 
     class Advert < ActiveRecord::Base
-      declare_schema do
+      fields do
         title :string, default: "Untitled", limit: 250, null: true
         body :text, null: true
       end
@@ -196,7 +196,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     ### Limits
 
     class Advert < ActiveRecord::Base
-      declare_schema do
+      fields do
         price :integer, null: true, limit: 2
       end
     end
@@ -209,7 +209,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     ActiveRecord::Migration.class_eval(up)
     class Advert < ActiveRecord::Base
-      declare_schema do
+      fields do
         price :integer, null: true, limit: 3
       end
     end
@@ -225,7 +225,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     ActiveRecord::Migration.class_eval("remove_column :adverts, :price")
     class Advert < ActiveRecord::Base
-      declare_schema do
+      fields do
         price :decimal, precision: 4, scale: 1, null: true
       end
     end
@@ -240,7 +240,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     end
 
     class Advert < ActiveRecord::Base
-      declare_schema do
+      fields do
         notes :text
         description :text, limit: 30000
       end
@@ -264,7 +264,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       expect(::DeclareSchema::Model::FieldSpec.mysql_text_limits?).to be_truthy
 
       class Advert < ActiveRecord::Base
-        declare_schema do
+        fields do
           notes :text
           description :text, limit: 250
         end
@@ -283,7 +283,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
       expect do
         class Advert < ActiveRecord::Base
-          declare_schema do
+          fields do
             notes :text
             description :text, limit: 0x1_0000_0000
           end
@@ -306,7 +306,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       # Now migrate to an unstated text limit:
 
       class Advert < ActiveRecord::Base
-        declare_schema do
+        fields do
           description :text
         end
       end
@@ -323,7 +323,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       # And migrate to a stated text limit that is the same as the unstated one:
 
       class Advert < ActiveRecord::Base
-        declare_schema do
+        fields do
           description :text, limit: 0xffffffff
         end
       end
@@ -342,7 +342,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     Advert.connection.schema_cache.clear!
     Advert.reset_column_information
     class Advert < ActiveRecord::Base
-      declare_schema do
+      fields do
         name :string, limit: 250, null: true
       end
     end
@@ -360,7 +360,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     class Category < ActiveRecord::Base; end
     class Advert < ActiveRecord::Base
-      declare_schema do
+      fields do
         name :string, limit: 250, null: true
       end
       belongs_to :category
@@ -390,7 +390,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     class Category < ActiveRecord::Base; end
     class Advert < ActiveRecord::Base
-      declare_schema { }
+      fields { }
       belongs_to :category, foreign_key: "c_id", class_name: 'Category'
     end
 
@@ -412,7 +412,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     class Category < ActiveRecord::Base; end
     class Advert < ActiveRecord::Base
-      declare_schema { }
+      fields { }
       belongs_to :category, index: false
     end
 
@@ -432,7 +432,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     class Category < ActiveRecord::Base; end
     class Advert < ActiveRecord::Base
-      declare_schema { }
+      fields { }
       belongs_to :category, index: 'my_index'
     end
 
@@ -456,7 +456,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     # Similarly, `lock_version` can be declared with the "shorthand" `optimimistic_lock`.
 
     class Advert < ActiveRecord::Base
-      declare_schema do
+      fields do
         timestamps
         optimistic_lock
       end
@@ -490,7 +490,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     # You can add an index to a field definition
 
     class Advert < ActiveRecord::Base
-      declare_schema do
+      fields do
         title :string, index: true, limit: 250, null: true
       end
     end
@@ -511,7 +511,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     # You can ask for a unique index
 
     class Advert < ActiveRecord::Base
-      declare_schema do
+      fields do
         title :string, index: true, unique: true, null: true, limit: 250
       end
     end
@@ -532,7 +532,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     # You can specify the name for the index
 
     class Advert < ActiveRecord::Base
-      declare_schema do
+      fields do
         title :string, index: 'my_index', limit: 250, null: true
       end
     end
@@ -617,7 +617,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     class Advert < ActiveRecord::Base
       self.table_name = "ads"
-      declare_schema do
+      fields do
         title :string, limit: 250, null: true
         body :text, null: true
       end
@@ -674,7 +674,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     nuke_model_class(Advert)
 
     class Advertisement < ActiveRecord::Base
-      declare_schema do
+      fields do
         title :string, limit: 250, null: true
         body :text, null: true
       end
@@ -735,7 +735,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     # Adding a subclass or two should introduce the 'type' column and no other changes
 
     class Advert < ActiveRecord::Base
-      declare_schema do
+      fields do
         body :text, null: true
         title :string, default: "Untitled", limit: 250, null: true
       end
@@ -789,7 +789,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     Advert.field_specs.clear
 
     class Advert < ActiveRecord::Base
-      declare_schema do
+      fields do
         name :string, default: "No Name", limit: 250, null: true
         body :text, null: true
       end
@@ -810,7 +810,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     nuke_model_class(Advert)
     class Ad < ActiveRecord::Base
-      declare_schema do
+      fields do
         title      :string, default: "Untitled", limit: 250
         body       :text, null: true
         created_at :datetime
@@ -833,7 +833,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     )
 
     class Advert < ActiveRecord::Base
-      declare_schema do
+      fields do
         body :text, null: true
         title :string, default: "Untitled", limit: 250, null: true
       end
@@ -846,7 +846,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     nuke_model_class(Ad)
 
     class Advert < ActiveRecord::Base
-      declare_schema do
+      fields do
         body :text, null: true
       end
       self.primary_key = "advert_id"
@@ -872,7 +872,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     # The DSL allows lambdas and constants
 
     class User < ActiveRecord::Base
-      declare_schema do
+      fields do
         company :string, limit: 250, ruby_default: -> { "BigCorp" }
       end
     end
@@ -891,7 +891,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     end
     expect(Ad).to receive(:validates).with(:company, presence: true, uniqueness: { case_sensitive: false })
     class Ad < ActiveRecord::Base
-      declare_schema do
+      fields do
         company :string, limit: 250, index: true, unique: true, validates: { presence: true, uniqueness: { case_sensitive: false } }
       end
       self.primary_key = "advert_id"
@@ -919,7 +919,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     describe 'untyped' do
       it 'allows serialize: true' do
         class Ad < ActiveRecord::Base
-          declare_schema do
+          fields do
             allow_list :text, limit: 0xFFFF, serialize: true
           end
         end
@@ -929,7 +929,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
       it 'converts defaults with .to_yaml' do
         class Ad < ActiveRecord::Base
-          declare_schema do
+          fields do
             allow_list :string, limit: 250, serialize: true, null: true, default: []
             allow_hash :string, limit: 250, serialize: true, null: true, default: {}
             allow_string :string, limit: 250, serialize: true, null: true, default: ['abc']
@@ -947,7 +947,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     describe 'Array' do
       it 'allows serialize: Array' do
         class Ad < ActiveRecord::Base
-          declare_schema do
+          fields do
             allow_list :string, limit: 250, serialize: Array, null: true
           end
         end
@@ -957,7 +957,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
       it 'allows Array defaults' do
         class Ad < ActiveRecord::Base
-          declare_schema do
+          fields do
             allow_list :string, limit: 250, serialize: Array, null: true, default: [2]
             allow_string :string, limit: 250, serialize: Array, null: true, default: ['abc']
             allow_empty :string, limit: 250, serialize: Array, null: true, default: []
@@ -975,7 +975,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     describe 'Hash' do
       it 'allows serialize: Hash' do
         class Ad < ActiveRecord::Base
-          declare_schema do
+          fields do
             allow_list :string, limit: 250, serialize: Hash, null: true
           end
         end
@@ -985,7 +985,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
       it 'allows Hash defaults' do
         class Ad < ActiveRecord::Base
-          declare_schema do
+          fields do
             allow_loc :string, limit: 250, serialize: Hash, null: true, default: { 'state' => 'CA' }
             allow_hash :string, limit: 250, serialize: Hash, null: true, default: {}
             allow_null :string, limit: 250, serialize: Hash, null: true, default: nil
@@ -1001,7 +1001,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     describe 'JSON' do
       it 'allows serialize: JSON' do
         class Ad < ActiveRecord::Base
-          declare_schema do
+          fields do
             allow_list :string, limit: 250, serialize: JSON
           end
         end
@@ -1011,7 +1011,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
       it 'allows JSON defaults' do
         class Ad < ActiveRecord::Base
-          declare_schema do
+          fields do
             allow_hash :string, limit: 250, serialize: JSON, null: true, default: { 'state' => 'CA' }
             allow_empty_array :string, limit: 250, serialize: JSON, null: true, default: []
             allow_empty_hash :string, limit: 250, serialize: JSON, null: true, default: {}
@@ -1051,7 +1051,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     describe 'custom coder' do
       it 'allows serialize: ValueClass' do
         class Ad < ActiveRecord::Base
-          declare_schema do
+          fields do
             allow_list :string, limit: 250, serialize: ValueClass
           end
         end
@@ -1061,7 +1061,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
       it 'allows ValueClass defaults' do
         class Ad < ActiveRecord::Base
-          declare_schema do
+          fields do
             allow_hash :string, limit: 250, serialize: ValueClass, null: true, default: ValueClass.new([2])
             allow_empty_array :string, limit: 250, serialize: ValueClass, null: true, default: ValueClass.new([])
             allow_null :string, limit: 250, serialize: ValueClass, null: true, default: nil
@@ -1077,7 +1077,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     it 'disallows serialize: with a non-string column type' do
       expect do
         class Ad < ActiveRecord::Base
-          declare_schema do
+          fields do
             allow_list :integer, limit: 8, serialize: true
           end
         end
@@ -1099,12 +1099,12 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       before do
         unless defined?(AdCategory)
           class AdCategory < ActiveRecord::Base
-            declare_schema { }
+            fields { }
           end
         end
 
         class Advert < ActiveRecord::Base
-          declare_schema do
+          fields do
             name :string, limit: 250, null: true
             category_id :integer, limit: 8
             nullable_category_id :integer, limit: 8, null: true
@@ -1117,7 +1117,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       it 'passes through optional: when given' do
         class AdvertBelongsTo < ActiveRecord::Base
           self.table_name = 'adverts'
-          declare_schema { }
+          fields { }
           reset_column_information
           belongs_to :ad_category, optional: true
         end
@@ -1128,7 +1128,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         it 'passes through optional: true, null: false' do
           class AdvertBelongsTo < ActiveRecord::Base
             self.table_name = 'adverts'
-            declare_schema { }
+            fields { }
             reset_column_information
             belongs_to :ad_category, optional: true, null: false
           end
@@ -1139,7 +1139,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         it 'passes through optional: false, null: true' do
           class AdvertBelongsTo < ActiveRecord::Base
             self.table_name = 'adverts'
-            declare_schema { }
+            fields { }
             reset_column_information
             belongs_to :ad_category, optional: false, null: true
           end
@@ -1153,7 +1153,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
           it 'infers optional: from null:' do
             eval <<~EOS
               class AdvertBelongsTo < ActiveRecord::Base
-                declare_schema { }
+                fields { }
                 belongs_to :ad_category, null: #{nullable}
               end
             EOS
@@ -1164,7 +1164,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
           it 'infers null: from optional:' do
             eval <<~EOS
               class AdvertBelongsTo < ActiveRecord::Base
-                declare_schema { }
+                fields { }
                 belongs_to :ad_category, optional: #{nullable}
               end
             EOS
@@ -1179,7 +1179,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
   describe 'migration base class' do
     it 'adapts to Rails 4' do
       class Advert < active_record_base_class.constantize
-        declare_schema do
+        fields do
           title :string, limit: 100
         end
       end
@@ -1200,7 +1200,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     it 'for aliased fields bigint -> integer limit 8' do
       if Rails::VERSION::MAJOR >= 5 || !ActiveRecord::Base.connection.class.name.match?(/SQLite3Adapter/)
         class Advert < active_record_base_class.constantize
-          declare_schema do
+          fields do
             price :bigint
           end
         end
@@ -1215,7 +1215,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         end
 
         class Advert < active_record_base_class.constantize
-          declare_schema do
+          fields do
             price :integer, limit: 8
           end
         end

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     Advert.reset_column_information
 
     class Advert < ActiveRecord::Base
-      fields do
+      declare_schema do
         name :string, limit: 250, null: true
       end
     end
@@ -102,7 +102,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     end
 
     class Advert < ActiveRecord::Base
-      fields do
+      declare_schema do
         name :string, limit: 250, null: true
         body :text, null: true
         published_at :datetime, null: true
@@ -125,7 +125,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     Advert.field_specs.clear # not normally needed
     class Advert < ActiveRecord::Base
-      fields do
+      declare_schema do
         name :string, limit: 250, null: true
         body :text, null: true
       end
@@ -139,7 +139,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     nuke_model_class(Advert)
     class Advert < ActiveRecord::Base
-      fields do
+      declare_schema do
         title :string, limit: 250, null: true
         body :text, null: true
       end
@@ -165,7 +165,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     migrate
 
     class Advert < ActiveRecord::Base
-      fields do
+      declare_schema do
         title :text, null: true
         body :text, null: true
       end
@@ -178,7 +178,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     )
 
     class Advert < ActiveRecord::Base
-      fields do
+      declare_schema do
         title :string, default: "Untitled", limit: 250, null: true
         body :text, null: true
       end
@@ -196,7 +196,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     ### Limits
 
     class Advert < ActiveRecord::Base
-      fields do
+      declare_schema do
         price :integer, null: true, limit: 2
       end
     end
@@ -209,7 +209,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     ActiveRecord::Migration.class_eval(up)
     class Advert < ActiveRecord::Base
-      fields do
+      declare_schema do
         price :integer, null: true, limit: 3
       end
     end
@@ -225,7 +225,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     ActiveRecord::Migration.class_eval("remove_column :adverts, :price")
     class Advert < ActiveRecord::Base
-      fields do
+      declare_schema do
         price :decimal, precision: 4, scale: 1, null: true
       end
     end
@@ -240,7 +240,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     end
 
     class Advert < ActiveRecord::Base
-      fields do
+      declare_schema do
         notes :text
         description :text, limit: 30000
       end
@@ -264,7 +264,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       expect(::DeclareSchema::Model::FieldSpec.mysql_text_limits?).to be_truthy
 
       class Advert < ActiveRecord::Base
-        fields do
+        declare_schema do
           notes :text
           description :text, limit: 250
         end
@@ -283,7 +283,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
       expect do
         class Advert < ActiveRecord::Base
-          fields do
+          declare_schema do
             notes :text
             description :text, limit: 0x1_0000_0000
           end
@@ -306,7 +306,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       # Now migrate to an unstated text limit:
 
       class Advert < ActiveRecord::Base
-        fields do
+        declare_schema do
           description :text
         end
       end
@@ -323,7 +323,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       # And migrate to a stated text limit that is the same as the unstated one:
 
       class Advert < ActiveRecord::Base
-        fields do
+        declare_schema do
           description :text, limit: 0xffffffff
         end
       end
@@ -342,7 +342,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     Advert.connection.schema_cache.clear!
     Advert.reset_column_information
     class Advert < ActiveRecord::Base
-      fields do
+      declare_schema do
         name :string, limit: 250, null: true
       end
     end
@@ -360,7 +360,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     class Category < ActiveRecord::Base; end
     class Advert < ActiveRecord::Base
-      fields do
+      declare_schema do
         name :string, limit: 250, null: true
       end
       belongs_to :category
@@ -456,7 +456,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     # Similarly, `lock_version` can be declared with the "shorthand" `optimimistic_lock`.
 
     class Advert < ActiveRecord::Base
-      fields do
+      declare_schema do
         timestamps
         optimistic_lock
       end
@@ -490,7 +490,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     # You can add an index to a field definition
 
     class Advert < ActiveRecord::Base
-      fields do
+      declare_schema do
         title :string, index: true, limit: 250, null: true
       end
     end
@@ -511,7 +511,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     # You can ask for a unique index
 
     class Advert < ActiveRecord::Base
-      fields do
+      declare_schema do
         title :string, index: true, unique: true, null: true, limit: 250
       end
     end
@@ -532,7 +532,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     # You can specify the name for the index
 
     class Advert < ActiveRecord::Base
-      fields do
+      declare_schema do
         title :string, index: 'my_index', limit: 250, null: true
       end
     end
@@ -617,7 +617,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     class Advert < ActiveRecord::Base
       self.table_name = "ads"
-      fields do
+      declare_schema do
         title :string, limit: 250, null: true
         body :text, null: true
       end
@@ -674,7 +674,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     nuke_model_class(Advert)
 
     class Advertisement < ActiveRecord::Base
-      fields do
+      declare_schema do
         title :string, limit: 250, null: true
         body :text, null: true
       end
@@ -735,7 +735,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     # Adding a subclass or two should introduce the 'type' column and no other changes
 
     class Advert < ActiveRecord::Base
-      fields do
+      declare_schema do
         body :text, null: true
         title :string, default: "Untitled", limit: 250, null: true
       end
@@ -789,7 +789,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     Advert.field_specs.clear
 
     class Advert < ActiveRecord::Base
-      fields do
+      declare_schema do
         name :string, default: "No Name", limit: 250, null: true
         body :text, null: true
       end
@@ -810,7 +810,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     nuke_model_class(Advert)
     class Ad < ActiveRecord::Base
-      fields do
+      declare_schema do
         title      :string, default: "Untitled", limit: 250
         body       :text, null: true
         created_at :datetime
@@ -833,7 +833,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     )
 
     class Advert < ActiveRecord::Base
-      fields do
+      declare_schema do
         body :text, null: true
         title :string, default: "Untitled", limit: 250, null: true
       end
@@ -846,7 +846,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     nuke_model_class(Ad)
 
     class Advert < ActiveRecord::Base
-      fields do
+      declare_schema do
         body :text, null: true
       end
       self.primary_key = "advert_id"
@@ -872,7 +872,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     # The DSL allows lambdas and constants
 
     class User < ActiveRecord::Base
-      fields do
+      declare_schema do
         company :string, limit: 250, ruby_default: -> { "BigCorp" }
       end
     end
@@ -891,7 +891,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     end
     expect(Ad).to receive(:validates).with(:company, presence: true, uniqueness: { case_sensitive: false })
     class Ad < ActiveRecord::Base
-      fields do
+      declare_schema do
         company :string, limit: 250, index: true, unique: true, validates: { presence: true, uniqueness: { case_sensitive: false } }
       end
       self.primary_key = "advert_id"
@@ -919,7 +919,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     describe 'untyped' do
       it 'allows serialize: true' do
         class Ad < ActiveRecord::Base
-          fields do
+          declare_schema do
             allow_list :text, limit: 0xFFFF, serialize: true
           end
         end
@@ -929,7 +929,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
       it 'converts defaults with .to_yaml' do
         class Ad < ActiveRecord::Base
-          fields do
+          declare_schema do
             allow_list :string, limit: 250, serialize: true, null: true, default: []
             allow_hash :string, limit: 250, serialize: true, null: true, default: {}
             allow_string :string, limit: 250, serialize: true, null: true, default: ['abc']
@@ -947,7 +947,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     describe 'Array' do
       it 'allows serialize: Array' do
         class Ad < ActiveRecord::Base
-          fields do
+          declare_schema do
             allow_list :string, limit: 250, serialize: Array, null: true
           end
         end
@@ -957,7 +957,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
       it 'allows Array defaults' do
         class Ad < ActiveRecord::Base
-          fields do
+          declare_schema do
             allow_list :string, limit: 250, serialize: Array, null: true, default: [2]
             allow_string :string, limit: 250, serialize: Array, null: true, default: ['abc']
             allow_empty :string, limit: 250, serialize: Array, null: true, default: []
@@ -975,7 +975,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     describe 'Hash' do
       it 'allows serialize: Hash' do
         class Ad < ActiveRecord::Base
-          fields do
+          declare_schema do
             allow_list :string, limit: 250, serialize: Hash, null: true
           end
         end
@@ -985,7 +985,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
       it 'allows Hash defaults' do
         class Ad < ActiveRecord::Base
-          fields do
+          declare_schema do
             allow_loc :string, limit: 250, serialize: Hash, null: true, default: { 'state' => 'CA' }
             allow_hash :string, limit: 250, serialize: Hash, null: true, default: {}
             allow_null :string, limit: 250, serialize: Hash, null: true, default: nil
@@ -1001,7 +1001,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     describe 'JSON' do
       it 'allows serialize: JSON' do
         class Ad < ActiveRecord::Base
-          fields do
+          declare_schema do
             allow_list :string, limit: 250, serialize: JSON
           end
         end
@@ -1011,7 +1011,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
       it 'allows JSON defaults' do
         class Ad < ActiveRecord::Base
-          fields do
+          declare_schema do
             allow_hash :string, limit: 250, serialize: JSON, null: true, default: { 'state' => 'CA' }
             allow_empty_array :string, limit: 250, serialize: JSON, null: true, default: []
             allow_empty_hash :string, limit: 250, serialize: JSON, null: true, default: {}
@@ -1051,7 +1051,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     describe 'custom coder' do
       it 'allows serialize: ValueClass' do
         class Ad < ActiveRecord::Base
-          fields do
+          declare_schema do
             allow_list :string, limit: 250, serialize: ValueClass
           end
         end
@@ -1061,7 +1061,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
       it 'allows ValueClass defaults' do
         class Ad < ActiveRecord::Base
-          fields do
+          declare_schema do
             allow_hash :string, limit: 250, serialize: ValueClass, null: true, default: ValueClass.new([2])
             allow_empty_array :string, limit: 250, serialize: ValueClass, null: true, default: ValueClass.new([])
             allow_null :string, limit: 250, serialize: ValueClass, null: true, default: nil
@@ -1077,7 +1077,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     it 'disallows serialize: with a non-string column type' do
       expect do
         class Ad < ActiveRecord::Base
-          fields do
+          declare_schema do
             allow_list :integer, limit: 8, serialize: true
           end
         end
@@ -1104,7 +1104,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         end
 
         class Advert < ActiveRecord::Base
-          fields do
+          declare_schema do
             name :string, limit: 250, null: true
             category_id :integer, limit: 8
             nullable_category_id :integer, limit: 8, null: true
@@ -1179,7 +1179,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
   describe 'migration base class' do
     it 'adapts to Rails 4' do
       class Advert < active_record_base_class.constantize
-        fields do
+        declare_schema do
           title :string, limit: 100
         end
       end
@@ -1200,7 +1200,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     it 'for aliased fields bigint -> integer limit 8' do
       if Rails::VERSION::MAJOR >= 5 || !ActiveRecord::Base.connection.class.name.match?(/SQLite3Adapter/)
         class Advert < active_record_base_class.constantize
-          fields do
+          declare_schema do
             price :bigint
           end
         end
@@ -1215,7 +1215,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         end
 
         class Advert < active_record_base_class.constantize
-          fields do
+          declare_schema do
             price :integer, limit: 8
           end
         end

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -390,7 +390,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     class Category < ActiveRecord::Base; end
     class Advert < ActiveRecord::Base
-      fields { }
+      declare_schema { }
       belongs_to :category, foreign_key: "c_id", class_name: 'Category'
     end
 
@@ -412,7 +412,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     class Category < ActiveRecord::Base; end
     class Advert < ActiveRecord::Base
-      fields { }
+      declare_schema { }
       belongs_to :category, index: false
     end
 
@@ -432,7 +432,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
     class Category < ActiveRecord::Base; end
     class Advert < ActiveRecord::Base
-      fields { }
+      declare_schema { }
       belongs_to :category, index: 'my_index'
     end
 
@@ -1099,7 +1099,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       before do
         unless defined?(AdCategory)
           class AdCategory < ActiveRecord::Base
-            fields { }
+            declare_schema { }
           end
         end
 
@@ -1117,7 +1117,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       it 'passes through optional: when given' do
         class AdvertBelongsTo < ActiveRecord::Base
           self.table_name = 'adverts'
-          fields { }
+          declare_schema { }
           reset_column_information
           belongs_to :ad_category, optional: true
         end
@@ -1128,7 +1128,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         it 'passes through optional: true, null: false' do
           class AdvertBelongsTo < ActiveRecord::Base
             self.table_name = 'adverts'
-            fields { }
+            declare_schema { }
             reset_column_information
             belongs_to :ad_category, optional: true, null: false
           end
@@ -1139,7 +1139,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         it 'passes through optional: false, null: true' do
           class AdvertBelongsTo < ActiveRecord::Base
             self.table_name = 'adverts'
-            fields { }
+            declare_schema { }
             reset_column_information
             belongs_to :ad_category, optional: false, null: true
           end
@@ -1153,7 +1153,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
           it 'infers optional: from null:' do
             eval <<~EOS
               class AdvertBelongsTo < ActiveRecord::Base
-                fields { }
+                declare_schema { }
                 belongs_to :ad_category, null: #{nullable}
               end
             EOS
@@ -1164,7 +1164,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
           it 'infers null: from optional:' do
             eval <<~EOS
               class AdvertBelongsTo < ActiveRecord::Base
-                fields { }
+                declare_schema { }
                 belongs_to :ad_category, optional: #{nullable}
               end
             EOS

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -56,1153 +56,1132 @@ RSpec.describe 'DeclareSchema Migration Generator' do
   end
 
   context 'Using fields' do
-  # DeclareSchema - Migration Generator
-  it 'generates migrations' do
-    ## The migration generator -- introduction
+    # DeclareSchema - Migration Generator
+    it 'generates migrations' do
+      ## The migration generator -- introduction
 
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to migrate_up("").and migrate_down("")
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to migrate_up("").and migrate_down("")
 
-    class Advert < ActiveRecord::Base
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to migrate_up("").and migrate_down("")
-
-    Generators::DeclareSchema::Migration::Migrator.ignore_tables = ["green_fishes"]
-
-    Advert.connection.schema_cache.clear!
-    Advert.reset_column_information
-
-    class Advert < ActiveRecord::Base
-      fields do
-        name :string, limit: 250, null: true
+      class Advert < ActiveRecord::Base
       end
-    end
 
-    up, _ = Generators::DeclareSchema::Migration::Migrator.run.tap do |migrations|
-      expect(migrations).to(
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to migrate_up("").and migrate_down("")
+
+      Generators::DeclareSchema::Migration::Migrator.ignore_tables = ["green_fishes"]
+
+      Advert.connection.schema_cache.clear!
+      Advert.reset_column_information
+
+      class Advert < ActiveRecord::Base
+        fields do
+          name :string, limit: 250, null: true
+        end
+      end
+
+      up, _ = Generators::DeclareSchema::Migration::Migrator.run.tap do |migrations|
+        expect(migrations).to(
+          migrate_up(<<~EOS.strip)
+            create_table :adverts, id: :bigint do |t|
+              t.string :name, limit: 250, null: true#{charset_and_collation}
+            end#{charset_alter_table}
+          EOS
+          .and migrate_down("drop_table :adverts")
+        )
+      end
+
+      ActiveRecord::Migration.class_eval(up)
+      expect(Advert.columns.map(&:name)).to eq(["id", "name"])
+
+      if Rails::VERSION::MAJOR < 5
+        # Rails 4 drivers don't always create PK properly. Fix that by dropping and recreating.
+        ActiveRecord::Base.connection.execute("drop table adverts")
+        if defined?(Mysql2)
+          ActiveRecord::Base.connection.execute("CREATE TABLE adverts (id integer PRIMARY KEY AUTO_INCREMENT NOT NULL, name varchar(250)) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin")
+        else
+          ActiveRecord::Base.connection.execute("CREATE TABLE adverts (id integer PRIMARY KEY AUTOINCREMENT  NOT NULL, name varchar(250))")
+        end
+      end
+
+      class Advert < ActiveRecord::Base
+        fields do
+          name :string, limit: 250, null: true
+          body :text, null: true
+          published_at :datetime, null: true
+        end
+      end
+
+      Advert.connection.schema_cache.clear!
+      Advert.reset_column_information
+
+      expect(migrate).to(
         migrate_up(<<~EOS.strip)
-          create_table :adverts, id: :bigint do |t|
-            t.string :name, limit: 250, null: true#{charset_and_collation}
-          end#{charset_alter_table}
+          add_column :adverts, :body, :text#{text_limit}, null: true#{charset_and_collation}
+          add_column :adverts, :published_at, :datetime, null: true
         EOS
-        .and migrate_down("drop_table :adverts")
+        .and migrate_down(<<~EOS.strip)
+          remove_column :adverts, :body
+          remove_column :adverts, :published_at
+        EOS
       )
-    end
 
-    ActiveRecord::Migration.class_eval(up)
-    expect(Advert.columns.map(&:name)).to eq(["id", "name"])
-
-    if Rails::VERSION::MAJOR < 5
-      # Rails 4 drivers don't always create PK properly. Fix that by dropping and recreating.
-      ActiveRecord::Base.connection.execute("drop table adverts")
-      if defined?(Mysql2)
-        ActiveRecord::Base.connection.execute("CREATE TABLE adverts (id integer PRIMARY KEY AUTO_INCREMENT NOT NULL, name varchar(250)) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin")
-      else
-        ActiveRecord::Base.connection.execute("CREATE TABLE adverts (id integer PRIMARY KEY AUTOINCREMENT  NOT NULL, name varchar(250))")
+      Advert.field_specs.clear # not normally needed
+      class Advert < ActiveRecord::Base
+        fields do
+          name :string, limit: 250, null: true
+          body :text, null: true
+        end
       end
-    end
 
-    class Advert < ActiveRecord::Base
-      fields do
-        name :string, limit: 250, null: true
-        body :text, null: true
-        published_at :datetime, null: true
-      end
-    end
-
-    Advert.connection.schema_cache.clear!
-    Advert.reset_column_information
-
-    expect(migrate).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :body, :text#{text_limit}, null: true#{charset_and_collation}
-        add_column :adverts, :published_at, :datetime, null: true
-      EOS
-      .and migrate_down(<<~EOS.strip)
-        remove_column :adverts, :body
-        remove_column :adverts, :published_at
-      EOS
-    )
-
-    Advert.field_specs.clear # not normally needed
-    class Advert < ActiveRecord::Base
-      fields do
-        name :string, limit: 250, null: true
-        body :text, null: true
-      end
-    end
-
-    expect(migrate).to(
-      migrate_up("remove_column :adverts, :published_at").and(
-        migrate_down("add_column :adverts, :published_at, :datetime#{datetime_precision}, null: true")
+      expect(migrate).to(
+        migrate_up("remove_column :adverts, :published_at").and(
+          migrate_down("add_column :adverts, :published_at, :datetime#{datetime_precision}, null: true")
+        )
       )
-    )
 
-    nuke_model_class(Advert)
-    class Advert < ActiveRecord::Base
-      fields do
-        title :string, limit: 250, null: true
-        body :text, null: true
+      nuke_model_class(Advert)
+      class Advert < ActiveRecord::Base
+        fields do
+          title :string, limit: 250, null: true
+          body :text, null: true
+        end
       end
-    end
 
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-        remove_column :adverts, :name
-      EOS
-      .and migrate_down(<<~EOS.strip)
-        remove_column :adverts, :title
-        add_column :adverts, :name, :string, limit: 250, null: true#{charset_and_collation}
-      EOS
-    )
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: { name: :title })).to(
-      migrate_up("rename_column :adverts, :name, :title").and(
-        migrate_down("rename_column :adverts, :title, :name")
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+          remove_column :adverts, :name
+        EOS
+        .and migrate_down(<<~EOS.strip)
+          remove_column :adverts, :title
+          add_column :adverts, :name, :string, limit: 250, null: true#{charset_and_collation}
+        EOS
       )
-    )
 
-    migrate
-
-    class Advert < ActiveRecord::Base
-      fields do
-        title :text, null: true
-        body :text, null: true
-      end
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up("change_column :adverts, :title, :text#{text_limit}, null: true#{charset_and_collation}").and(
-        migrate_down("change_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}")
+      expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: { name: :title })).to(
+        migrate_up("rename_column :adverts, :name, :title").and(
+          migrate_down("rename_column :adverts, :title, :name")
+        )
       )
-    )
 
-    class Advert < ActiveRecord::Base
-      fields do
-        title :string, default: "Untitled", limit: 250, null: true
-        body :text, null: true
+      migrate
+
+      class Advert < ActiveRecord::Base
+        fields do
+          title :text, null: true
+          body :text, null: true
+        end
       end
-    end
 
-    expect(migrate).to(
-      migrate_up(<<~EOS.strip)
-        change_column :adverts, :title, :string, limit: 250, null: true, default: "Untitled"#{charset_and_collation}
-      EOS
-      .and migrate_down(<<~EOS.strip)
-        change_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-      EOS
-    )
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up("change_column :adverts, :title, :text#{text_limit}, null: true#{charset_and_collation}").and(
+          migrate_down("change_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}")
+        )
+      )
 
-    ### Limits
-
-    class Advert < ActiveRecord::Base
-      fields do
-        price :integer, null: true, limit: 2
+      class Advert < ActiveRecord::Base
+        fields do
+          title :string, default: "Untitled", limit: 250, null: true
+          body :text, null: true
+        end
       end
-    end
 
-    up, _ = Generators::DeclareSchema::Migration::Migrator.run.tap do |migrations|
-      expect(migrations).to migrate_up("add_column :adverts, :price, :integer, limit: 2, null: true")
-    end
+      expect(migrate).to(
+        migrate_up(<<~EOS.strip)
+          change_column :adverts, :title, :string, limit: 250, null: true, default: "Untitled"#{charset_and_collation}
+        EOS
+        .and migrate_down(<<~EOS.strip)
+          change_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+        EOS
+      )
 
-    # Now run the migration, then change the limit:
+      ### Limits
 
-    ActiveRecord::Migration.class_eval(up)
-    class Advert < ActiveRecord::Base
-      fields do
-        price :integer, null: true, limit: 3
+      class Advert < ActiveRecord::Base
+        fields do
+          price :integer, null: true, limit: 2
+        end
       end
-    end
 
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        change_column :adverts, :price, :integer, limit: 3, null: true
-      EOS
-      .and migrate_down(<<~EOS.strip)
-        change_column :adverts, :price, :integer, limit: 2, null: true
-      EOS
-    )
-
-    ActiveRecord::Migration.class_eval("remove_column :adverts, :price")
-    class Advert < ActiveRecord::Base
-      fields do
-        price :decimal, precision: 4, scale: 1, null: true
+      up, _ = Generators::DeclareSchema::Migration::Migrator.run.tap do |migrations|
+        expect(migrations).to migrate_up("add_column :adverts, :price, :integer, limit: 2, null: true")
       end
-    end
 
-    # Limits are generally not needed for `text` fields, because by default, `text` fields will use the maximum size
-    # allowed for that database type (0xffffffff for LONGTEXT in MySQL unlimited in Postgres, 1 billion in Sqlite).
-    # If a `limit` is given, it will only be used in MySQL, to choose the smallest TEXT field that will accommodate
-    # that limit (0xff for TINYTEXT, 0xffff for TEXT, 0xffffff for MEDIUMTEXT, 0xffffffff for LONGTEXT).
+      # Now run the migration, then change the limit:
 
-    if defined?(SQLite3)
-      expect(::DeclareSchema::Model::FieldSpec.mysql_text_limits?).to be_falsey
-    end
-
-    class Advert < ActiveRecord::Base
-      fields do
-        notes :text
-        description :text, limit: 30000
+      ActiveRecord::Migration.class_eval(up)
+      class Advert < ActiveRecord::Base
+        fields do
+          price :integer, null: true, limit: 3
+        end
       end
-    end
 
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :price, :decimal, precision: 4, scale: 1, null: true
-        add_column :adverts, :notes, :text#{text_limit}, null: false#{charset_and_collation}
-        add_column :adverts, :description, :text#{', limit: 65535' if defined?(Mysql2)}, null: false#{charset_and_collation}
-      EOS
-    )
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          change_column :adverts, :price, :integer, limit: 3, null: true
+        EOS
+        .and migrate_down(<<~EOS.strip)
+          change_column :adverts, :price, :integer, limit: 2, null: true
+        EOS
+      )
 
-    Advert.field_specs.delete :price
-    Advert.field_specs.delete :notes
-    Advert.field_specs.delete :description
+      ActiveRecord::Migration.class_eval("remove_column :adverts, :price")
+      class Advert < ActiveRecord::Base
+        fields do
+          price :decimal, precision: 4, scale: 1, null: true
+        end
+      end
 
-    # In MySQL, limits are applied, rounded up:
+      # Limits are generally not needed for `text` fields, because by default, `text` fields will use the maximum size
+      # allowed for that database type (0xffffffff for LONGTEXT in MySQL unlimited in Postgres, 1 billion in Sqlite).
+      # If a `limit` is given, it will only be used in MySQL, to choose the smallest TEXT field that will accommodate
+      # that limit (0xff for TINYTEXT, 0xffff for TEXT, 0xffffff for MEDIUMTEXT, 0xffffffff for LONGTEXT).
 
-    if defined?(Mysql2)
-      expect(::DeclareSchema::Model::FieldSpec.mysql_text_limits?).to be_truthy
+      if defined?(SQLite3)
+        expect(::DeclareSchema::Model::FieldSpec.mysql_text_limits?).to be_falsey
+      end
 
       class Advert < ActiveRecord::Base
         fields do
           notes :text
-          description :text, limit: 250
+          description :text, limit: 30000
         end
       end
 
       expect(Generators::DeclareSchema::Migration::Migrator.run).to(
         migrate_up(<<~EOS.strip)
-          add_column :adverts, :notes, :text, limit: 4294967295, null: false#{charset_and_collation}
-          add_column :adverts, :description, :text, limit: 255, null: false#{charset_and_collation}
+          add_column :adverts, :price, :decimal, precision: 4, scale: 1, null: true
+          add_column :adverts, :notes, :text#{text_limit}, null: false#{charset_and_collation}
+          add_column :adverts, :description, :text#{', limit: 65535' if defined?(Mysql2)}, null: false#{charset_and_collation}
         EOS
       )
 
+      Advert.field_specs.delete :price
       Advert.field_specs.delete :notes
+      Advert.field_specs.delete :description
 
-      # Limits that are too high for MySQL will raise an exception.
+      # In MySQL, limits are applied, rounded up:
 
-      expect do
+      if defined?(Mysql2)
+        expect(::DeclareSchema::Model::FieldSpec.mysql_text_limits?).to be_truthy
+
         class Advert < ActiveRecord::Base
           fields do
             notes :text
-            description :text, limit: 0x1_0000_0000
-          end
-        end
-      end.to raise_exception(ArgumentError, "limit of 4294967296 is too large for MySQL")
-
-      Advert.field_specs.delete :notes
-
-      # And in MySQL, unstated text limits are treated as the maximum (LONGTEXT) limit.
-
-      # To start, we'll set the database schema for `description` to match the above limit of 250.
-
-      Advert.connection.execute "ALTER TABLE adverts ADD COLUMN description TINYTEXT"
-      Advert.connection.schema_cache.clear!
-      Advert.reset_column_information
-      expect(Advert.connection.tables - Generators::DeclareSchema::Migration::Migrator.always_ignore_tables).
-        to eq(["adverts"])
-      expect(Advert.columns.map(&:name)).to eq(["id", "body", "title", "description"])
-
-      # Now migrate to an unstated text limit:
-
-      class Advert < ActiveRecord::Base
-        fields do
-          description :text
-        end
-      end
-
-      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-        migrate_up(<<~EOS.strip)
-          change_column :adverts, :description, :text, limit: 4294967295, null: false#{charset_and_collation}
-        EOS
-        .and migrate_down(<<~EOS.strip)
-          change_column :adverts, :description, :text#{', limit: 255' if defined?(Mysql2)}, null: true#{charset_and_collation}
-        EOS
-      )
-
-      # And migrate to a stated text limit that is the same as the unstated one:
-
-      class Advert < ActiveRecord::Base
-        fields do
-          description :text, limit: 0xffffffff
-        end
-      end
-
-      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-        migrate_up(<<~EOS.strip)
-          change_column :adverts, :description, :text, limit: 4294967295, null: false#{charset_and_collation}
-        EOS
-        .and migrate_down(<<~EOS.strip)
-          change_column :adverts, :description, :text#{', limit: 255' if defined?(Mysql2)}, null: true#{charset_and_collation}
-        EOS
-      )
-    end
-
-    Advert.field_specs.clear
-    Advert.connection.schema_cache.clear!
-    Advert.reset_column_information
-    class Advert < ActiveRecord::Base
-      fields do
-        name :string, limit: 250, null: true
-      end
-    end
-
-    up = Generators::DeclareSchema::Migration::Migrator.run.first
-    ActiveRecord::Migration.class_eval up
-
-    Advert.connection.schema_cache.clear!
-    Advert.reset_column_information
-
-    ### Foreign Keys
-
-    # DeclareSchema extends the `belongs_to` macro so that it also declares the
-    # foreign-key field.  It also generates an index on the field.
-
-    class Category < ActiveRecord::Base; end
-    class Advert < ActiveRecord::Base
-      fields do
-        name :string, limit: 250, null: true
-      end
-      belongs_to :category
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :category_id, :integer, limit: 8, null: false
-
-        add_index :adverts, [:category_id], name: 'on_category_id'
-
-        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" if defined?(Mysql2)}
-      EOS
-      .and migrate_down(<<~EOS.strip)
-        remove_column :adverts, :category_id
-
-        remove_index :adverts, name: :on_category_id rescue ActiveRecord::StatementInvalid
-
-        #{"remove_foreign_key(\"adverts\", name: \"on_category_id\")\n" if defined?(Mysql2)}
-      EOS
-    )
-
-    Advert.field_specs.delete(:category_id)
-    Advert.index_definitions.delete_if { |spec| spec.fields==["category_id"] }
-
-    # If you specify a custom foreign key, the migration generator observes that:
-
-    class Category < ActiveRecord::Base; end
-    class Advert < ActiveRecord::Base
-      fields { }
-      belongs_to :category, foreign_key: "c_id", class_name: 'Category'
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :c_id, :integer, limit: 8, null: false
-
-        add_index :adverts, [:c_id], name: 'on_c_id'
-
-        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
-      EOS
-    )
-
-    Advert.field_specs.delete(:c_id)
-    Advert.index_definitions.delete_if { |spec| spec.fields == ["c_id"] }
-
-    # You can avoid generating the index by specifying `index: false`
-
-    class Category < ActiveRecord::Base; end
-    class Advert < ActiveRecord::Base
-      fields { }
-      belongs_to :category, index: false
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :category_id, :integer, limit: 8, null: false
-
-        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
-      EOS
-    )
-
-    Advert.field_specs.delete(:category_id)
-    Advert.index_definitions.delete_if { |spec| spec.fields == ["category_id"] }
-
-    # You can specify the index name with :index
-
-    class Category < ActiveRecord::Base; end
-    class Advert < ActiveRecord::Base
-      fields { }
-      belongs_to :category, index: 'my_index'
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :category_id, :integer, limit: 8, null: false
-
-        add_index :adverts, [:category_id], name: 'my_index'
-
-        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
-      EOS
-    )
-
-    Advert.field_specs.delete(:category_id)
-    Advert.index_definitions.delete_if { |spec| spec.fields == ["category_id"] }
-
-    ### Timestamps and Optimimistic Locking
-
-    # `updated_at` and `created_at` can be declared with the shorthand `timestamps`.
-    # Similarly, `lock_version` can be declared with the "shorthand" `optimimistic_lock`.
-
-    class Advert < ActiveRecord::Base
-      fields do
-        timestamps
-        optimistic_lock
-      end
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :created_at, :datetime, null: true
-        add_column :adverts, :updated_at, :datetime, null: true
-        add_column :adverts, :lock_version, :integer#{lock_version_limit}, null: false, default: 1
-
-        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
-      EOS
-      .and migrate_down(<<~EOS.strip)
-        remove_column :adverts, :created_at
-        remove_column :adverts, :updated_at
-        remove_column :adverts, :lock_version
-
-        #{"remove_foreign_key(\"adverts\", name: \"on_category_id\")\n" +
-          "remove_foreign_key(\"adverts\", name: \"on_c_id\")" if defined?(Mysql2)}
-      EOS
-    )
-
-    Advert.field_specs.delete(:updated_at)
-    Advert.field_specs.delete(:created_at)
-    Advert.field_specs.delete(:lock_version)
-
-    ### Indices
-
-    # You can add an index to a field definition
-
-    class Advert < ActiveRecord::Base
-      fields do
-        title :string, index: true, limit: 250, null: true
-      end
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-
-        add_index :adverts, [:title], name: 'on_title'
-
-        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
-      EOS
-    )
-
-    Advert.index_definitions.delete_if { |spec| spec.fields==["title"] }
-
-    # You can ask for a unique index
-
-    class Advert < ActiveRecord::Base
-      fields do
-        title :string, index: true, unique: true, null: true, limit: 250
-      end
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-
-        add_index :adverts, [:title], unique: true, name: 'on_title'
-
-        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
-      EOS
-    )
-
-    Advert.index_definitions.delete_if { |spec| spec.fields == ["title"] }
-
-    # You can specify the name for the index
-
-    class Advert < ActiveRecord::Base
-      fields do
-        title :string, index: 'my_index', limit: 250, null: true
-      end
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-
-        add_index :adverts, [:title], name: 'my_index'
-
-        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
-      EOS
-    )
-
-    Advert.index_definitions.delete_if { |spec| spec.fields==["title"] }
-
-    # You can ask for an index outside of the fields block
-
-    class Advert < ActiveRecord::Base
-      index :title
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-
-        add_index :adverts, [:title], name: 'on_title'
-
-        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
-      EOS
-    )
-
-    Advert.index_definitions.delete_if { |spec| spec.fields == ["title"] }
-
-    # The available options for the index function are `:unique` and `:name`
-
-    class Advert < ActiveRecord::Base
-      index :title, unique: true, name: 'my_index'
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-
-        add_index :adverts, [:title], unique: true, name: 'my_index'
-
-        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
-      EOS
-    )
-
-    Advert.index_definitions.delete_if { |spec| spec.fields == ["title"] }
-
-    # You can create an index on more than one field
-
-    class Advert < ActiveRecord::Base
-      index [:title, :category_id]
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-
-        add_index :adverts, [:title, :category_id], name: 'on_title_and_category_id'
-
-        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
-      EOS
-    )
-
-    Advert.index_definitions.delete_if { |spec| spec.fields==["title", "category_id"] }
-
-    # Finally, you can specify that the migration generator should completely ignore an
-    # index by passing its name to ignore_index in the model.
-    # This is helpful for preserving indices that can't be automatically generated, such as prefix indices in MySQL.
-
-    ### Rename a table
-
-    # The migration generator respects the `set_table_name` declaration, although as before, we need to explicitly tell the generator that we want a rename rather than a create and a drop.
-
-    class Advert < ActiveRecord::Base
-      self.table_name = "ads"
-      fields do
-        title :string, limit: 250, null: true
-        body :text, null: true
-      end
-    end
-
-    Advert.connection.schema_cache.clear!
-    Advert.reset_column_information
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run("adverts" => "ads")).to(
-      migrate_up(<<~EOS.strip)
-        rename_table :adverts, :ads
-
-        add_column :ads, :title, :string, limit: 250, null: true#{charset_and_collation}
-        add_column :ads, :body, :text#{', limit: 4294967295' if defined?(Mysql2)}, null: true#{charset_and_collation}
-
-        #{if defined?(SQLite3)
-            "add_index :ads, [:id], unique: true, name: 'PRIMARY'\n"
-          elsif defined?(Mysql2)
-            "execute \"ALTER TABLE ads DROP PRIMARY KEY, ADD PRIMARY KEY (id)\"\n\n" +
-            "add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
-            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")"
-          end}
-      EOS
-      .and migrate_down(<<~EOS.strip)
-        remove_column :ads, :title
-        remove_column :ads, :body
-
-        rename_table :ads, :adverts
-
-        #{if defined?(SQLite3)
-            "add_index :adverts, [:id], unique: true, name: 'PRIMARY'\n"
-          elsif defined?(Mysql2)
-            "execute \"ALTER TABLE adverts DROP PRIMARY KEY, ADD PRIMARY KEY (id)\"\n\n" +
-            "remove_foreign_key(\"adverts\", name: \"on_category_id\")\n" +
-            "remove_foreign_key(\"adverts\", name: \"on_c_id\")"
-          end}
-      EOS
-    )
-
-    # Set the table name back to what it should be and confirm we're in sync:
-
-    nuke_model_class(Advert)
-
-    class Advert < ActiveRecord::Base
-      self.table_name = "adverts"
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to eq(["", ""])
-
-    ### Rename a table
-
-    # As with renaming columns, we have to tell the migration generator about the rename. Here we create a new class 'Advertisement', and tell ActiveRecord to forget about the Advert class. This requires code that shouldn't be shown to impressionable children.
-
-    nuke_model_class(Advert)
-
-    class Advertisement < ActiveRecord::Base
-      fields do
-        title :string, limit: 250, null: true
-        body :text, null: true
-      end
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run("adverts" => "advertisements")).to(
-      migrate_up(<<~EOS.strip)
-        rename_table :adverts, :advertisements
-
-        add_column :advertisements, :title, :string, limit: 250, null: true#{charset_and_collation}
-        add_column :advertisements, :body, :text#{', limit: 4294967295' if defined?(Mysql2)}, null: true#{charset_and_collation}
-        remove_column :advertisements, :name
-
-        #{if defined?(SQLite3)
-            "add_index :advertisements, [:id], unique: true, name: 'PRIMARY'"
-          elsif defined?(Mysql2)
-            "execute \"ALTER TABLE advertisements DROP PRIMARY KEY, ADD PRIMARY KEY (id)\""
-          end}
-      EOS
-      .and migrate_down(<<~EOS.strip)
-        remove_column :advertisements, :title
-        remove_column :advertisements, :body
-        add_column :adverts, :name, :string, limit: 250, null: true#{charset_and_collation}
-
-        rename_table :advertisements, :adverts
-
-        #{if defined?(SQLite3)
-            "add_index :adverts, [:id], unique: true, name: 'PRIMARY'"
-          elsif defined?(Mysql2)
-            "execute \"ALTER TABLE adverts DROP PRIMARY KEY, ADD PRIMARY KEY (id)\""
-          end}
-      EOS
-    )
-
-    ### Drop a table
-
-    nuke_model_class(Advertisement)
-
-    # If you delete a model, the migration generator will create a `drop_table` migration.
-
-    # Dropping tables is where the automatic down-migration really comes in handy:
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        drop_table :adverts
-      EOS
-      .and migrate_down(<<~EOS.strip)
-        create_table "adverts"#{table_options}, force: :cascade do |t|
-          t.string "name", limit: 250#{charset_and_collation}
-        end
-      EOS
-    )
-
-    ## STI
-
-    ### Adding an STI subclass
-
-    # Adding a subclass or two should introduce the 'type' column and no other changes
-
-    class Advert < ActiveRecord::Base
-      fields do
-        body :text, null: true
-        title :string, default: "Untitled", limit: 250, null: true
-      end
-    end
-    up = Generators::DeclareSchema::Migration::Migrator.run.first
-    ActiveRecord::Migration.class_eval(up)
-
-    class FancyAdvert < Advert
-    end
-    class SuperFancyAdvert < FancyAdvert
-    end
-
-    up, _ = Generators::DeclareSchema::Migration::Migrator.run do |migrations|
-      expect(migrations).to(
-        migrate_up(<<~EOS.strip)
-          add_column :adverts, :type, :string, limit: 250, null: true#{charset_and_collation}
-
-          add_index :adverts, [:type], name: 'on_type'
-        EOS
-        .and migrate_down(<<~EOS.strip)
-          remove_column :adverts, :type
-
-          remove_index :adverts, name: :on_type rescue ActiveRecord::StatementInvalid
-        EOS
-      )
-    end
-
-    Advert.field_specs.delete(:type)
-    nuke_model_class(SuperFancyAdvert)
-    nuke_model_class(FancyAdvert)
-    Advert.index_definitions.delete_if { |spec| spec.fields==["type"] }
-
-    ## Coping with multiple changes
-
-    # The migration generator is designed to create complete migrations even if many changes to the models have taken place.
-
-    # First let's confirm we're in a known state. One model, 'Advert', with a string 'title' and text 'body':
-
-    ActiveRecord::Migration.class_eval up.gsub(/.*type.*/, '')
-    Advert.connection.schema_cache.clear!
-    Advert.reset_column_information
-
-    expect(Advert.connection.tables - Generators::DeclareSchema::Migration::Migrator.always_ignore_tables).
-      to eq(["adverts"])
-    expect(Advert.columns.map(&:name).sort).to eq(["body", "id", "title"])
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to eq(["", ""])
-
-
-    ### Rename a column and change the default
-
-    Advert.field_specs.clear
-
-    class Advert < ActiveRecord::Base
-      fields do
-        name :string, default: "No Name", limit: 250, null: true
-        body :text, null: true
-      end
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: { title: :name })).to(
-      migrate_up(<<~EOS.strip)
-        rename_column :adverts, :title, :name
-        change_column :adverts, :name, :string, limit: 250, null: true, default: "No Name"#{charset_and_collation}
-      EOS
-      .and migrate_down(<<~EOS.strip)
-        rename_column :adverts, :name, :title
-        change_column :adverts, :title, :string, limit: 250, null: true, default: "Untitled"#{charset_and_collation}
-      EOS
-    )
-
-    ### Rename a table and add a column
-
-    nuke_model_class(Advert)
-    class Ad < ActiveRecord::Base
-      fields do
-        title      :string, default: "Untitled", limit: 250
-        body       :text, null: true
-        created_at :datetime
-      end
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: :ads)).to(
-      migrate_up(<<~EOS.strip)
-        rename_table :adverts, :ads
-
-        add_column :ads, :created_at, :datetime, null: false
-        change_column :ads, :title, :string, limit: 250, null: false, default: \"Untitled\"#{charset_and_collation}
-
-        #{if defined?(SQLite3)
-            "add_index :ads, [:id], unique: true, name: 'PRIMARY'"
-          elsif defined?(Mysql2)
-            'execute "ALTER TABLE ads DROP PRIMARY KEY, ADD PRIMARY KEY (id)"'
-          end}
-      EOS
-    )
-
-    class Advert < ActiveRecord::Base
-      fields do
-        body :text, null: true
-        title :string, default: "Untitled", limit: 250, null: true
-      end
-    end
-
-    ## Legacy Keys
-
-    # DeclareSchema has some support for legacy keys.
-
-    nuke_model_class(Ad)
-
-    class Advert < ActiveRecord::Base
-      fields do
-        body :text, null: true
-      end
-      self.primary_key = "advert_id"
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: { id: :advert_id })).to(
-      migrate_up(<<~EOS.strip)
-        rename_column :adverts, :id, :advert_id
-
-        #{if defined?(SQLite3)
-            "add_index :adverts, [:advert_id], unique: true, name: 'PRIMARY'"
-          elsif defined?(Mysql2)
-          'execute "ALTER TABLE adverts DROP PRIMARY KEY, ADD PRIMARY KEY (advert_id)"'
-          end}
-      EOS
-    )
-
-    nuke_model_class(Advert)
-    ActiveRecord::Base.connection.execute("drop table `adverts`;")
-
-    ## DSL
-
-    # The DSL allows lambdas and constants
-
-    class User < ActiveRecord::Base
-      fields do
-        company :string, limit: 250, ruby_default: -> { "BigCorp" }
-      end
-    end
-    expect(User.field_specs.keys).to eq(['company'])
-    expect(User.field_specs['company'].options[:ruby_default]&.call).to eq("BigCorp")
-
-    ## validates
-
-    # DeclareSchema can accept a validates hash in the field options.
-
-    class Ad < ActiveRecord::Base
-      class << self
-        def validates(field_name, options)
-        end
-      end
-    end
-    expect(Ad).to receive(:validates).with(:company, presence: true, uniqueness: { case_sensitive: false })
-    class Ad < ActiveRecord::Base
-      fields do
-        company :string, limit: 250, index: true, unique: true, validates: { presence: true, uniqueness: { case_sensitive: false } }
-      end
-      self.primary_key = "advert_id"
-    end
-    up, _down = Generators::DeclareSchema::Migration::Migrator.run
-    ActiveRecord::Migration.class_eval(up)
-    expect(Ad.field_specs['company'].options[:validates].inspect).to eq("{:presence=>true, :uniqueness=>{:case_sensitive=>false}}")
-  end
-
-  describe 'serialize' do
-    before do
-      class Ad < ActiveRecord::Base
-        @serialize_args = []
-
-        class << self
-          attr_reader :serialize_args
-
-          def serialize(*args)
-            @serialize_args << args
-          end
-        end
-      end
-    end
-
-    describe 'untyped' do
-      it 'allows serialize: true' do
-        class Ad < ActiveRecord::Base
-          fields do
-            allow_list :text, limit: 0xFFFF, serialize: true
+            description :text, limit: 250
           end
         end
 
-        expect(Ad.serialize_args).to eq([[:allow_list]])
-      end
+        expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+          migrate_up(<<~EOS.strip)
+            add_column :adverts, :notes, :text, limit: 4294967295, null: false#{charset_and_collation}
+            add_column :adverts, :description, :text, limit: 255, null: false#{charset_and_collation}
+          EOS
+        )
 
-      it 'converts defaults with .to_yaml' do
-        class Ad < ActiveRecord::Base
-          fields do
-            allow_list :string, limit: 250, serialize: true, null: true, default: []
-            allow_hash :string, limit: 250, serialize: true, null: true, default: {}
-            allow_string :string, limit: 250, serialize: true, null: true, default: ['abc']
-            allow_null :string, limit: 250, serialize: true, null: true, default: nil
+        Advert.field_specs.delete :notes
+
+        # Limits that are too high for MySQL will raise an exception.
+
+        expect do
+          class Advert < ActiveRecord::Base
+            fields do
+              notes :text
+              description :text, limit: 0x1_0000_0000
+            end
           end
-        end
+        end.to raise_exception(ArgumentError, "limit of 4294967296 is too large for MySQL")
 
-        expect(Ad.field_specs['allow_list'].default).to eq("--- []\n")
-        expect(Ad.field_specs['allow_hash'].default).to eq("--- {}\n")
-        expect(Ad.field_specs['allow_string'].default).to eq("---\n- abc\n")
-        expect(Ad.field_specs['allow_null'].default).to eq(nil)
-      end
-    end
+        Advert.field_specs.delete :notes
 
-    describe 'Array' do
-      it 'allows serialize: Array' do
-        class Ad < ActiveRecord::Base
-          fields do
-            allow_list :string, limit: 250, serialize: Array, null: true
-          end
-        end
+        # And in MySQL, unstated text limits are treated as the maximum (LONGTEXT) limit.
 
-        expect(Ad.serialize_args).to eq([[:allow_list, Array]])
-      end
+        # To start, we'll set the database schema for `description` to match the above limit of 250.
 
-      it 'allows Array defaults' do
-        class Ad < ActiveRecord::Base
-          fields do
-            allow_list :string, limit: 250, serialize: Array, null: true, default: [2]
-            allow_string :string, limit: 250, serialize: Array, null: true, default: ['abc']
-            allow_empty :string, limit: 250, serialize: Array, null: true, default: []
-            allow_null :string, limit: 250, serialize: Array, null: true, default: nil
-          end
-        end
+        Advert.connection.execute "ALTER TABLE adverts ADD COLUMN description TINYTEXT"
+        Advert.connection.schema_cache.clear!
+        Advert.reset_column_information
+        expect(Advert.connection.tables - Generators::DeclareSchema::Migration::Migrator.always_ignore_tables).
+          to eq(["adverts"])
+        expect(Advert.columns.map(&:name)).to eq(["id", "body", "title", "description"])
 
-        expect(Ad.field_specs['allow_list'].default).to eq("---\n- 2\n")
-        expect(Ad.field_specs['allow_string'].default).to eq("---\n- abc\n")
-        expect(Ad.field_specs['allow_empty'].default).to eq(nil)
-        expect(Ad.field_specs['allow_null'].default).to eq(nil)
-      end
-    end
-
-    describe 'Hash' do
-      it 'allows serialize: Hash' do
-        class Ad < ActiveRecord::Base
-          fields do
-            allow_list :string, limit: 250, serialize: Hash, null: true
-          end
-        end
-
-        expect(Ad.serialize_args).to eq([[:allow_list, Hash]])
-      end
-
-      it 'allows Hash defaults' do
-        class Ad < ActiveRecord::Base
-          fields do
-            allow_loc :string, limit: 250, serialize: Hash, null: true, default: { 'state' => 'CA' }
-            allow_hash :string, limit: 250, serialize: Hash, null: true, default: {}
-            allow_null :string, limit: 250, serialize: Hash, null: true, default: nil
-          end
-        end
-
-        expect(Ad.field_specs['allow_loc'].default).to eq("---\nstate: CA\n")
-        expect(Ad.field_specs['allow_hash'].default).to eq(nil)
-        expect(Ad.field_specs['allow_null'].default).to eq(nil)
-      end
-    end
-
-    describe 'JSON' do
-      it 'allows serialize: JSON' do
-        class Ad < ActiveRecord::Base
-          fields do
-            allow_list :string, limit: 250, serialize: JSON
-          end
-        end
-
-        expect(Ad.serialize_args).to eq([[:allow_list, JSON]])
-      end
-
-      it 'allows JSON defaults' do
-        class Ad < ActiveRecord::Base
-          fields do
-            allow_hash :string, limit: 250, serialize: JSON, null: true, default: { 'state' => 'CA' }
-            allow_empty_array :string, limit: 250, serialize: JSON, null: true, default: []
-            allow_empty_hash :string, limit: 250, serialize: JSON, null: true, default: {}
-            allow_null :string, limit: 250, serialize: JSON, null: true, default: nil
-          end
-        end
-
-        expect(Ad.field_specs['allow_hash'].default).to eq("{\"state\":\"CA\"}")
-        expect(Ad.field_specs['allow_empty_array'].default).to eq("[]")
-        expect(Ad.field_specs['allow_empty_hash'].default).to eq("{}")
-        expect(Ad.field_specs['allow_null'].default).to eq(nil)
-      end
-    end
-
-    class ValueClass
-      delegate :present?, :inspect, to: :@value
-
-      def initialize(value)
-        @value = value
-      end
-
-      class << self
-        def dump(object)
-          if object&.present?
-            object.inspect
-          end
-        end
-
-        def load(serialized)
-          if serialized
-            raise 'not used ???'
-          end
-        end
-      end
-    end
-
-    describe 'custom coder' do
-      it 'allows serialize: ValueClass' do
-        class Ad < ActiveRecord::Base
-          fields do
-            allow_list :string, limit: 250, serialize: ValueClass
-          end
-        end
-
-        expect(Ad.serialize_args).to eq([[:allow_list, ValueClass]])
-      end
-
-      it 'allows ValueClass defaults' do
-        class Ad < ActiveRecord::Base
-          fields do
-            allow_hash :string, limit: 250, serialize: ValueClass, null: true, default: ValueClass.new([2])
-            allow_empty_array :string, limit: 250, serialize: ValueClass, null: true, default: ValueClass.new([])
-            allow_null :string, limit: 250, serialize: ValueClass, null: true, default: nil
-          end
-        end
-
-        expect(Ad.field_specs['allow_hash'].default).to eq("[2]")
-        expect(Ad.field_specs['allow_empty_array'].default).to eq(nil)
-        expect(Ad.field_specs['allow_null'].default).to eq(nil)
-      end
-    end
-
-    it 'disallows serialize: with a non-string column type' do
-      expect do
-        class Ad < ActiveRecord::Base
-          fields do
-            allow_list :integer, limit: 8, serialize: true
-          end
-        end
-      end.to raise_exception(ArgumentError, /must be :string or :text/)
-    end
-  end
-
-  context "for Rails #{Rails::VERSION::MAJOR}" do
-    if Rails::VERSION::MAJOR >= 5
-      let(:optional_true) { { optional: true } }
-      let(:optional_false) { { optional: false } }
-    else
-      let(:optional_true) { {} }
-      let(:optional_false) { {} }
-    end
-    let(:optional_flag) { { false => optional_false, true => optional_true } }
-
-    describe 'belongs_to' do
-      before do
-        unless defined?(AdCategory)
-          class AdCategory < ActiveRecord::Base
-            fields { }
-          end
-        end
+        # Now migrate to an unstated text limit:
 
         class Advert < ActiveRecord::Base
           fields do
-            name :string, limit: 250, null: true
-            category_id :integer, limit: 8
-            nullable_category_id :integer, limit: 8, null: true
+            description :text
           end
         end
-        up = Generators::DeclareSchema::Migration::Migrator.run.first
-        ActiveRecord::Migration.class_eval(up)
-      end
 
-      it 'passes through optional: when given' do
-        class AdvertBelongsTo < ActiveRecord::Base
-          self.table_name = 'adverts'
-          fields { }
-          reset_column_information
-          belongs_to :ad_category, optional: true
+        expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+          migrate_up(<<~EOS.strip)
+            change_column :adverts, :description, :text, limit: 4294967295, null: false#{charset_and_collation}
+          EOS
+          .and migrate_down(<<~EOS.strip)
+            change_column :adverts, :description, :text#{', limit: 255' if defined?(Mysql2)}, null: true#{charset_and_collation}
+          EOS
+        )
+
+        # And migrate to a stated text limit that is the same as the unstated one:
+
+        class Advert < ActiveRecord::Base
+          fields do
+            description :text, limit: 0xffffffff
+          end
         end
-        expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_true)
+
+        expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+          migrate_up(<<~EOS.strip)
+            change_column :adverts, :description, :text, limit: 4294967295, null: false#{charset_and_collation}
+          EOS
+          .and migrate_down(<<~EOS.strip)
+            change_column :adverts, :description, :text#{', limit: 255' if defined?(Mysql2)}, null: true#{charset_and_collation}
+          EOS
+        )
       end
 
-      describe 'contradictory settings' do # contradictory settings are ok--for example, during migration
-        it 'passes through optional: true, null: false' do
+      Advert.field_specs.clear
+      Advert.connection.schema_cache.clear!
+      Advert.reset_column_information
+      class Advert < ActiveRecord::Base
+        fields do
+          name :string, limit: 250, null: true
+        end
+      end
+
+      up = Generators::DeclareSchema::Migration::Migrator.run.first
+      ActiveRecord::Migration.class_eval up
+
+      Advert.connection.schema_cache.clear!
+      Advert.reset_column_information
+
+      ### Foreign Keys
+
+      # DeclareSchema extends the `belongs_to` macro so that it also declares the
+      # foreign-key field.  It also generates an index on the field.
+
+      class Category < ActiveRecord::Base; end
+      class Advert < ActiveRecord::Base
+        fields do
+          name :string, limit: 250, null: true
+        end
+        belongs_to :category
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :category_id, :integer, limit: 8, null: false
+
+          add_index :adverts, [:category_id], name: 'on_category_id'
+
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" if defined?(Mysql2)}
+        EOS
+        .and migrate_down(<<~EOS.strip)
+          remove_column :adverts, :category_id
+
+          remove_index :adverts, name: :on_category_id rescue ActiveRecord::StatementInvalid
+
+          #{"remove_foreign_key(\"adverts\", name: \"on_category_id\")\n" if defined?(Mysql2)}
+        EOS
+      )
+
+      Advert.field_specs.delete(:category_id)
+      Advert.index_definitions.delete_if { |spec| spec.fields==["category_id"] }
+
+      # If you specify a custom foreign key, the migration generator observes that:
+
+      class Category < ActiveRecord::Base; end
+      class Advert < ActiveRecord::Base
+        fields { }
+        belongs_to :category, foreign_key: "c_id", class_name: 'Category'
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :c_id, :integer, limit: 8, null: false
+
+          add_index :adverts, [:c_id], name: 'on_c_id'
+
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
+            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
+        EOS
+      )
+
+      Advert.field_specs.delete(:c_id)
+      Advert.index_definitions.delete_if { |spec| spec.fields == ["c_id"] }
+
+      # You can avoid generating the index by specifying `index: false`
+
+      class Category < ActiveRecord::Base; end
+      class Advert < ActiveRecord::Base
+        fields { }
+        belongs_to :category, index: false
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :category_id, :integer, limit: 8, null: false
+
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
+            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
+        EOS
+      )
+
+      Advert.field_specs.delete(:category_id)
+      Advert.index_definitions.delete_if { |spec| spec.fields == ["category_id"] }
+
+      # You can specify the index name with :index
+
+      class Category < ActiveRecord::Base; end
+      class Advert < ActiveRecord::Base
+        fields { }
+        belongs_to :category, index: 'my_index'
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :category_id, :integer, limit: 8, null: false
+
+          add_index :adverts, [:category_id], name: 'my_index'
+
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
+            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
+        EOS
+      )
+
+      Advert.field_specs.delete(:category_id)
+      Advert.index_definitions.delete_if { |spec| spec.fields == ["category_id"] }
+
+      ### Timestamps and Optimimistic Locking
+
+      # `updated_at` and `created_at` can be declared with the shorthand `timestamps`.
+      # Similarly, `lock_version` can be declared with the "shorthand" `optimimistic_lock`.
+
+      class Advert < ActiveRecord::Base
+        fields do
+          timestamps
+          optimistic_lock
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :created_at, :datetime, null: true
+          add_column :adverts, :updated_at, :datetime, null: true
+          add_column :adverts, :lock_version, :integer#{lock_version_limit}, null: false, default: 1
+  
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
+            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
+        EOS
+        .and migrate_down(<<~EOS.strip)
+          remove_column :adverts, :created_at
+          remove_column :adverts, :updated_at
+          remove_column :adverts, :lock_version
+
+          #{"remove_foreign_key(\"adverts\", name: \"on_category_id\")\n" +
+            "remove_foreign_key(\"adverts\", name: \"on_c_id\")" if defined?(Mysql2)}
+        EOS
+      )
+
+      Advert.field_specs.delete(:updated_at)
+      Advert.field_specs.delete(:created_at)
+      Advert.field_specs.delete(:lock_version)
+
+      ### Indices
+
+      # You can add an index to a field definition
+
+      class Advert < ActiveRecord::Base
+        fields do
+          title :string, index: true, limit: 250, null: true
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+
+          add_index :adverts, [:title], name: 'on_title'
+
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
+            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
+        EOS
+      )
+
+      Advert.index_definitions.delete_if { |spec| spec.fields==["title"] }
+
+      # You can ask for a unique index
+
+      class Advert < ActiveRecord::Base
+        fields do
+          title :string, index: true, unique: true, null: true, limit: 250
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+
+          add_index :adverts, [:title], unique: true, name: 'on_title'
+
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
+            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
+        EOS
+      )
+
+      Advert.index_definitions.delete_if { |spec| spec.fields == ["title"] }
+
+      # You can specify the name for the index
+
+      class Advert < ActiveRecord::Base
+        fields do
+          title :string, index: 'my_index', limit: 250, null: true
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+
+          add_index :adverts, [:title], name: 'my_index'
+
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
+            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
+        EOS
+      )
+
+      Advert.index_definitions.delete_if { |spec| spec.fields==["title"] }
+
+      # You can ask for an index outside of the fields block
+
+      class Advert < ActiveRecord::Base
+        index :title
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+
+          add_index :adverts, [:title], name: 'on_title'
+
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
+            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
+        EOS
+      )
+
+      Advert.index_definitions.delete_if { |spec| spec.fields == ["title"] }
+
+      # The available options for the index function are `:unique` and `:name`
+
+      class Advert < ActiveRecord::Base
+        index :title, unique: true, name: 'my_index'
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+
+          add_index :adverts, [:title], unique: true, name: 'my_index'
+
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
+            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
+        EOS
+      )
+
+      Advert.index_definitions.delete_if { |spec| spec.fields == ["title"] }
+
+      # You can create an index on more than one field
+
+      class Advert < ActiveRecord::Base
+        index [:title, :category_id]
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+
+          add_index :adverts, [:title, :category_id], name: 'on_title_and_category_id'
+
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
+            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
+        EOS
+      )
+
+      Advert.index_definitions.delete_if { |spec| spec.fields==["title", "category_id"] }
+
+      # Finally, you can specify that the migration generator should completely ignore an
+      # index by passing its name to ignore_index in the model.
+      # This is helpful for preserving indices that can't be automatically generated, such as prefix indices in MySQL.
+
+      ### Rename a table
+
+      # The migration generator respects the `set_table_name` declaration, although as before, we need to explicitly tell the generator that we want a rename rather than a create and a drop.
+
+      class Advert < ActiveRecord::Base
+        self.table_name = "ads"
+        fields do
+          title :string, limit: 250, null: true
+          body :text, null: true
+        end
+      end
+
+      Advert.connection.schema_cache.clear!
+      Advert.reset_column_information
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run("adverts" => "ads")).to(
+        migrate_up(<<~EOS.strip)
+          rename_table :adverts, :ads
+
+          add_column :ads, :title, :string, limit: 250, null: true#{charset_and_collation}
+          add_column :ads, :body, :text#{', limit: 4294967295' if defined?(Mysql2)}, null: true#{charset_and_collation}
+
+          #{if defined?(SQLite3)
+              "add_index :ads, [:id], unique: true, name: 'PRIMARY'\n"
+            elsif defined?(Mysql2)
+              "execute \"ALTER TABLE ads DROP PRIMARY KEY, ADD PRIMARY KEY (id)\"\n\n" +
+              "add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
+              "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")"
+            end}
+        EOS
+        .and migrate_down(<<~EOS.strip)
+          remove_column :ads, :title
+          remove_column :ads, :body
+
+          rename_table :ads, :adverts
+
+          #{if defined?(SQLite3)
+              "add_index :adverts, [:id], unique: true, name: 'PRIMARY'\n"
+            elsif defined?(Mysql2)
+              "execute \"ALTER TABLE adverts DROP PRIMARY KEY, ADD PRIMARY KEY (id)\"\n\n" +
+              "remove_foreign_key(\"adverts\", name: \"on_category_id\")\n" +
+              "remove_foreign_key(\"adverts\", name: \"on_c_id\")"
+            end}
+        EOS
+      )
+
+      # Set the table name back to what it should be and confirm we're in sync:
+
+      nuke_model_class(Advert)
+
+      class Advert < ActiveRecord::Base
+        self.table_name = "adverts"
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to eq(["", ""])
+
+      ### Rename a table
+
+      # As with renaming columns, we have to tell the migration generator about the rename. Here we create a new class 'Advertisement', and tell ActiveRecord to forget about the Advert class. This requires code that shouldn't be shown to impressionable children.
+
+      nuke_model_class(Advert)
+
+      class Advertisement < ActiveRecord::Base
+        fields do
+          title :string, limit: 250, null: true
+          body :text, null: true
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run("adverts" => "advertisements")).to(
+        migrate_up(<<~EOS.strip)
+          rename_table :adverts, :advertisements
+
+          add_column :advertisements, :title, :string, limit: 250, null: true#{charset_and_collation}
+          add_column :advertisements, :body, :text#{', limit: 4294967295' if defined?(Mysql2)}, null: true#{charset_and_collation}
+          remove_column :advertisements, :name
+
+          #{if defined?(SQLite3)
+              "add_index :advertisements, [:id], unique: true, name: 'PRIMARY'"
+            elsif defined?(Mysql2)
+              "execute \"ALTER TABLE advertisements DROP PRIMARY KEY, ADD PRIMARY KEY (id)\""
+            end}
+        EOS
+        .and migrate_down(<<~EOS.strip)
+          remove_column :advertisements, :title
+          remove_column :advertisements, :body
+          add_column :adverts, :name, :string, limit: 250, null: true#{charset_and_collation}
+
+          rename_table :advertisements, :adverts
+
+          #{if defined?(SQLite3)
+              "add_index :adverts, [:id], unique: true, name: 'PRIMARY'"
+            elsif defined?(Mysql2)
+              "execute \"ALTER TABLE adverts DROP PRIMARY KEY, ADD PRIMARY KEY (id)\""
+            end}
+        EOS
+      )
+
+      ### Drop a table
+
+      nuke_model_class(Advertisement)
+
+      # If you delete a model, the migration generator will create a `drop_table` migration.
+
+      # Dropping tables is where the automatic down-migration really comes in handy:
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          drop_table :adverts
+        EOS
+        .and migrate_down(<<~EOS.strip)
+          create_table "adverts"#{table_options}, force: :cascade do |t|
+            t.string "name", limit: 250#{charset_and_collation}
+          end
+        EOS
+      )
+
+      ## STI
+
+      ### Adding an STI subclass
+
+      # Adding a subclass or two should introduce the 'type' column and no other changes
+
+      class Advert < ActiveRecord::Base
+        fields do
+          body :text, null: true
+          title :string, default: "Untitled", limit: 250, null: true
+        end
+      end
+      up = Generators::DeclareSchema::Migration::Migrator.run.first
+      ActiveRecord::Migration.class_eval(up)
+
+      class FancyAdvert < Advert
+      end
+      class SuperFancyAdvert < FancyAdvert
+      end
+
+      up, _ = Generators::DeclareSchema::Migration::Migrator.run do |migrations|
+        expect(migrations).to(
+          migrate_up(<<~EOS.strip)
+            add_column :adverts, :type, :string, limit: 250, null: true#{charset_and_collation}
+
+            add_index :adverts, [:type], name: 'on_type'
+          EOS
+          .and migrate_down(<<~EOS.strip)
+            remove_column :adverts, :type
+
+            remove_index :adverts, name: :on_type rescue ActiveRecord::StatementInvalid
+          EOS
+        )
+      end
+
+      Advert.field_specs.delete(:type)
+      nuke_model_class(SuperFancyAdvert)
+      nuke_model_class(FancyAdvert)
+      Advert.index_definitions.delete_if { |spec| spec.fields==["type"] }
+
+      ## Coping with multiple changes
+
+      # The migration generator is designed to create complete migrations even if many changes to the models have taken place.
+
+      # First let's confirm we're in a known state. One model, 'Advert', with a string 'title' and text 'body':
+
+      ActiveRecord::Migration.class_eval up.gsub(/.*type.*/, '')
+      Advert.connection.schema_cache.clear!
+      Advert.reset_column_information
+
+      expect(Advert.connection.tables - Generators::DeclareSchema::Migration::Migrator.always_ignore_tables).
+        to eq(["adverts"])
+      expect(Advert.columns.map(&:name).sort).to eq(["body", "id", "title"])
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to eq(["", ""])
+
+
+      ### Rename a column and change the default
+
+      Advert.field_specs.clear
+
+      class Advert < ActiveRecord::Base
+        fields do
+          name :string, default: "No Name", limit: 250, null: true
+          body :text, null: true
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: { title: :name })).to(
+        migrate_up(<<~EOS.strip)
+          rename_column :adverts, :title, :name
+          change_column :adverts, :name, :string, limit: 250, null: true, default: "No Name"#{charset_and_collation}
+        EOS
+        .and migrate_down(<<~EOS.strip)
+          rename_column :adverts, :name, :title
+          change_column :adverts, :title, :string, limit: 250, null: true, default: "Untitled"#{charset_and_collation}
+        EOS
+      )
+
+      ### Rename a table and add a column
+
+      nuke_model_class(Advert)
+      class Ad < ActiveRecord::Base
+        fields do
+          title      :string, default: "Untitled", limit: 250
+          body       :text, null: true
+          created_at :datetime
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: :ads)).to(
+        migrate_up(<<~EOS.strip)
+          rename_table :adverts, :ads
+
+          add_column :ads, :created_at, :datetime, null: false
+          change_column :ads, :title, :string, limit: 250, null: false, default: \"Untitled\"#{charset_and_collation}
+
+          #{if defined?(SQLite3)
+              "add_index :ads, [:id], unique: true, name: 'PRIMARY'"
+            elsif defined?(Mysql2)
+              'execute "ALTER TABLE ads DROP PRIMARY KEY, ADD PRIMARY KEY (id)"'
+            end}
+        EOS
+      )
+
+      class Advert < ActiveRecord::Base
+        fields do
+          body :text, null: true
+          title :string, default: "Untitled", limit: 250, null: true
+        end
+      end
+
+      ## Legacy Keys
+
+      # DeclareSchema has some support for legacy keys.
+
+      nuke_model_class(Ad)
+
+      class Advert < ActiveRecord::Base
+        fields do
+          body :text, null: true
+        end
+        self.primary_key = "advert_id"
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: { id: :advert_id })).to(
+        migrate_up(<<~EOS.strip)
+          rename_column :adverts, :id, :advert_id
+
+          #{if defined?(SQLite3)
+              "add_index :adverts, [:advert_id], unique: true, name: 'PRIMARY'"
+            elsif defined?(Mysql2)
+            'execute "ALTER TABLE adverts DROP PRIMARY KEY, ADD PRIMARY KEY (advert_id)"'
+            end}
+        EOS
+      )
+
+      nuke_model_class(Advert)
+      ActiveRecord::Base.connection.execute("drop table `adverts`;")
+
+      ## DSL
+
+      # The DSL allows lambdas and constants
+
+      class User < ActiveRecord::Base
+        fields do
+          company :string, limit: 250, ruby_default: -> { "BigCorp" }
+        end
+      end
+      expect(User.field_specs.keys).to eq(['company'])
+      expect(User.field_specs['company'].options[:ruby_default]&.call).to eq("BigCorp")
+
+      ## validates
+
+      # DeclareSchema can accept a validates hash in the field options.
+
+      class Ad < ActiveRecord::Base
+        class << self
+          def validates(field_name, options)
+          end
+        end
+      end
+      expect(Ad).to receive(:validates).with(:company, presence: true, uniqueness: { case_sensitive: false })
+      class Ad < ActiveRecord::Base
+        fields do
+          company :string, limit: 250, index: true, unique: true, validates: { presence: true, uniqueness: { case_sensitive: false } }
+        end
+        self.primary_key = "advert_id"
+      end
+      up, _down = Generators::DeclareSchema::Migration::Migrator.run
+      ActiveRecord::Migration.class_eval(up)
+      expect(Ad.field_specs['company'].options[:validates].inspect).to eq("{:presence=>true, :uniqueness=>{:case_sensitive=>false}}")
+    end
+
+    describe 'serialize' do
+      before do
+        class Ad < ActiveRecord::Base
+          @serialize_args = []
+
+          class << self
+            attr_reader :serialize_args
+
+            def serialize(*args)
+              @serialize_args << args
+            end
+          end
+        end
+      end
+
+      describe 'untyped' do
+        it 'allows serialize: true' do
+          class Ad < ActiveRecord::Base
+            fields do
+              allow_list :text, limit: 0xFFFF, serialize: true
+            end
+          end
+
+          expect(Ad.serialize_args).to eq([[:allow_list]])
+        end
+
+        it 'converts defaults with .to_yaml' do
+          class Ad < ActiveRecord::Base
+            fields do
+              allow_list :string, limit: 250, serialize: true, null: true, default: []
+              allow_hash :string, limit: 250, serialize: true, null: true, default: {}
+              allow_string :string, limit: 250, serialize: true, null: true, default: ['abc']
+              allow_null :string, limit: 250, serialize: true, null: true, default: nil
+            end
+          end
+
+          expect(Ad.field_specs['allow_list'].default).to eq("--- []\n")
+          expect(Ad.field_specs['allow_hash'].default).to eq("--- {}\n")
+          expect(Ad.field_specs['allow_string'].default).to eq("---\n- abc\n")
+          expect(Ad.field_specs['allow_null'].default).to eq(nil)
+        end
+      end
+
+      describe 'Array' do
+        it 'allows serialize: Array' do
+          class Ad < ActiveRecord::Base
+            fields do
+              allow_list :string, limit: 250, serialize: Array, null: true
+            end
+          end
+
+          expect(Ad.serialize_args).to eq([[:allow_list, Array]])
+        end
+
+        it 'allows Array defaults' do
+          class Ad < ActiveRecord::Base
+            fields do
+              allow_list :string, limit: 250, serialize: Array, null: true, default: [2]
+              allow_string :string, limit: 250, serialize: Array, null: true, default: ['abc']
+              allow_empty :string, limit: 250, serialize: Array, null: true, default: []
+              allow_null :string, limit: 250, serialize: Array, null: true, default: nil
+            end
+          end
+
+          expect(Ad.field_specs['allow_list'].default).to eq("---\n- 2\n")
+          expect(Ad.field_specs['allow_string'].default).to eq("---\n- abc\n")
+          expect(Ad.field_specs['allow_empty'].default).to eq(nil)
+          expect(Ad.field_specs['allow_null'].default).to eq(nil)
+        end
+      end
+
+      describe 'Hash' do
+        it 'allows serialize: Hash' do
+          class Ad < ActiveRecord::Base
+            fields do
+              allow_list :string, limit: 250, serialize: Hash, null: true
+            end
+          end
+
+          expect(Ad.serialize_args).to eq([[:allow_list, Hash]])
+        end
+
+        it 'allows Hash defaults' do
+          class Ad < ActiveRecord::Base
+            fields do
+              allow_loc :string, limit: 250, serialize: Hash, null: true, default: { 'state' => 'CA' }
+              allow_hash :string, limit: 250, serialize: Hash, null: true, default: {}
+              allow_null :string, limit: 250, serialize: Hash, null: true, default: nil
+            end
+          end
+
+          expect(Ad.field_specs['allow_loc'].default).to eq("---\nstate: CA\n")
+          expect(Ad.field_specs['allow_hash'].default).to eq(nil)
+          expect(Ad.field_specs['allow_null'].default).to eq(nil)
+        end
+      end
+
+      describe 'JSON' do
+        it 'allows serialize: JSON' do
+          class Ad < ActiveRecord::Base
+            fields do
+              allow_list :string, limit: 250, serialize: JSON
+            end
+          end
+
+          expect(Ad.serialize_args).to eq([[:allow_list, JSON]])
+        end
+
+        it 'allows JSON defaults' do
+          class Ad < ActiveRecord::Base
+            fields do
+              allow_hash :string, limit: 250, serialize: JSON, null: true, default: { 'state' => 'CA' }
+              allow_empty_array :string, limit: 250, serialize: JSON, null: true, default: []
+              allow_empty_hash :string, limit: 250, serialize: JSON, null: true, default: {}
+              allow_null :string, limit: 250, serialize: JSON, null: true, default: nil
+            end
+          end
+
+          expect(Ad.field_specs['allow_hash'].default).to eq("{\"state\":\"CA\"}")
+          expect(Ad.field_specs['allow_empty_array'].default).to eq("[]")
+          expect(Ad.field_specs['allow_empty_hash'].default).to eq("{}")
+          expect(Ad.field_specs['allow_null'].default).to eq(nil)
+        end
+      end
+
+      class ValueClass
+        delegate :present?, :inspect, to: :@value
+
+        def initialize(value)
+          @value = value
+        end
+
+        class << self
+          def dump(object)
+            if object&.present?
+              object.inspect
+            end
+          end
+
+          def load(serialized)
+            if serialized
+              raise 'not used ???'
+            end
+          end
+        end
+      end
+
+      describe 'custom coder' do
+        it 'allows serialize: ValueClass' do
+          class Ad < ActiveRecord::Base
+            fields do
+              allow_list :string, limit: 250, serialize: ValueClass
+            end
+          end
+
+          expect(Ad.serialize_args).to eq([[:allow_list, ValueClass]])
+        end
+
+        it 'allows ValueClass defaults' do
+          class Ad < ActiveRecord::Base
+            fields do
+              allow_hash :string, limit: 250, serialize: ValueClass, null: true, default: ValueClass.new([2])
+              allow_empty_array :string, limit: 250, serialize: ValueClass, null: true, default: ValueClass.new([])
+              allow_null :string, limit: 250, serialize: ValueClass, null: true, default: nil
+            end
+          end
+
+          expect(Ad.field_specs['allow_hash'].default).to eq("[2]")
+          expect(Ad.field_specs['allow_empty_array'].default).to eq(nil)
+          expect(Ad.field_specs['allow_null'].default).to eq(nil)
+        end
+      end
+
+      it 'disallows serialize: with a non-string column type' do
+        expect do
+          class Ad < ActiveRecord::Base
+            fields do
+              allow_list :integer, limit: 8, serialize: true
+            end
+          end
+        end.to raise_exception(ArgumentError, /must be :string or :text/)
+      end
+    end
+
+    context "for Rails #{Rails::VERSION::MAJOR}" do
+      if Rails::VERSION::MAJOR >= 5
+        let(:optional_true) { { optional: true } }
+        let(:optional_false) { { optional: false } }
+      else
+        let(:optional_true) { {} }
+        let(:optional_false) { {} }
+      end
+      let(:optional_flag) { { false => optional_false, true => optional_true } }
+
+      describe 'belongs_to' do
+        before do
+          unless defined?(AdCategory)
+            class AdCategory < ActiveRecord::Base
+              fields { }
+            end
+          end
+
+          class Advert < ActiveRecord::Base
+            fields do
+              name :string, limit: 250, null: true
+              category_id :integer, limit: 8
+              nullable_category_id :integer, limit: 8, null: true
+            end
+          end
+          up = Generators::DeclareSchema::Migration::Migrator.run.first
+          ActiveRecord::Migration.class_eval(up)
+        end
+
+        it 'passes through optional: when given' do
           class AdvertBelongsTo < ActiveRecord::Base
             self.table_name = 'adverts'
             fields { }
             reset_column_information
-            belongs_to :ad_category, optional: true, null: false
+            belongs_to :ad_category, optional: true
           end
           expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_true)
-          expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(false)
         end
 
-        it 'passes through optional: false, null: true' do
-          class AdvertBelongsTo < ActiveRecord::Base
-            self.table_name = 'adverts'
-            fields { }
-            reset_column_information
-            belongs_to :ad_category, optional: false, null: true
+        describe 'contradictory settings' do # contradictory settings are ok--for example, during migration
+          it 'passes through optional: true, null: false' do
+            class AdvertBelongsTo < ActiveRecord::Base
+              self.table_name = 'adverts'
+              fields { }
+              reset_column_information
+              belongs_to :ad_category, optional: true, null: false
+            end
+            expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_true)
+            expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(false)
           end
-          expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_false)
-          expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(true)
+
+          it 'passes through optional: false, null: true' do
+            class AdvertBelongsTo < ActiveRecord::Base
+              self.table_name = 'adverts'
+              fields { }
+              reset_column_information
+              belongs_to :ad_category, optional: false, null: true
+            end
+            expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_false)
+            expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(true)
+          end
         end
-      end
 
-      [false, true].each do |nullable|
-        context "nullable=#{nullable}" do
-          it 'infers optional: from null:' do
-            eval <<~EOS
-              class AdvertBelongsTo < ActiveRecord::Base
-                fields { }
-                belongs_to :ad_category, null: #{nullable}
-              end
-            EOS
-            expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_flag[nullable])
-            expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(nullable)
-          end
+        [false, true].each do |nullable|
+          context "nullable=#{nullable}" do
+            it 'infers optional: from null:' do
+              eval <<~EOS
+                class AdvertBelongsTo < ActiveRecord::Base
+                  fields { }
+                  belongs_to :ad_category, null: #{nullable}
+                end
+              EOS
+              expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_flag[nullable])
+              expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(nullable)
+            end
 
-          it 'infers null: from optional:' do
-            eval <<~EOS
-              class AdvertBelongsTo < ActiveRecord::Base
-                fields { }
-                belongs_to :ad_category, optional: #{nullable}
-              end
-            EOS
-            expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_flag[nullable])
-            expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(nullable)
+            it 'infers null: from optional:' do
+              eval <<~EOS
+                class AdvertBelongsTo < ActiveRecord::Base
+                  fields { }
+                  belongs_to :ad_category, optional: #{nullable}
+                end
+              EOS
+              expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_flag[nullable])
+              expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(nullable)
+            end
           end
         end
       end
     end
-  end
 
-  describe 'migration base class' do
-    it 'adapts to Rails 4' do
-      class Advert < active_record_base_class.constantize
-        fields do
-          title :string, limit: 100
-        end
-      end
-
-      generate_migrations '-n', '-m'
-
-      migrations = Dir.glob('db/migrate/*declare_schema_migration*.rb')
-      expect(migrations.size).to eq(1), migrations.inspect
-
-      migration_content = File.read(migrations.first)
-      first_line = migration_content.split("\n").first
-      base_class = first_line.split(' < ').last
-      expect(base_class).to eq("(Rails::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration)")
-    end
-  end
-
-  context 'Does not generate migrations' do
-    it 'for aliased fields bigint -> integer limit 8' do
-      if Rails::VERSION::MAJOR >= 5 || !ActiveRecord::Base.connection.class.name.match?(/SQLite3Adapter/)
+    describe 'migration base class' do
+      it 'adapts to Rails 4' do
         class Advert < active_record_base_class.constantize
           fields do
-            price :bigint
+            title :string, limit: 100
           end
         end
 
@@ -1211,20 +1190,41 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         migrations = Dir.glob('db/migrate/*declare_schema_migration*.rb')
         expect(migrations.size).to eq(1), migrations.inspect
 
-        if defined?(Mysql2) && Rails::VERSION::MAJOR < 5
-          ActiveRecord::Base.connection.execute("ALTER TABLE adverts ADD PRIMARY KEY (id)")
-        end
-
-        class Advert < active_record_base_class.constantize
-          fields do
-            price :integer, limit: 8
-          end
-        end
-
-        expect { generate_migrations '-n', '-g' }.to output("Database and models match -- nothing to change\n").to_stdout
+        migration_content = File.read(migrations.first)
+        first_line = migration_content.split("\n").first
+        base_class = first_line.split(' < ').last
+        expect(base_class).to eq("(Rails::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration)")
       end
     end
-  end
+
+    context 'Does not generate migrations' do
+      it 'for aliased fields bigint -> integer limit 8' do
+        if Rails::VERSION::MAJOR >= 5 || !ActiveRecord::Base.connection.class.name.match?(/SQLite3Adapter/)
+          class Advert < active_record_base_class.constantize
+            fields do
+              price :bigint
+            end
+          end
+
+          generate_migrations '-n', '-m'
+
+          migrations = Dir.glob('db/migrate/*declare_schema_migration*.rb')
+          expect(migrations.size).to eq(1), migrations.inspect
+
+          if defined?(Mysql2) && Rails::VERSION::MAJOR < 5
+            ActiveRecord::Base.connection.execute("ALTER TABLE adverts ADD PRIMARY KEY (id)")
+          end
+
+          class Advert < active_record_base_class.constantize
+            fields do
+              price :integer, limit: 8
+            end
+          end
+
+          expect { generate_migrations '-n', '-g' }.to output("Database and models match -- nothing to change\n").to_stdout
+        end
+      end
+    end
   end
 
   context 'Using declare_schema' do

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -56,1132 +56,1153 @@ RSpec.describe 'DeclareSchema Migration Generator' do
   end
 
   context 'Using fields' do
-    # DeclareSchema - Migration Generator
-    it 'generates migrations' do
-      ## The migration generator -- introduction
+  # DeclareSchema - Migration Generator
+  it 'generates migrations' do
+    ## The migration generator -- introduction
 
-      expect(Generators::DeclareSchema::Migration::Migrator.run).to migrate_up("").and migrate_down("")
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to migrate_up("").and migrate_down("")
 
-      class Advert < ActiveRecord::Base
+    class Advert < ActiveRecord::Base
+    end
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to migrate_up("").and migrate_down("")
+
+    Generators::DeclareSchema::Migration::Migrator.ignore_tables = ["green_fishes"]
+
+    Advert.connection.schema_cache.clear!
+    Advert.reset_column_information
+
+    class Advert < ActiveRecord::Base
+      fields do
+        name :string, limit: 250, null: true
       end
+    end
 
-      expect(Generators::DeclareSchema::Migration::Migrator.run).to migrate_up("").and migrate_down("")
-
-      Generators::DeclareSchema::Migration::Migrator.ignore_tables = ["green_fishes"]
-
-      Advert.connection.schema_cache.clear!
-      Advert.reset_column_information
-
-      class Advert < ActiveRecord::Base
-        fields do
-          name :string, limit: 250, null: true
-        end
-      end
-
-      up, _ = Generators::DeclareSchema::Migration::Migrator.run.tap do |migrations|
-        expect(migrations).to(
-          migrate_up(<<~EOS.strip)
-            create_table :adverts, id: :bigint do |t|
-              t.string :name, limit: 250, null: true#{charset_and_collation}
-            end#{charset_alter_table}
-          EOS
-          .and migrate_down("drop_table :adverts")
-        )
-      end
-
-      ActiveRecord::Migration.class_eval(up)
-      expect(Advert.columns.map(&:name)).to eq(["id", "name"])
-
-      if Rails::VERSION::MAJOR < 5
-        # Rails 4 drivers don't always create PK properly. Fix that by dropping and recreating.
-        ActiveRecord::Base.connection.execute("drop table adverts")
-        if defined?(Mysql2)
-          ActiveRecord::Base.connection.execute("CREATE TABLE adverts (id integer PRIMARY KEY AUTO_INCREMENT NOT NULL, name varchar(250)) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin")
-        else
-          ActiveRecord::Base.connection.execute("CREATE TABLE adverts (id integer PRIMARY KEY AUTOINCREMENT  NOT NULL, name varchar(250))")
-        end
-      end
-
-      class Advert < ActiveRecord::Base
-        fields do
-          name :string, limit: 250, null: true
-          body :text, null: true
-          published_at :datetime, null: true
-        end
-      end
-
-      Advert.connection.schema_cache.clear!
-      Advert.reset_column_information
-
-      expect(migrate).to(
+    up, _ = Generators::DeclareSchema::Migration::Migrator.run.tap do |migrations|
+      expect(migrations).to(
         migrate_up(<<~EOS.strip)
-          add_column :adverts, :body, :text#{text_limit}, null: true#{charset_and_collation}
-          add_column :adverts, :published_at, :datetime, null: true
+          create_table :adverts, id: :bigint do |t|
+            t.string :name, limit: 250, null: true#{charset_and_collation}
+          end#{charset_alter_table}
         EOS
-        .and migrate_down(<<~EOS.strip)
-          remove_column :adverts, :body
-          remove_column :adverts, :published_at
-        EOS
+        .and migrate_down("drop_table :adverts")
       )
+    end
 
-      Advert.field_specs.clear # not normally needed
-      class Advert < ActiveRecord::Base
-        fields do
-          name :string, limit: 250, null: true
-          body :text, null: true
-        end
+    ActiveRecord::Migration.class_eval(up)
+    expect(Advert.columns.map(&:name)).to eq(["id", "name"])
+
+    if Rails::VERSION::MAJOR < 5
+      # Rails 4 drivers don't always create PK properly. Fix that by dropping and recreating.
+      ActiveRecord::Base.connection.execute("drop table adverts")
+      if defined?(Mysql2)
+        ActiveRecord::Base.connection.execute("CREATE TABLE adverts (id integer PRIMARY KEY AUTO_INCREMENT NOT NULL, name varchar(250)) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin")
+      else
+        ActiveRecord::Base.connection.execute("CREATE TABLE adverts (id integer PRIMARY KEY AUTOINCREMENT  NOT NULL, name varchar(250))")
       end
+    end
 
-      expect(migrate).to(
-        migrate_up("remove_column :adverts, :published_at").and(
-          migrate_down("add_column :adverts, :published_at, :datetime#{datetime_precision}, null: true")
-        )
+    class Advert < ActiveRecord::Base
+      fields do
+        name :string, limit: 250, null: true
+        body :text, null: true
+        published_at :datetime, null: true
+      end
+    end
+
+    Advert.connection.schema_cache.clear!
+    Advert.reset_column_information
+
+    expect(migrate).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :body, :text#{text_limit}, null: true#{charset_and_collation}
+        add_column :adverts, :published_at, :datetime, null: true
+      EOS
+      .and migrate_down(<<~EOS.strip)
+        remove_column :adverts, :body
+        remove_column :adverts, :published_at
+      EOS
+    )
+
+    Advert.field_specs.clear # not normally needed
+    class Advert < ActiveRecord::Base
+      fields do
+        name :string, limit: 250, null: true
+        body :text, null: true
+      end
+    end
+
+    expect(migrate).to(
+      migrate_up("remove_column :adverts, :published_at").and(
+        migrate_down("add_column :adverts, :published_at, :datetime#{datetime_precision}, null: true")
       )
+    )
 
-      nuke_model_class(Advert)
-      class Advert < ActiveRecord::Base
-        fields do
-          title :string, limit: 250, null: true
-          body :text, null: true
-        end
+    nuke_model_class(Advert)
+    class Advert < ActiveRecord::Base
+      fields do
+        title :string, limit: 250, null: true
+        body :text, null: true
       end
+    end
 
-      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-        migrate_up(<<~EOS.strip)
-          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-          remove_column :adverts, :name
-        EOS
-        .and migrate_down(<<~EOS.strip)
-          remove_column :adverts, :title
-          add_column :adverts, :name, :string, limit: 250, null: true#{charset_and_collation}
-        EOS
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+        remove_column :adverts, :name
+      EOS
+      .and migrate_down(<<~EOS.strip)
+        remove_column :adverts, :title
+        add_column :adverts, :name, :string, limit: 250, null: true#{charset_and_collation}
+      EOS
+    )
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: { name: :title })).to(
+      migrate_up("rename_column :adverts, :name, :title").and(
+        migrate_down("rename_column :adverts, :title, :name")
       )
+    )
 
-      expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: { name: :title })).to(
-        migrate_up("rename_column :adverts, :name, :title").and(
-          migrate_down("rename_column :adverts, :title, :name")
-        )
+    migrate
+
+    class Advert < ActiveRecord::Base
+      fields do
+        title :text, null: true
+        body :text, null: true
+      end
+    end
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up("change_column :adverts, :title, :text#{text_limit}, null: true#{charset_and_collation}").and(
+        migrate_down("change_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}")
       )
+    )
 
-      migrate
-
-      class Advert < ActiveRecord::Base
-        fields do
-          title :text, null: true
-          body :text, null: true
-        end
+    class Advert < ActiveRecord::Base
+      fields do
+        title :string, default: "Untitled", limit: 250, null: true
+        body :text, null: true
       end
+    end
 
-      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-        migrate_up("change_column :adverts, :title, :text#{text_limit}, null: true#{charset_and_collation}").and(
-          migrate_down("change_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}")
-        )
-      )
+    expect(migrate).to(
+      migrate_up(<<~EOS.strip)
+        change_column :adverts, :title, :string, limit: 250, null: true, default: "Untitled"#{charset_and_collation}
+      EOS
+      .and migrate_down(<<~EOS.strip)
+        change_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+      EOS
+    )
 
-      class Advert < ActiveRecord::Base
-        fields do
-          title :string, default: "Untitled", limit: 250, null: true
-          body :text, null: true
-        end
+    ### Limits
+
+    class Advert < ActiveRecord::Base
+      fields do
+        price :integer, null: true, limit: 2
       end
+    end
 
-      expect(migrate).to(
-        migrate_up(<<~EOS.strip)
-          change_column :adverts, :title, :string, limit: 250, null: true, default: "Untitled"#{charset_and_collation}
-        EOS
-        .and migrate_down(<<~EOS.strip)
-          change_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-        EOS
-      )
+    up, _ = Generators::DeclareSchema::Migration::Migrator.run.tap do |migrations|
+      expect(migrations).to migrate_up("add_column :adverts, :price, :integer, limit: 2, null: true")
+    end
 
-      ### Limits
+    # Now run the migration, then change the limit:
 
-      class Advert < ActiveRecord::Base
-        fields do
-          price :integer, null: true, limit: 2
-        end
+    ActiveRecord::Migration.class_eval(up)
+    class Advert < ActiveRecord::Base
+      fields do
+        price :integer, null: true, limit: 3
       end
+    end
 
-      up, _ = Generators::DeclareSchema::Migration::Migrator.run.tap do |migrations|
-        expect(migrations).to migrate_up("add_column :adverts, :price, :integer, limit: 2, null: true")
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        change_column :adverts, :price, :integer, limit: 3, null: true
+      EOS
+      .and migrate_down(<<~EOS.strip)
+        change_column :adverts, :price, :integer, limit: 2, null: true
+      EOS
+    )
+
+    ActiveRecord::Migration.class_eval("remove_column :adverts, :price")
+    class Advert < ActiveRecord::Base
+      fields do
+        price :decimal, precision: 4, scale: 1, null: true
       end
+    end
 
-      # Now run the migration, then change the limit:
+    # Limits are generally not needed for `text` fields, because by default, `text` fields will use the maximum size
+    # allowed for that database type (0xffffffff for LONGTEXT in MySQL unlimited in Postgres, 1 billion in Sqlite).
+    # If a `limit` is given, it will only be used in MySQL, to choose the smallest TEXT field that will accommodate
+    # that limit (0xff for TINYTEXT, 0xffff for TEXT, 0xffffff for MEDIUMTEXT, 0xffffffff for LONGTEXT).
 
-      ActiveRecord::Migration.class_eval(up)
-      class Advert < ActiveRecord::Base
-        fields do
-          price :integer, null: true, limit: 3
-        end
+    if defined?(SQLite3)
+      expect(::DeclareSchema::Model::FieldSpec.mysql_text_limits?).to be_falsey
+    end
+
+    class Advert < ActiveRecord::Base
+      fields do
+        notes :text
+        description :text, limit: 30000
       end
+    end
 
-      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-        migrate_up(<<~EOS.strip)
-          change_column :adverts, :price, :integer, limit: 3, null: true
-        EOS
-        .and migrate_down(<<~EOS.strip)
-          change_column :adverts, :price, :integer, limit: 2, null: true
-        EOS
-      )
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :price, :decimal, precision: 4, scale: 1, null: true
+        add_column :adverts, :notes, :text#{text_limit}, null: false#{charset_and_collation}
+        add_column :adverts, :description, :text#{', limit: 65535' if defined?(Mysql2)}, null: false#{charset_and_collation}
+      EOS
+    )
 
-      ActiveRecord::Migration.class_eval("remove_column :adverts, :price")
-      class Advert < ActiveRecord::Base
-        fields do
-          price :decimal, precision: 4, scale: 1, null: true
-        end
-      end
+    Advert.field_specs.delete :price
+    Advert.field_specs.delete :notes
+    Advert.field_specs.delete :description
 
-      # Limits are generally not needed for `text` fields, because by default, `text` fields will use the maximum size
-      # allowed for that database type (0xffffffff for LONGTEXT in MySQL unlimited in Postgres, 1 billion in Sqlite).
-      # If a `limit` is given, it will only be used in MySQL, to choose the smallest TEXT field that will accommodate
-      # that limit (0xff for TINYTEXT, 0xffff for TEXT, 0xffffff for MEDIUMTEXT, 0xffffffff for LONGTEXT).
+    # In MySQL, limits are applied, rounded up:
 
-      if defined?(SQLite3)
-        expect(::DeclareSchema::Model::FieldSpec.mysql_text_limits?).to be_falsey
-      end
+    if defined?(Mysql2)
+      expect(::DeclareSchema::Model::FieldSpec.mysql_text_limits?).to be_truthy
 
       class Advert < ActiveRecord::Base
         fields do
           notes :text
-          description :text, limit: 30000
+          description :text, limit: 250
         end
       end
 
       expect(Generators::DeclareSchema::Migration::Migrator.run).to(
         migrate_up(<<~EOS.strip)
-          add_column :adverts, :price, :decimal, precision: 4, scale: 1, null: true
-          add_column :adverts, :notes, :text#{text_limit}, null: false#{charset_and_collation}
-          add_column :adverts, :description, :text#{', limit: 65535' if defined?(Mysql2)}, null: false#{charset_and_collation}
+          add_column :adverts, :notes, :text, limit: 4294967295, null: false#{charset_and_collation}
+          add_column :adverts, :description, :text, limit: 255, null: false#{charset_and_collation}
         EOS
       )
 
-      Advert.field_specs.delete :price
       Advert.field_specs.delete :notes
-      Advert.field_specs.delete :description
 
-      # In MySQL, limits are applied, rounded up:
+      # Limits that are too high for MySQL will raise an exception.
 
-      if defined?(Mysql2)
-        expect(::DeclareSchema::Model::FieldSpec.mysql_text_limits?).to be_truthy
-
+      expect do
         class Advert < ActiveRecord::Base
           fields do
             notes :text
-            description :text, limit: 250
+            description :text, limit: 0x1_0000_0000
           end
         end
+      end.to raise_exception(ArgumentError, "limit of 4294967296 is too large for MySQL")
 
-        expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-          migrate_up(<<~EOS.strip)
-            add_column :adverts, :notes, :text, limit: 4294967295, null: false#{charset_and_collation}
-            add_column :adverts, :description, :text, limit: 255, null: false#{charset_and_collation}
-          EOS
-        )
+      Advert.field_specs.delete :notes
 
-        Advert.field_specs.delete :notes
+      # And in MySQL, unstated text limits are treated as the maximum (LONGTEXT) limit.
 
-        # Limits that are too high for MySQL will raise an exception.
+      # To start, we'll set the database schema for `description` to match the above limit of 250.
 
-        expect do
-          class Advert < ActiveRecord::Base
-            fields do
-              notes :text
-              description :text, limit: 0x1_0000_0000
-            end
-          end
-        end.to raise_exception(ArgumentError, "limit of 4294967296 is too large for MySQL")
-
-        Advert.field_specs.delete :notes
-
-        # And in MySQL, unstated text limits are treated as the maximum (LONGTEXT) limit.
-
-        # To start, we'll set the database schema for `description` to match the above limit of 250.
-
-        Advert.connection.execute "ALTER TABLE adverts ADD COLUMN description TINYTEXT"
-        Advert.connection.schema_cache.clear!
-        Advert.reset_column_information
-        expect(Advert.connection.tables - Generators::DeclareSchema::Migration::Migrator.always_ignore_tables).
-          to eq(["adverts"])
-        expect(Advert.columns.map(&:name)).to eq(["id", "body", "title", "description"])
-
-        # Now migrate to an unstated text limit:
-
-        class Advert < ActiveRecord::Base
-          fields do
-            description :text
-          end
-        end
-
-        expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-          migrate_up(<<~EOS.strip)
-            change_column :adverts, :description, :text, limit: 4294967295, null: false#{charset_and_collation}
-          EOS
-          .and migrate_down(<<~EOS.strip)
-            change_column :adverts, :description, :text#{', limit: 255' if defined?(Mysql2)}, null: true#{charset_and_collation}
-          EOS
-        )
-
-        # And migrate to a stated text limit that is the same as the unstated one:
-
-        class Advert < ActiveRecord::Base
-          fields do
-            description :text, limit: 0xffffffff
-          end
-        end
-
-        expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-          migrate_up(<<~EOS.strip)
-            change_column :adverts, :description, :text, limit: 4294967295, null: false#{charset_and_collation}
-          EOS
-          .and migrate_down(<<~EOS.strip)
-            change_column :adverts, :description, :text#{', limit: 255' if defined?(Mysql2)}, null: true#{charset_and_collation}
-          EOS
-        )
-      end
-
-      Advert.field_specs.clear
+      Advert.connection.execute "ALTER TABLE adverts ADD COLUMN description TINYTEXT"
       Advert.connection.schema_cache.clear!
       Advert.reset_column_information
-      class Advert < ActiveRecord::Base
-        fields do
-          name :string, limit: 250, null: true
-        end
-      end
-
-      up = Generators::DeclareSchema::Migration::Migrator.run.first
-      ActiveRecord::Migration.class_eval up
-
-      Advert.connection.schema_cache.clear!
-      Advert.reset_column_information
-
-      ### Foreign Keys
-
-      # DeclareSchema extends the `belongs_to` macro so that it also declares the
-      # foreign-key field.  It also generates an index on the field.
-
-      class Category < ActiveRecord::Base; end
-      class Advert < ActiveRecord::Base
-        fields do
-          name :string, limit: 250, null: true
-        end
-        belongs_to :category
-      end
-
-      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-        migrate_up(<<~EOS.strip)
-          add_column :adverts, :category_id, :integer, limit: 8, null: false
-  
-          add_index :adverts, [:category_id], name: 'on_category_id'
-  
-          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" if defined?(Mysql2)}
-        EOS
-        .and migrate_down(<<~EOS.strip)
-          remove_column :adverts, :category_id
-  
-          remove_index :adverts, name: :on_category_id rescue ActiveRecord::StatementInvalid
-  
-          #{"remove_foreign_key(\"adverts\", name: \"index_adverts_on_category_id\")\n" if defined?(Mysql2)}
-        EOS
-      )
-
-      Advert.field_specs.delete(:category_id)
-      Advert.index_definitions.delete_if { |spec| spec.fields==["category_id"] }
-
-      # If you specify a custom foreign key, the migration generator observes that:
-
-      class Category < ActiveRecord::Base; end
-      class Advert < ActiveRecord::Base
-        fields { }
-        belongs_to :category, foreign_key: "c_id", class_name: 'Category'
-      end
-
-      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-        migrate_up(<<~EOS.strip)
-          add_column :adverts, :c_id, :integer, limit: 8, null: false
-  
-          add_index :adverts, [:c_id], name: 'on_c_id'
-  
-          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
-        EOS
-      )
-
-      Advert.field_specs.delete(:c_id)
-      Advert.index_definitions.delete_if { |spec| spec.fields == ["c_id"] }
-
-      # You can avoid generating the index by specifying `index: false`
-
-      class Category < ActiveRecord::Base; end
-      class Advert < ActiveRecord::Base
-        fields { }
-        belongs_to :category, index: false
-      end
-
-      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-        migrate_up(<<~EOS.strip)
-          add_column :adverts, :category_id, :integer, limit: 8, null: false
-  
-          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
-        EOS
-      )
-
-      Advert.field_specs.delete(:category_id)
-      Advert.index_definitions.delete_if { |spec| spec.fields == ["category_id"] }
-
-      # You can specify the index name with :index
-
-      class Category < ActiveRecord::Base; end
-      class Advert < ActiveRecord::Base
-        fields { }
-        belongs_to :category, index: 'my_index'
-      end
-
-      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-        migrate_up(<<~EOS.strip)
-          add_column :adverts, :category_id, :integer, limit: 8, null: false
-  
-          add_index :adverts, [:category_id], name: 'my_index'
-  
-          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
-        EOS
-      )
-
-      Advert.field_specs.delete(:category_id)
-      Advert.index_definitions.delete_if { |spec| spec.fields == ["category_id"] }
-
-      ### Timestamps and Optimimistic Locking
-
-      # `updated_at` and `created_at` can be declared with the shorthand `timestamps`.
-      # Similarly, `lock_version` can be declared with the "shorthand" `optimimistic_lock`.
-
-      class Advert < ActiveRecord::Base
-        fields do
-          timestamps
-          optimistic_lock
-        end
-      end
-
-      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-        migrate_up(<<~EOS.strip)
-          add_column :adverts, :created_at, :datetime, null: true
-          add_column :adverts, :updated_at, :datetime, null: true
-          add_column :adverts, :lock_version, :integer#{lock_version_limit}, null: false, default: 1
-  
-          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
-        EOS
-        .and migrate_down(<<~EOS.strip)
-          remove_column :adverts, :created_at
-          remove_column :adverts, :updated_at
-          remove_column :adverts, :lock_version
-  
-          #{"remove_foreign_key(\"adverts\", name: \"index_adverts_on_category_id\")\n" +
-            "remove_foreign_key(\"adverts\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
-        EOS
-      )
-
-      Advert.field_specs.delete(:updated_at)
-      Advert.field_specs.delete(:created_at)
-      Advert.field_specs.delete(:lock_version)
-
-      ### Indices
-
-      # You can add an index to a field definition
-
-      class Advert < ActiveRecord::Base
-        fields do
-          title :string, index: true, limit: 250, null: true
-        end
-      end
-
-      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-        migrate_up(<<~EOS.strip)
-          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-  
-          add_index :adverts, [:title], name: 'on_title'
-  
-          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
-        EOS
-      )
-
-      Advert.index_definitions.delete_if { |spec| spec.fields==["title"] }
-
-      # You can ask for a unique index
-
-      class Advert < ActiveRecord::Base
-        fields do
-          title :string, index: true, unique: true, null: true, limit: 250
-        end
-      end
-
-      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-        migrate_up(<<~EOS.strip)
-          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-  
-          add_index :adverts, [:title], unique: true, name: 'on_title'
-  
-          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
-        EOS
-      )
-
-      Advert.index_definitions.delete_if { |spec| spec.fields == ["title"] }
-
-      # You can specify the name for the index
-
-      class Advert < ActiveRecord::Base
-        fields do
-          title :string, index: 'my_index', limit: 250, null: true
-        end
-      end
-
-      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-        migrate_up(<<~EOS.strip)
-          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-  
-          add_index :adverts, [:title], name: 'my_index'
-  
-          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
-        EOS
-      )
-
-      Advert.index_definitions.delete_if { |spec| spec.fields==["title"] }
-
-      # You can ask for an index outside of the fields block
-
-      class Advert < ActiveRecord::Base
-        index :title
-      end
-
-      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-        migrate_up(<<~EOS.strip)
-          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-  
-          add_index :adverts, [:title], name: 'on_title'
-  
-          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
-        EOS
-      )
-
-      Advert.index_definitions.delete_if { |spec| spec.fields == ["title"] }
-
-      # The available options for the index function are `:unique` and `:name`
-
-      class Advert < ActiveRecord::Base
-        index :title, unique: true, name: 'my_index'
-      end
-
-      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-        migrate_up(<<~EOS.strip)
-          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-  
-          add_index :adverts, [:title], unique: true, name: 'my_index'
-  
-          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
-        EOS
-      )
-
-      Advert.index_definitions.delete_if { |spec| spec.fields == ["title"] }
-
-      # You can create an index on more than one field
-
-      class Advert < ActiveRecord::Base
-        index [:title, :category_id]
-      end
-
-      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-        migrate_up(<<~EOS.strip)
-          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-  
-          add_index :adverts, [:title, :category_id], name: 'on_title_and_category_id'
-  
-          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
-        EOS
-      )
-
-      Advert.index_definitions.delete_if { |spec| spec.fields==["title", "category_id"] }
-
-      # Finally, you can specify that the migration generator should completely ignore an
-      # index by passing its name to ignore_index in the model.
-      # This is helpful for preserving indices that can't be automatically generated, such as prefix indices in MySQL.
-
-      ### Rename a table
-
-      # The migration generator respects the `set_table_name` declaration, although as before, we need to explicitly tell the generator that we want a rename rather than a create and a drop.
-
-      class Advert < ActiveRecord::Base
-        self.table_name = "ads"
-        fields do
-          title :string, limit: 250, null: true
-          body :text, null: true
-        end
-      end
-
-      Advert.connection.schema_cache.clear!
-      Advert.reset_column_information
-
-      expect(Generators::DeclareSchema::Migration::Migrator.run("adverts" => "ads")).to(
-        migrate_up(<<~EOS.strip)
-          rename_table :adverts, :ads
-  
-          add_column :ads, :title, :string, limit: 250, null: true#{charset_and_collation}
-          add_column :ads, :body, :text#{', limit: 4294967295' if defined?(Mysql2)}, null: true#{charset_and_collation}
-  
-          #{if defined?(SQLite3)
-              "add_index :ads, [:id], unique: true, name: 'PRIMARY'\n"
-            elsif defined?(Mysql2)
-              "execute \"ALTER TABLE ads DROP PRIMARY KEY, ADD PRIMARY KEY (id)\"\n\n" +
-              "add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-              "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")"
-            end}
-        EOS
-        .and migrate_down(<<~EOS.strip)
-          remove_column :ads, :title
-          remove_column :ads, :body
-  
-          rename_table :ads, :adverts
-  
-          #{if defined?(SQLite3)
-              "add_index :adverts, [:id], unique: true, name: 'PRIMARY'\n"
-            elsif defined?(Mysql2)
-              "execute \"ALTER TABLE adverts DROP PRIMARY KEY, ADD PRIMARY KEY (id)\"\n\n" +
-              "remove_foreign_key(\"adverts\", name: \"index_adverts_on_category_id\")\n" +
-              "remove_foreign_key(\"adverts\", name: \"index_adverts_on_c_id\")"
-            end}
-        EOS
-      )
-
-      # Set the table name back to what it should be and confirm we're in sync:
-
-      nuke_model_class(Advert)
-
-      class Advert < ActiveRecord::Base
-        self.table_name = "adverts"
-      end
-
-      expect(Generators::DeclareSchema::Migration::Migrator.run).to eq(["", ""])
-
-      ### Rename a table
-
-      # As with renaming columns, we have to tell the migration generator about the rename. Here we create a new class 'Advertisement', and tell ActiveRecord to forget about the Advert class. This requires code that shouldn't be shown to impressionable children.
-
-      nuke_model_class(Advert)
-
-      class Advertisement < ActiveRecord::Base
-        fields do
-          title :string, limit: 250, null: true
-          body :text, null: true
-        end
-      end
-
-      expect(Generators::DeclareSchema::Migration::Migrator.run("adverts" => "advertisements")).to(
-        migrate_up(<<~EOS.strip)
-          rename_table :adverts, :advertisements
-  
-          add_column :advertisements, :title, :string, limit: 250, null: true#{charset_and_collation}
-          add_column :advertisements, :body, :text#{', limit: 4294967295' if defined?(Mysql2)}, null: true#{charset_and_collation}
-          remove_column :advertisements, :name
-  
-          #{if defined?(SQLite3)
-              "add_index :advertisements, [:id], unique: true, name: 'PRIMARY'"
-            elsif defined?(Mysql2)
-              "execute \"ALTER TABLE advertisements DROP PRIMARY KEY, ADD PRIMARY KEY (id)\""
-            end}
-        EOS
-        .and migrate_down(<<~EOS.strip)
-          remove_column :advertisements, :title
-          remove_column :advertisements, :body
-          add_column :adverts, :name, :string, limit: 250, null: true#{charset_and_collation}
-  
-          rename_table :advertisements, :adverts
-  
-          #{if defined?(SQLite3)
-              "add_index :adverts, [:id], unique: true, name: 'PRIMARY'"
-            elsif defined?(Mysql2)
-              "execute \"ALTER TABLE adverts DROP PRIMARY KEY, ADD PRIMARY KEY (id)\""
-            end}
-        EOS
-      )
-
-      ### Drop a table
-
-      nuke_model_class(Advertisement)
-
-      # If you delete a model, the migration generator will create a `drop_table` migration.
-
-      # Dropping tables is where the automatic down-migration really comes in handy:
-
-      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-        migrate_up(<<~EOS.strip)
-          drop_table :adverts
-        EOS
-        .and migrate_down(<<~EOS.strip)
-          create_table "adverts"#{table_options}, force: :cascade do |t|
-            t.string "name", limit: 250#{charset_and_collation}
-          end
-        EOS
-      )
-
-      ## STI
-
-      ### Adding an STI subclass
-
-      # Adding a subclass or two should introduce the 'type' column and no other changes
-
-      class Advert < ActiveRecord::Base
-        fields do
-          body :text, null: true
-          title :string, default: "Untitled", limit: 250, null: true
-        end
-      end
-      up = Generators::DeclareSchema::Migration::Migrator.run.first
-      ActiveRecord::Migration.class_eval(up)
-
-      class FancyAdvert < Advert
-      end
-      class SuperFancyAdvert < FancyAdvert
-      end
-
-      up, _ = Generators::DeclareSchema::Migration::Migrator.run do |migrations|
-        expect(migrations).to(
-          migrate_up(<<~EOS.strip)
-            add_column :adverts, :type, :string, limit: 250, null: true#{charset_and_collation}
-  
-            add_index :adverts, [:type], name: 'on_type'
-          EOS
-          .and migrate_down(<<~EOS.strip)
-            remove_column :adverts, :type
-  
-            remove_index :adverts, name: :on_type rescue ActiveRecord::StatementInvalid
-          EOS
-        )
-      end
-
-      Advert.field_specs.delete(:type)
-      nuke_model_class(SuperFancyAdvert)
-      nuke_model_class(FancyAdvert)
-      Advert.index_definitions.delete_if { |spec| spec.fields==["type"] }
-
-      ## Coping with multiple changes
-
-      # The migration generator is designed to create complete migrations even if many changes to the models have taken place.
-
-      # First let's confirm we're in a known state. One model, 'Advert', with a string 'title' and text 'body':
-
-      ActiveRecord::Migration.class_eval up.gsub(/.*type.*/, '')
-      Advert.connection.schema_cache.clear!
-      Advert.reset_column_information
-
       expect(Advert.connection.tables - Generators::DeclareSchema::Migration::Migrator.always_ignore_tables).
         to eq(["adverts"])
-      expect(Advert.columns.map(&:name).sort).to eq(["body", "id", "title"])
-      expect(Generators::DeclareSchema::Migration::Migrator.run).to eq(["", ""])
+      expect(Advert.columns.map(&:name)).to eq(["id", "body", "title", "description"])
 
-
-      ### Rename a column and change the default
-
-      Advert.field_specs.clear
+      # Now migrate to an unstated text limit:
 
       class Advert < ActiveRecord::Base
         fields do
-          name :string, default: "No Name", limit: 250, null: true
-          body :text, null: true
+          description :text
         end
       end
 
-      expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: { title: :name })).to(
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
         migrate_up(<<~EOS.strip)
-          rename_column :adverts, :title, :name
-          change_column :adverts, :name, :string, limit: 250, null: true, default: "No Name"#{charset_and_collation}
+          change_column :adverts, :description, :text, limit: 4294967295, null: false#{charset_and_collation}
         EOS
         .and migrate_down(<<~EOS.strip)
-          rename_column :adverts, :name, :title
-          change_column :adverts, :title, :string, limit: 250, null: true, default: "Untitled"#{charset_and_collation}
+          change_column :adverts, :description, :text#{', limit: 255' if defined?(Mysql2)}, null: true#{charset_and_collation}
         EOS
       )
 
-      ### Rename a table and add a column
-
-      nuke_model_class(Advert)
-      class Ad < ActiveRecord::Base
-        fields do
-          title      :string, default: "Untitled", limit: 250
-          body       :text, null: true
-          created_at :datetime
-        end
-      end
-
-      expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: :ads)).to(
-        migrate_up(<<~EOS.strip)
-          rename_table :adverts, :ads
-  
-          add_column :ads, :created_at, :datetime, null: false
-          change_column :ads, :title, :string, limit: 250, null: false, default: \"Untitled\"#{charset_and_collation}
-  
-          #{if defined?(SQLite3)
-              "add_index :ads, [:id], unique: true, name: 'PRIMARY'"
-            elsif defined?(Mysql2)
-              'execute "ALTER TABLE ads DROP PRIMARY KEY, ADD PRIMARY KEY (id)"'
-            end}
-        EOS
-      )
+      # And migrate to a stated text limit that is the same as the unstated one:
 
       class Advert < ActiveRecord::Base
         fields do
-          body :text, null: true
-          title :string, default: "Untitled", limit: 250, null: true
+          description :text, limit: 0xffffffff
         end
       end
 
-      ## Legacy Keys
-
-      # DeclareSchema has some support for legacy keys.
-
-      nuke_model_class(Ad)
-
-      class Advert < ActiveRecord::Base
-        fields do
-          body :text, null: true
-        end
-        self.primary_key = "advert_id"
-      end
-
-      expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: { id: :advert_id })).to(
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
         migrate_up(<<~EOS.strip)
-          rename_column :adverts, :id, :advert_id
-  
-          #{if defined?(SQLite3)
-              "add_index :adverts, [:advert_id], unique: true, name: 'PRIMARY'"
-            elsif defined?(Mysql2)
-            'execute "ALTER TABLE adverts DROP PRIMARY KEY, ADD PRIMARY KEY (advert_id)"'
-            end}
+          change_column :adverts, :description, :text, limit: 4294967295, null: false#{charset_and_collation}
+        EOS
+        .and migrate_down(<<~EOS.strip)
+          change_column :adverts, :description, :text#{', limit: 255' if defined?(Mysql2)}, null: true#{charset_and_collation}
         EOS
       )
+    end
 
-      nuke_model_class(Advert)
-      ActiveRecord::Base.connection.execute("drop table `adverts`;")
+    Advert.field_specs.clear
+    Advert.connection.schema_cache.clear!
+    Advert.reset_column_information
+    class Advert < ActiveRecord::Base
+      fields do
+        name :string, limit: 250, null: true
+      end
+    end
 
-      ## DSL
+    up = Generators::DeclareSchema::Migration::Migrator.run.first
+    ActiveRecord::Migration.class_eval up
 
-      # The DSL allows lambdas and constants
+    Advert.connection.schema_cache.clear!
+    Advert.reset_column_information
 
-      class User < ActiveRecord::Base
-        fields do
-          company :string, limit: 250, ruby_default: -> { "BigCorp" }
+    ### Foreign Keys
+
+    # DeclareSchema extends the `belongs_to` macro so that it also declares the
+    # foreign-key field.  It also generates an index on the field.
+
+    class Category < ActiveRecord::Base; end
+    class Advert < ActiveRecord::Base
+      fields do
+        name :string, limit: 250, null: true
+      end
+      belongs_to :category
+    end
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :category_id, :integer, limit: 8, null: false
+
+        add_index :adverts, [:category_id], name: 'on_category_id'
+
+        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" if defined?(Mysql2)}
+      EOS
+      .and migrate_down(<<~EOS.strip)
+        remove_column :adverts, :category_id
+
+        remove_index :adverts, name: :on_category_id rescue ActiveRecord::StatementInvalid
+
+        #{"remove_foreign_key(\"adverts\", name: \"index_adverts_on_category_id\")\n" if defined?(Mysql2)}
+      EOS
+    )
+
+    Advert.field_specs.delete(:category_id)
+    Advert.index_definitions.delete_if { |spec| spec.fields==["category_id"] }
+
+    # If you specify a custom foreign key, the migration generator observes that:
+
+    class Category < ActiveRecord::Base; end
+    class Advert < ActiveRecord::Base
+      fields { }
+      belongs_to :category, foreign_key: "c_id", class_name: 'Category'
+    end
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :c_id, :integer, limit: 8, null: false
+
+        add_index :adverts, [:c_id], name: 'on_c_id'
+
+        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+      EOS
+    )
+
+    Advert.field_specs.delete(:c_id)
+    Advert.index_definitions.delete_if { |spec| spec.fields == ["c_id"] }
+
+    # You can avoid generating the index by specifying `index: false`
+
+    class Category < ActiveRecord::Base; end
+    class Advert < ActiveRecord::Base
+      fields { }
+      belongs_to :category, index: false
+    end
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :category_id, :integer, limit: 8, null: false
+
+        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+      EOS
+    )
+
+    Advert.field_specs.delete(:category_id)
+    Advert.index_definitions.delete_if { |spec| spec.fields == ["category_id"] }
+
+    # You can specify the index name with :index
+
+    class Category < ActiveRecord::Base; end
+    class Advert < ActiveRecord::Base
+      fields { }
+      belongs_to :category, index: 'my_index'
+    end
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :category_id, :integer, limit: 8, null: false
+
+        add_index :adverts, [:category_id], name: 'my_index'
+
+        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+      EOS
+    )
+
+    Advert.field_specs.delete(:category_id)
+    Advert.index_definitions.delete_if { |spec| spec.fields == ["category_id"] }
+
+    ### Timestamps and Optimimistic Locking
+
+    # `updated_at` and `created_at` can be declared with the shorthand `timestamps`.
+    # Similarly, `lock_version` can be declared with the "shorthand" `optimimistic_lock`.
+
+    class Advert < ActiveRecord::Base
+      fields do
+        timestamps
+        optimistic_lock
+      end
+    end
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :created_at, :datetime, null: true
+        add_column :adverts, :updated_at, :datetime, null: true
+        add_column :adverts, :lock_version, :integer#{lock_version_limit}, null: false, default: 1
+
+        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+      EOS
+      .and migrate_down(<<~EOS.strip)
+        remove_column :adverts, :created_at
+        remove_column :adverts, :updated_at
+        remove_column :adverts, :lock_version
+
+        #{"remove_foreign_key(\"adverts\", name: \"index_adverts_on_category_id\")\n" +
+          "remove_foreign_key(\"adverts\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+      EOS
+    )
+
+    Advert.field_specs.delete(:updated_at)
+    Advert.field_specs.delete(:created_at)
+    Advert.field_specs.delete(:lock_version)
+
+    ### Indices
+
+    # You can add an index to a field definition
+
+    class Advert < ActiveRecord::Base
+      fields do
+        title :string, index: true, limit: 250, null: true
+      end
+    end
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+
+        add_index :adverts, [:title], name: 'on_title'
+
+        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+      EOS
+    )
+
+    Advert.index_definitions.delete_if { |spec| spec.fields==["title"] }
+
+    # You can ask for a unique index
+
+    class Advert < ActiveRecord::Base
+      fields do
+        title :string, index: true, unique: true, null: true, limit: 250
+      end
+    end
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+
+        add_index :adverts, [:title], unique: true, name: 'on_title'
+
+        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+      EOS
+    )
+
+    Advert.index_definitions.delete_if { |spec| spec.fields == ["title"] }
+
+    # You can specify the name for the index
+
+    class Advert < ActiveRecord::Base
+      fields do
+        title :string, index: 'my_index', limit: 250, null: true
+      end
+    end
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+
+        add_index :adverts, [:title], name: 'my_index'
+
+        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+      EOS
+    )
+
+    Advert.index_definitions.delete_if { |spec| spec.fields==["title"] }
+
+    # You can ask for an index outside of the fields block
+
+    class Advert < ActiveRecord::Base
+      index :title
+    end
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+
+        add_index :adverts, [:title], name: 'on_title'
+
+        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+      EOS
+    )
+
+    Advert.index_definitions.delete_if { |spec| spec.fields == ["title"] }
+
+    # The available options for the index function are `:unique` and `:name`
+
+    class Advert < ActiveRecord::Base
+      index :title, unique: true, name: 'my_index'
+    end
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+
+        add_index :adverts, [:title], unique: true, name: 'my_index'
+
+        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+      EOS
+    )
+
+    Advert.index_definitions.delete_if { |spec| spec.fields == ["title"] }
+
+    # You can create an index on more than one field
+
+    class Advert < ActiveRecord::Base
+      index [:title, :category_id]
+    end
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+
+        add_index :adverts, [:title, :category_id], name: 'on_title_and_category_id'
+
+        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+      EOS
+    )
+
+    Advert.index_definitions.delete_if { |spec| spec.fields==["title", "category_id"] }
+
+    # Finally, you can specify that the migration generator should completely ignore an
+    # index by passing its name to ignore_index in the model.
+    # This is helpful for preserving indices that can't be automatically generated, such as prefix indices in MySQL.
+
+    ### Rename a table
+
+    # The migration generator respects the `set_table_name` declaration, although as before, we need to explicitly tell the generator that we want a rename rather than a create and a drop.
+
+    class Advert < ActiveRecord::Base
+      self.table_name = "ads"
+      fields do
+        title :string, limit: 250, null: true
+        body :text, null: true
+      end
+    end
+
+    Advert.connection.schema_cache.clear!
+    Advert.reset_column_information
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run("adverts" => "ads")).to(
+      migrate_up(<<~EOS.strip)
+        rename_table :adverts, :ads
+
+        add_column :ads, :title, :string, limit: 250, null: true#{charset_and_collation}
+        add_column :ads, :body, :text#{', limit: 4294967295' if defined?(Mysql2)}, null: true#{charset_and_collation}
+
+        #{if defined?(SQLite3)
+            "add_index :ads, [:id], unique: true, name: 'PRIMARY'\n"
+          elsif defined?(Mysql2)
+            "execute \"ALTER TABLE ads DROP PRIMARY KEY, ADD PRIMARY KEY (id)\"\n\n" +
+            "add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")"
+          end}
+      EOS
+      .and migrate_down(<<~EOS.strip)
+        remove_column :ads, :title
+        remove_column :ads, :body
+
+        rename_table :ads, :adverts
+
+        #{if defined?(SQLite3)
+            "add_index :adverts, [:id], unique: true, name: 'PRIMARY'\n"
+          elsif defined?(Mysql2)
+            "execute \"ALTER TABLE adverts DROP PRIMARY KEY, ADD PRIMARY KEY (id)\"\n\n" +
+            "remove_foreign_key(\"adverts\", name: \"index_adverts_on_category_id\")\n" +
+            "remove_foreign_key(\"adverts\", name: \"index_adverts_on_c_id\")"
+          end}
+      EOS
+    )
+
+    # Set the table name back to what it should be and confirm we're in sync:
+
+    nuke_model_class(Advert)
+
+    class Advert < ActiveRecord::Base
+      self.table_name = "adverts"
+    end
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to eq(["", ""])
+
+    ### Rename a table
+
+    # As with renaming columns, we have to tell the migration generator about the rename. Here we create a new class 'Advertisement', and tell ActiveRecord to forget about the Advert class. This requires code that shouldn't be shown to impressionable children.
+
+    nuke_model_class(Advert)
+
+    class Advertisement < ActiveRecord::Base
+      fields do
+        title :string, limit: 250, null: true
+        body :text, null: true
+      end
+    end
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run("adverts" => "advertisements")).to(
+      migrate_up(<<~EOS.strip)
+        rename_table :adverts, :advertisements
+
+        add_column :advertisements, :title, :string, limit: 250, null: true#{charset_and_collation}
+        add_column :advertisements, :body, :text#{', limit: 4294967295' if defined?(Mysql2)}, null: true#{charset_and_collation}
+        remove_column :advertisements, :name
+
+        #{if defined?(SQLite3)
+            "add_index :advertisements, [:id], unique: true, name: 'PRIMARY'"
+          elsif defined?(Mysql2)
+            "execute \"ALTER TABLE advertisements DROP PRIMARY KEY, ADD PRIMARY KEY (id)\""
+          end}
+      EOS
+      .and migrate_down(<<~EOS.strip)
+        remove_column :advertisements, :title
+        remove_column :advertisements, :body
+        add_column :adverts, :name, :string, limit: 250, null: true#{charset_and_collation}
+
+        rename_table :advertisements, :adverts
+
+        #{if defined?(SQLite3)
+            "add_index :adverts, [:id], unique: true, name: 'PRIMARY'"
+          elsif defined?(Mysql2)
+            "execute \"ALTER TABLE adverts DROP PRIMARY KEY, ADD PRIMARY KEY (id)\""
+          end}
+      EOS
+    )
+
+    ### Drop a table
+
+    nuke_model_class(Advertisement)
+
+    # If you delete a model, the migration generator will create a `drop_table` migration.
+
+    # Dropping tables is where the automatic down-migration really comes in handy:
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+      migrate_up(<<~EOS.strip)
+        drop_table :adverts
+      EOS
+      .and migrate_down(<<~EOS.strip)
+        create_table "adverts"#{table_options}, force: :cascade do |t|
+          t.string "name", limit: 250#{charset_and_collation}
+        end
+      EOS
+    )
+
+    ## STI
+
+    ### Adding an STI subclass
+
+    # Adding a subclass or two should introduce the 'type' column and no other changes
+
+    class Advert < ActiveRecord::Base
+      fields do
+        body :text, null: true
+        title :string, default: "Untitled", limit: 250, null: true
+      end
+    end
+    up = Generators::DeclareSchema::Migration::Migrator.run.first
+    ActiveRecord::Migration.class_eval(up)
+
+    class FancyAdvert < Advert
+    end
+    class SuperFancyAdvert < FancyAdvert
+    end
+
+    up, _ = Generators::DeclareSchema::Migration::Migrator.run do |migrations|
+      expect(migrations).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :type, :string, limit: 250, null: true#{charset_and_collation}
+
+          add_index :adverts, [:type], name: 'on_type'
+        EOS
+        .and migrate_down(<<~EOS.strip)
+          remove_column :adverts, :type
+
+          remove_index :adverts, name: :on_type rescue ActiveRecord::StatementInvalid
+        EOS
+      )
+    end
+
+    Advert.field_specs.delete(:type)
+    nuke_model_class(SuperFancyAdvert)
+    nuke_model_class(FancyAdvert)
+    Advert.index_definitions.delete_if { |spec| spec.fields==["type"] }
+
+    ## Coping with multiple changes
+
+    # The migration generator is designed to create complete migrations even if many changes to the models have taken place.
+
+    # First let's confirm we're in a known state. One model, 'Advert', with a string 'title' and text 'body':
+
+    ActiveRecord::Migration.class_eval up.gsub(/.*type.*/, '')
+    Advert.connection.schema_cache.clear!
+    Advert.reset_column_information
+
+    expect(Advert.connection.tables - Generators::DeclareSchema::Migration::Migrator.always_ignore_tables).
+      to eq(["adverts"])
+    expect(Advert.columns.map(&:name).sort).to eq(["body", "id", "title"])
+    expect(Generators::DeclareSchema::Migration::Migrator.run).to eq(["", ""])
+
+
+    ### Rename a column and change the default
+
+    Advert.field_specs.clear
+
+    class Advert < ActiveRecord::Base
+      fields do
+        name :string, default: "No Name", limit: 250, null: true
+        body :text, null: true
+      end
+    end
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: { title: :name })).to(
+      migrate_up(<<~EOS.strip)
+        rename_column :adverts, :title, :name
+        change_column :adverts, :name, :string, limit: 250, null: true, default: "No Name"#{charset_and_collation}
+      EOS
+      .and migrate_down(<<~EOS.strip)
+        rename_column :adverts, :name, :title
+        change_column :adverts, :title, :string, limit: 250, null: true, default: "Untitled"#{charset_and_collation}
+      EOS
+    )
+
+    ### Rename a table and add a column
+
+    nuke_model_class(Advert)
+    class Ad < ActiveRecord::Base
+      fields do
+        title      :string, default: "Untitled", limit: 250
+        body       :text, null: true
+        created_at :datetime
+      end
+    end
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: :ads)).to(
+      migrate_up(<<~EOS.strip)
+        rename_table :adverts, :ads
+
+        add_column :ads, :created_at, :datetime, null: false
+        change_column :ads, :title, :string, limit: 250, null: false, default: \"Untitled\"#{charset_and_collation}
+
+        #{if defined?(SQLite3)
+            "add_index :ads, [:id], unique: true, name: 'PRIMARY'"
+          elsif defined?(Mysql2)
+            'execute "ALTER TABLE ads DROP PRIMARY KEY, ADD PRIMARY KEY (id)"'
+          end}
+      EOS
+    )
+
+    class Advert < ActiveRecord::Base
+      fields do
+        body :text, null: true
+        title :string, default: "Untitled", limit: 250, null: true
+      end
+    end
+
+    ## Legacy Keys
+
+    # DeclareSchema has some support for legacy keys.
+
+    nuke_model_class(Ad)
+
+    class Advert < ActiveRecord::Base
+      fields do
+        body :text, null: true
+      end
+      self.primary_key = "advert_id"
+    end
+
+    expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: { id: :advert_id })).to(
+      migrate_up(<<~EOS.strip)
+        rename_column :adverts, :id, :advert_id
+
+        #{if defined?(SQLite3)
+            "add_index :adverts, [:advert_id], unique: true, name: 'PRIMARY'"
+          elsif defined?(Mysql2)
+          'execute "ALTER TABLE adverts DROP PRIMARY KEY, ADD PRIMARY KEY (advert_id)"'
+          end}
+      EOS
+    )
+
+    nuke_model_class(Advert)
+    ActiveRecord::Base.connection.execute("drop table `adverts`;")
+
+    ## DSL
+
+    # The DSL allows lambdas and constants
+
+    class User < ActiveRecord::Base
+      fields do
+        company :string, limit: 250, ruby_default: -> { "BigCorp" }
+      end
+    end
+    expect(User.field_specs.keys).to eq(['company'])
+    expect(User.field_specs['company'].options[:ruby_default]&.call).to eq("BigCorp")
+
+    ## validates
+
+    # DeclareSchema can accept a validates hash in the field options.
+
+    class Ad < ActiveRecord::Base
+      class << self
+        def validates(field_name, options)
         end
       end
-      expect(User.field_specs.keys).to eq(['company'])
-      expect(User.field_specs['company'].options[:ruby_default]&.call).to eq("BigCorp")
+    end
+    expect(Ad).to receive(:validates).with(:company, presence: true, uniqueness: { case_sensitive: false })
+    class Ad < ActiveRecord::Base
+      fields do
+        company :string, limit: 250, index: true, unique: true, validates: { presence: true, uniqueness: { case_sensitive: false } }
+      end
+      self.primary_key = "advert_id"
+    end
+    up, _down = Generators::DeclareSchema::Migration::Migrator.run
+    ActiveRecord::Migration.class_eval(up)
+    expect(Ad.field_specs['company'].options[:validates].inspect).to eq("{:presence=>true, :uniqueness=>{:case_sensitive=>false}}")
+  end
 
-      ## validates
-
-      # DeclareSchema can accept a validates hash in the field options.
-
+  describe 'serialize' do
+    before do
       class Ad < ActiveRecord::Base
+        @serialize_args = []
+
         class << self
-          def validates(field_name, options)
+          attr_reader :serialize_args
+
+          def serialize(*args)
+            @serialize_args << args
           end
         end
       end
-      expect(Ad).to receive(:validates).with(:company, presence: true, uniqueness: { case_sensitive: false })
-      class Ad < ActiveRecord::Base
-        fields do
-          company :string, limit: 250, index: true, unique: true, validates: { presence: true, uniqueness: { case_sensitive: false } }
-        end
-        self.primary_key = "advert_id"
-      end
-      up, _down = Generators::DeclareSchema::Migration::Migrator.run
-      ActiveRecord::Migration.class_eval(up)
-      expect(Ad.field_specs['company'].options[:validates].inspect).to eq("{:presence=>true, :uniqueness=>{:case_sensitive=>false}}")
     end
 
-    describe 'serialize' do
-      before do
+    describe 'untyped' do
+      it 'allows serialize: true' do
         class Ad < ActiveRecord::Base
-          @serialize_args = []
-
-          class << self
-            attr_reader :serialize_args
-
-            def serialize(*args)
-              @serialize_args << args
-            end
+          fields do
+            allow_list :text, limit: 0xFFFF, serialize: true
           end
         end
+
+        expect(Ad.serialize_args).to eq([[:allow_list]])
       end
 
-      describe 'untyped' do
-        it 'allows serialize: true' do
-          class Ad < ActiveRecord::Base
-            fields do
-              allow_list :text, limit: 0xFFFF, serialize: true
-            end
-          end
-
-          expect(Ad.serialize_args).to eq([[:allow_list]])
-        end
-
-        it 'converts defaults with .to_yaml' do
-          class Ad < ActiveRecord::Base
-            fields do
-              allow_list :string, limit: 250, serialize: true, null: true, default: []
-              allow_hash :string, limit: 250, serialize: true, null: true, default: {}
-              allow_string :string, limit: 250, serialize: true, null: true, default: ['abc']
-              allow_null :string, limit: 250, serialize: true, null: true, default: nil
-            end
-          end
-
-          expect(Ad.field_specs['allow_list'].default).to eq("--- []\n")
-          expect(Ad.field_specs['allow_hash'].default).to eq("--- {}\n")
-          expect(Ad.field_specs['allow_string'].default).to eq("---\n- abc\n")
-          expect(Ad.field_specs['allow_null'].default).to eq(nil)
-        end
-      end
-
-      describe 'Array' do
-        it 'allows serialize: Array' do
-          class Ad < ActiveRecord::Base
-            fields do
-              allow_list :string, limit: 250, serialize: Array, null: true
-            end
-          end
-
-          expect(Ad.serialize_args).to eq([[:allow_list, Array]])
-        end
-
-        it 'allows Array defaults' do
-          class Ad < ActiveRecord::Base
-            fields do
-              allow_list :string, limit: 250, serialize: Array, null: true, default: [2]
-              allow_string :string, limit: 250, serialize: Array, null: true, default: ['abc']
-              allow_empty :string, limit: 250, serialize: Array, null: true, default: []
-              allow_null :string, limit: 250, serialize: Array, null: true, default: nil
-            end
-          end
-
-          expect(Ad.field_specs['allow_list'].default).to eq("---\n- 2\n")
-          expect(Ad.field_specs['allow_string'].default).to eq("---\n- abc\n")
-          expect(Ad.field_specs['allow_empty'].default).to eq(nil)
-          expect(Ad.field_specs['allow_null'].default).to eq(nil)
-        end
-      end
-
-      describe 'Hash' do
-        it 'allows serialize: Hash' do
-          class Ad < ActiveRecord::Base
-            fields do
-              allow_list :string, limit: 250, serialize: Hash, null: true
-            end
-          end
-
-          expect(Ad.serialize_args).to eq([[:allow_list, Hash]])
-        end
-
-        it 'allows Hash defaults' do
-          class Ad < ActiveRecord::Base
-            fields do
-              allow_loc :string, limit: 250, serialize: Hash, null: true, default: { 'state' => 'CA' }
-              allow_hash :string, limit: 250, serialize: Hash, null: true, default: {}
-              allow_null :string, limit: 250, serialize: Hash, null: true, default: nil
-            end
-          end
-
-          expect(Ad.field_specs['allow_loc'].default).to eq("---\nstate: CA\n")
-          expect(Ad.field_specs['allow_hash'].default).to eq(nil)
-          expect(Ad.field_specs['allow_null'].default).to eq(nil)
-        end
-      end
-
-      describe 'JSON' do
-        it 'allows serialize: JSON' do
-          class Ad < ActiveRecord::Base
-            fields do
-              allow_list :string, limit: 250, serialize: JSON
-            end
-          end
-
-          expect(Ad.serialize_args).to eq([[:allow_list, JSON]])
-        end
-
-        it 'allows JSON defaults' do
-          class Ad < ActiveRecord::Base
-            fields do
-              allow_hash :string, limit: 250, serialize: JSON, null: true, default: { 'state' => 'CA' }
-              allow_empty_array :string, limit: 250, serialize: JSON, null: true, default: []
-              allow_empty_hash :string, limit: 250, serialize: JSON, null: true, default: {}
-              allow_null :string, limit: 250, serialize: JSON, null: true, default: nil
-            end
-          end
-
-          expect(Ad.field_specs['allow_hash'].default).to eq("{\"state\":\"CA\"}")
-          expect(Ad.field_specs['allow_empty_array'].default).to eq("[]")
-          expect(Ad.field_specs['allow_empty_hash'].default).to eq("{}")
-          expect(Ad.field_specs['allow_null'].default).to eq(nil)
-        end
-      end
-
-      class ValueClass
-        delegate :present?, :inspect, to: :@value
-
-        def initialize(value)
-          @value = value
-        end
-
-        class << self
-          def dump(object)
-            if object&.present?
-              object.inspect
-            end
-          end
-
-          def load(serialized)
-            if serialized
-              raise 'not used ???'
-            end
+      it 'converts defaults with .to_yaml' do
+        class Ad < ActiveRecord::Base
+          fields do
+            allow_list :string, limit: 250, serialize: true, null: true, default: []
+            allow_hash :string, limit: 250, serialize: true, null: true, default: {}
+            allow_string :string, limit: 250, serialize: true, null: true, default: ['abc']
+            allow_null :string, limit: 250, serialize: true, null: true, default: nil
           end
         end
-      end
 
-      describe 'custom coder' do
-        it 'allows serialize: ValueClass' do
-          class Ad < ActiveRecord::Base
-            fields do
-              allow_list :string, limit: 250, serialize: ValueClass
-            end
-          end
-
-          expect(Ad.serialize_args).to eq([[:allow_list, ValueClass]])
-        end
-
-        it 'allows ValueClass defaults' do
-          class Ad < ActiveRecord::Base
-            fields do
-              allow_hash :string, limit: 250, serialize: ValueClass, null: true, default: ValueClass.new([2])
-              allow_empty_array :string, limit: 250, serialize: ValueClass, null: true, default: ValueClass.new([])
-              allow_null :string, limit: 250, serialize: ValueClass, null: true, default: nil
-            end
-          end
-
-          expect(Ad.field_specs['allow_hash'].default).to eq("[2]")
-          expect(Ad.field_specs['allow_empty_array'].default).to eq(nil)
-          expect(Ad.field_specs['allow_null'].default).to eq(nil)
-        end
-      end
-
-      it 'disallows serialize: with a non-string column type' do
-        expect do
-          class Ad < ActiveRecord::Base
-            fields do
-              allow_list :integer, limit: 8, serialize: true
-            end
-          end
-        end.to raise_exception(ArgumentError, /must be :string or :text/)
+        expect(Ad.field_specs['allow_list'].default).to eq("--- []\n")
+        expect(Ad.field_specs['allow_hash'].default).to eq("--- {}\n")
+        expect(Ad.field_specs['allow_string'].default).to eq("---\n- abc\n")
+        expect(Ad.field_specs['allow_null'].default).to eq(nil)
       end
     end
 
-    context "for Rails #{Rails::VERSION::MAJOR}" do
-      if Rails::VERSION::MAJOR >= 5
-        let(:optional_true) { { optional: true } }
-        let(:optional_false) { { optional: false } }
-      else
-        let(:optional_true) { {} }
-        let(:optional_false) { {} }
-      end
-      let(:optional_flag) { { false => optional_false, true => optional_true } }
-
-      describe 'belongs_to' do
-        before do
-          unless defined?(AdCategory)
-            class AdCategory < ActiveRecord::Base
-              fields { }
-            end
+    describe 'Array' do
+      it 'allows serialize: Array' do
+        class Ad < ActiveRecord::Base
+          fields do
+            allow_list :string, limit: 250, serialize: Array, null: true
           end
-
-          class Advert < ActiveRecord::Base
-            fields do
-              name :string, limit: 250, null: true
-              category_id :integer, limit: 8
-              nullable_category_id :integer, limit: 8, null: true
-            end
-          end
-          up = Generators::DeclareSchema::Migration::Migrator.run.first
-          ActiveRecord::Migration.class_eval(up)
         end
 
-        it 'passes through optional: when given' do
+        expect(Ad.serialize_args).to eq([[:allow_list, Array]])
+      end
+
+      it 'allows Array defaults' do
+        class Ad < ActiveRecord::Base
+          fields do
+            allow_list :string, limit: 250, serialize: Array, null: true, default: [2]
+            allow_string :string, limit: 250, serialize: Array, null: true, default: ['abc']
+            allow_empty :string, limit: 250, serialize: Array, null: true, default: []
+            allow_null :string, limit: 250, serialize: Array, null: true, default: nil
+          end
+        end
+
+        expect(Ad.field_specs['allow_list'].default).to eq("---\n- 2\n")
+        expect(Ad.field_specs['allow_string'].default).to eq("---\n- abc\n")
+        expect(Ad.field_specs['allow_empty'].default).to eq(nil)
+        expect(Ad.field_specs['allow_null'].default).to eq(nil)
+      end
+    end
+
+    describe 'Hash' do
+      it 'allows serialize: Hash' do
+        class Ad < ActiveRecord::Base
+          fields do
+            allow_list :string, limit: 250, serialize: Hash, null: true
+          end
+        end
+
+        expect(Ad.serialize_args).to eq([[:allow_list, Hash]])
+      end
+
+      it 'allows Hash defaults' do
+        class Ad < ActiveRecord::Base
+          fields do
+            allow_loc :string, limit: 250, serialize: Hash, null: true, default: { 'state' => 'CA' }
+            allow_hash :string, limit: 250, serialize: Hash, null: true, default: {}
+            allow_null :string, limit: 250, serialize: Hash, null: true, default: nil
+          end
+        end
+
+        expect(Ad.field_specs['allow_loc'].default).to eq("---\nstate: CA\n")
+        expect(Ad.field_specs['allow_hash'].default).to eq(nil)
+        expect(Ad.field_specs['allow_null'].default).to eq(nil)
+      end
+    end
+
+    describe 'JSON' do
+      it 'allows serialize: JSON' do
+        class Ad < ActiveRecord::Base
+          fields do
+            allow_list :string, limit: 250, serialize: JSON
+          end
+        end
+
+        expect(Ad.serialize_args).to eq([[:allow_list, JSON]])
+      end
+
+      it 'allows JSON defaults' do
+        class Ad < ActiveRecord::Base
+          fields do
+            allow_hash :string, limit: 250, serialize: JSON, null: true, default: { 'state' => 'CA' }
+            allow_empty_array :string, limit: 250, serialize: JSON, null: true, default: []
+            allow_empty_hash :string, limit: 250, serialize: JSON, null: true, default: {}
+            allow_null :string, limit: 250, serialize: JSON, null: true, default: nil
+          end
+        end
+
+        expect(Ad.field_specs['allow_hash'].default).to eq("{\"state\":\"CA\"}")
+        expect(Ad.field_specs['allow_empty_array'].default).to eq("[]")
+        expect(Ad.field_specs['allow_empty_hash'].default).to eq("{}")
+        expect(Ad.field_specs['allow_null'].default).to eq(nil)
+      end
+    end
+
+    class ValueClass
+      delegate :present?, :inspect, to: :@value
+
+      def initialize(value)
+        @value = value
+      end
+
+      class << self
+        def dump(object)
+          if object&.present?
+            object.inspect
+          end
+        end
+
+        def load(serialized)
+          if serialized
+            raise 'not used ???'
+          end
+        end
+      end
+    end
+
+    describe 'custom coder' do
+      it 'allows serialize: ValueClass' do
+        class Ad < ActiveRecord::Base
+          fields do
+            allow_list :string, limit: 250, serialize: ValueClass
+          end
+        end
+
+        expect(Ad.serialize_args).to eq([[:allow_list, ValueClass]])
+      end
+
+      it 'allows ValueClass defaults' do
+        class Ad < ActiveRecord::Base
+          fields do
+            allow_hash :string, limit: 250, serialize: ValueClass, null: true, default: ValueClass.new([2])
+            allow_empty_array :string, limit: 250, serialize: ValueClass, null: true, default: ValueClass.new([])
+            allow_null :string, limit: 250, serialize: ValueClass, null: true, default: nil
+          end
+        end
+
+        expect(Ad.field_specs['allow_hash'].default).to eq("[2]")
+        expect(Ad.field_specs['allow_empty_array'].default).to eq(nil)
+        expect(Ad.field_specs['allow_null'].default).to eq(nil)
+      end
+    end
+
+    it 'disallows serialize: with a non-string column type' do
+      expect do
+        class Ad < ActiveRecord::Base
+          fields do
+            allow_list :integer, limit: 8, serialize: true
+          end
+        end
+      end.to raise_exception(ArgumentError, /must be :string or :text/)
+    end
+  end
+
+  context "for Rails #{Rails::VERSION::MAJOR}" do
+    if Rails::VERSION::MAJOR >= 5
+      let(:optional_true) { { optional: true } }
+      let(:optional_false) { { optional: false } }
+    else
+      let(:optional_true) { {} }
+      let(:optional_false) { {} }
+    end
+    let(:optional_flag) { { false => optional_false, true => optional_true } }
+
+    describe 'belongs_to' do
+      before do
+        unless defined?(AdCategory)
+          class AdCategory < ActiveRecord::Base
+            fields { }
+          end
+        end
+
+        class Advert < ActiveRecord::Base
+          fields do
+            name :string, limit: 250, null: true
+            category_id :integer, limit: 8
+            nullable_category_id :integer, limit: 8, null: true
+          end
+        end
+        up = Generators::DeclareSchema::Migration::Migrator.run.first
+        ActiveRecord::Migration.class_eval(up)
+      end
+
+      it 'passes through optional: when given' do
+        class AdvertBelongsTo < ActiveRecord::Base
+          self.table_name = 'adverts'
+          fields { }
+          reset_column_information
+          belongs_to :ad_category, optional: true
+        end
+        expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_true)
+      end
+
+      describe 'contradictory settings' do # contradictory settings are ok--for example, during migration
+        it 'passes through optional: true, null: false' do
           class AdvertBelongsTo < ActiveRecord::Base
             self.table_name = 'adverts'
             fields { }
             reset_column_information
-            belongs_to :ad_category, optional: true
+            belongs_to :ad_category, optional: true, null: false
           end
           expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_true)
+          expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(false)
         end
 
-        describe 'contradictory settings' do # contradictory settings are ok--for example, during migration
-          it 'passes through optional: true, null: false' do
-            class AdvertBelongsTo < ActiveRecord::Base
-              self.table_name = 'adverts'
-              fields { }
-              reset_column_information
-              belongs_to :ad_category, optional: true, null: false
-            end
-            expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_true)
-            expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(false)
+        it 'passes through optional: false, null: true' do
+          class AdvertBelongsTo < ActiveRecord::Base
+            self.table_name = 'adverts'
+            fields { }
+            reset_column_information
+            belongs_to :ad_category, optional: false, null: true
           end
-
-          it 'passes through optional: false, null: true' do
-            class AdvertBelongsTo < ActiveRecord::Base
-              self.table_name = 'adverts'
-              fields { }
-              reset_column_information
-              belongs_to :ad_category, optional: false, null: true
-            end
-            expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_false)
-            expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(true)
-          end
+          expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_false)
+          expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(true)
         end
+      end
 
-        [false, true].each do |nullable|
-          context "nullable=#{nullable}" do
-            it 'infers optional: from null:' do
-              eval <<~EOS
-                class AdvertBelongsTo < ActiveRecord::Base
-                  fields { }
-                  belongs_to :ad_category, null: #{nullable}
-                end
-              EOS
-              expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_flag[nullable])
-              expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(nullable)
-            end
+      [false, true].each do |nullable|
+        context "nullable=#{nullable}" do
+          it 'infers optional: from null:' do
+            eval <<~EOS
+              class AdvertBelongsTo < ActiveRecord::Base
+                fields { }
+                belongs_to :ad_category, null: #{nullable}
+              end
+            EOS
+            expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_flag[nullable])
+            expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(nullable)
+          end
 
-            it 'infers null: from optional:' do
-              eval <<~EOS
-                class AdvertBelongsTo < ActiveRecord::Base
-                  fields { }
-                  belongs_to :ad_category, optional: #{nullable}
-                end
-              EOS
-              expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_flag[nullable])
-              expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(nullable)
-            end
+          it 'infers null: from optional:' do
+            eval <<~EOS
+              class AdvertBelongsTo < ActiveRecord::Base
+                fields { }
+                belongs_to :ad_category, optional: #{nullable}
+              end
+            EOS
+            expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_flag[nullable])
+            expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(nullable)
           end
         end
       end
     end
+  end
 
-    describe 'migration base class' do
-      it 'adapts to Rails 4' do
+  describe 'migration base class' do
+    it 'adapts to Rails 4' do
+      class Advert < active_record_base_class.constantize
+        fields do
+          title :string, limit: 100
+        end
+      end
+
+      generate_migrations '-n', '-m'
+
+      migrations = Dir.glob('db/migrate/*declare_schema_migration*.rb')
+      expect(migrations.size).to eq(1), migrations.inspect
+
+      migration_content = File.read(migrations.first)
+      first_line = migration_content.split("\n").first
+      base_class = first_line.split(' < ').last
+      expect(base_class).to eq("(Rails::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration)")
+    end
+  end
+
+  context 'Does not generate migrations' do
+    it 'for aliased fields bigint -> integer limit 8' do
+      if Rails::VERSION::MAJOR >= 5 || !ActiveRecord::Base.connection.class.name.match?(/SQLite3Adapter/)
         class Advert < active_record_base_class.constantize
           fields do
-            title :string, limit: 100
+            price :bigint
           end
         end
 
@@ -1190,41 +1211,20 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         migrations = Dir.glob('db/migrate/*declare_schema_migration*.rb')
         expect(migrations.size).to eq(1), migrations.inspect
 
-        migration_content = File.read(migrations.first)
-        first_line = migration_content.split("\n").first
-        base_class = first_line.split(' < ').last
-        expect(base_class).to eq("(Rails::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration)")
-      end
-    end
-
-    context 'Does not generate migrations' do
-      it 'for aliased fields bigint -> integer limit 8' do
-        if Rails::VERSION::MAJOR >= 5 || !ActiveRecord::Base.connection.class.name.match?(/SQLite3Adapter/)
-          class Advert < active_record_base_class.constantize
-            fields do
-              price :bigint
-            end
-          end
-
-          generate_migrations '-n', '-m'
-
-          migrations = Dir.glob('db/migrate/*declare_schema_migration*.rb')
-          expect(migrations.size).to eq(1), migrations.inspect
-
-          if defined?(Mysql2) && Rails::VERSION::MAJOR < 5
-            ActiveRecord::Base.connection.execute("ALTER TABLE adverts ADD PRIMARY KEY (id)")
-          end
-
-          class Advert < active_record_base_class.constantize
-            fields do
-              price :integer, limit: 8
-            end
-          end
-
-          expect { generate_migrations '-n', '-g' }.to output("Database and models match -- nothing to change\n").to_stdout
+        if defined?(Mysql2) && Rails::VERSION::MAJOR < 5
+          ActiveRecord::Base.connection.execute("ALTER TABLE adverts ADD PRIMARY KEY (id)")
         end
+
+        class Advert < active_record_base_class.constantize
+          fields do
+            price :integer, limit: 8
+          end
+        end
+
+        expect { generate_migrations '-n', '-g' }.to output("Database and models match -- nothing to change\n").to_stdout
       end
     end
+  end
   end
 
   context 'Using declare_schema' do

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -1542,17 +1542,17 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       expect(Generators::DeclareSchema::Migration::Migrator.run).to(
           migrate_up(<<~EOS.strip)
           add_column :adverts, :category_id, :integer, limit: 8, null: false
-  
+
           add_index :adverts, [:category_id], name: 'on_category_id'
-  
-          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" if defined?(Mysql2)}
+
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" if defined?(Mysql2)}
           EOS
               .and migrate_down(<<~EOS.strip)
           remove_column :adverts, :category_id
-  
+
           remove_index :adverts, name: :on_category_id rescue ActiveRecord::StatementInvalid
-  
-          #{"remove_foreign_key(\"adverts\", name: \"index_adverts_on_category_id\")\n" if defined?(Mysql2)}
+
+          #{"remove_foreign_key(\"adverts\", name: \"on_category_id\")\n" if defined?(Mysql2)}
       EOS
       )
 
@@ -1570,11 +1570,11 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       expect(Generators::DeclareSchema::Migration::Migrator.run).to(
           migrate_up(<<~EOS.strip)
           add_column :adverts, :c_id, :integer, limit: 8, null: false
-  
+
           add_index :adverts, [:c_id], name: 'on_c_id'
-  
-          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
       EOS
       )
 
@@ -1592,9 +1592,9 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       expect(Generators::DeclareSchema::Migration::Migrator.run).to(
           migrate_up(<<~EOS.strip)
           add_column :adverts, :category_id, :integer, limit: 8, null: false
-  
-          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
       EOS
       )
 
@@ -1612,11 +1612,11 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       expect(Generators::DeclareSchema::Migration::Migrator.run).to(
           migrate_up(<<~EOS.strip)
           add_column :adverts, :category_id, :integer, limit: 8, null: false
-  
+
           add_index :adverts, [:category_id], name: 'my_index'
-  
-          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
       EOS
       )
 
@@ -1641,16 +1641,16 @@ RSpec.describe 'DeclareSchema Migration Generator' do
           add_column :adverts, :updated_at, :datetime, null: true
           add_column :adverts, :lock_version, :integer#{lock_version_limit}, null: false, default: 1
   
-          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-              "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
+              "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
           EOS
               .and migrate_down(<<~EOS.strip)
           remove_column :adverts, :created_at
           remove_column :adverts, :updated_at
           remove_column :adverts, :lock_version
-  
-          #{"remove_foreign_key(\"adverts\", name: \"index_adverts_on_category_id\")\n" +
-          "remove_foreign_key(\"adverts\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+
+          #{"remove_foreign_key(\"adverts\", name: \"on_category_id\")\n" +
+          "remove_foreign_key(\"adverts\", name: \"on_c_id\")" if defined?(Mysql2)}
       EOS
       )
 
@@ -1671,11 +1671,11 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       expect(Generators::DeclareSchema::Migration::Migrator.run).to(
           migrate_up(<<~EOS.strip)
           add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-  
+
           add_index :adverts, [:title], name: 'on_title'
-  
-          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
       EOS
       )
 
@@ -1692,11 +1692,11 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       expect(Generators::DeclareSchema::Migration::Migrator.run).to(
           migrate_up(<<~EOS.strip)
           add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-  
+
           add_index :adverts, [:title], unique: true, name: 'on_title'
-  
-          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
       EOS
       )
 
@@ -1713,11 +1713,11 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       expect(Generators::DeclareSchema::Migration::Migrator.run).to(
           migrate_up(<<~EOS.strip)
           add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-  
+
           add_index :adverts, [:title], name: 'my_index'
-  
-          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
       EOS
       )
 
@@ -1732,11 +1732,11 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       expect(Generators::DeclareSchema::Migration::Migrator.run).to(
           migrate_up(<<~EOS.strip)
           add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-  
+
           add_index :adverts, [:title], name: 'on_title'
-  
-          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
       EOS
       )
 
@@ -1751,11 +1751,11 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       expect(Generators::DeclareSchema::Migration::Migrator.run).to(
           migrate_up(<<~EOS.strip)
           add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-  
+
           add_index :adverts, [:title], unique: true, name: 'my_index'
-  
-          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
       EOS
       )
 
@@ -1770,11 +1770,11 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       expect(Generators::DeclareSchema::Migration::Migrator.run).to(
           migrate_up(<<~EOS.strip)
           add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-  
+
           add_index :adverts, [:title, :category_id], name: 'on_title_and_category_id'
-  
-          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")" if defined?(Mysql2)}
       EOS
       )
 
@@ -1802,30 +1802,30 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       expect(Generators::DeclareSchema::Migration::Migrator.run("adverts" => "ads")).to(
           migrate_up(<<~EOS.strip)
           rename_table :adverts, :ads
-  
+
           add_column :ads, :title, :string, limit: 250, null: true#{charset_and_collation}
           add_column :ads, :body, :text#{', limit: 4294967295' if defined?(Mysql2)}, null: true#{charset_and_collation}
-  
+
           #{if defined?(SQLite3)
                                                                                                                                                                                                                                "add_index :ads, [:id], unique: true, name: 'PRIMARY'\n"
             elsif defined?(Mysql2)
               "execute \"ALTER TABLE ads DROP PRIMARY KEY, ADD PRIMARY KEY (id)\"\n\n" +
-                  "add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-                  "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")"
+                  "add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"on_category_id\")\n" +
+                  "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"on_c_id\")"
             end}
           EOS
               .and migrate_down(<<~EOS.strip)
           remove_column :ads, :title
           remove_column :ads, :body
-  
+
           rename_table :ads, :adverts
-  
+
           #{if defined?(SQLite3)
               "add_index :adverts, [:id], unique: true, name: 'PRIMARY'\n"
             elsif defined?(Mysql2)
               "execute \"ALTER TABLE adverts DROP PRIMARY KEY, ADD PRIMARY KEY (id)\"\n\n" +
-                  "remove_foreign_key(\"adverts\", name: \"index_adverts_on_category_id\")\n" +
-                  "remove_foreign_key(\"adverts\", name: \"index_adverts_on_c_id\")"
+                  "remove_foreign_key(\"adverts\", name: \"on_category_id\")\n" +
+                  "remove_foreign_key(\"adverts\", name: \"on_c_id\")"
             end}
       EOS
       )
@@ -1856,11 +1856,11 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       expect(Generators::DeclareSchema::Migration::Migrator.run("adverts" => "advertisements")).to(
           migrate_up(<<~EOS.strip)
           rename_table :adverts, :advertisements
-  
+
           add_column :advertisements, :title, :string, limit: 250, null: true#{charset_and_collation}
           add_column :advertisements, :body, :text#{', limit: 4294967295' if defined?(Mysql2)}, null: true#{charset_and_collation}
           remove_column :advertisements, :name
-  
+
           #{if defined?(SQLite3)
                                                                                                                                                                                                                                                      "add_index :advertisements, [:id], unique: true, name: 'PRIMARY'"
             elsif defined?(Mysql2)
@@ -1871,9 +1871,9 @@ RSpec.describe 'DeclareSchema Migration Generator' do
           remove_column :advertisements, :title
           remove_column :advertisements, :body
           add_column :adverts, :name, :string, limit: 250, null: true#{charset_and_collation}
-  
+
           rename_table :advertisements, :adverts
-  
+
           #{if defined?(SQLite3)
                                                                                                            "add_index :adverts, [:id], unique: true, name: 'PRIMARY'"
             elsif defined?(Mysql2)
@@ -1925,12 +1925,12 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         expect(migrations).to(
             migrate_up(<<~EOS.strip)
             add_column :adverts, :type, :string, limit: 250, null: true#{charset_and_collation}
-  
+
             add_index :adverts, [:type], name: 'on_type'
             EOS
                 .and migrate_down(<<~EOS.strip)
             remove_column :adverts, :type
-  
+
             remove_index :adverts, name: :on_type rescue ActiveRecord::StatementInvalid
         EOS
         )
@@ -1993,10 +1993,10 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: :ads)).to(
           migrate_up(<<~EOS.strip)
           rename_table :adverts, :ads
-  
+
           add_column :ads, :created_at, :datetime, null: false
           change_column :ads, :title, :string, limit: 250, null: false, default: \"Untitled\"#{charset_and_collation}
-  
+
           #{if defined?(SQLite3)
                                                                                                                                    "add_index :ads, [:id], unique: true, name: 'PRIMARY'"
             elsif defined?(Mysql2)
@@ -2028,7 +2028,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: { id: :advert_id })).to(
           migrate_up(<<~EOS.strip)
           rename_column :adverts, :id, :advert_id
-  
+
           #{if defined?(SQLite3)
               "add_index :adverts, [:advert_id], unique: true, name: 'PRIMARY'"
             elsif defined?(Mysql2)

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -55,1153 +55,1133 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     end
   end
 
-  # DeclareSchema - Migration Generator
-  it 'generates migrations' do
-    ## The migration generator -- introduction
+  context 'Using fields' do
+    # DeclareSchema - Migration Generator
+    it 'generates migrations' do
+      ## The migration generator -- introduction
 
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to migrate_up("").and migrate_down("")
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to migrate_up("").and migrate_down("")
 
-    class Advert < ActiveRecord::Base
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to migrate_up("").and migrate_down("")
-
-    Generators::DeclareSchema::Migration::Migrator.ignore_tables = ["green_fishes"]
-
-    Advert.connection.schema_cache.clear!
-    Advert.reset_column_information
-
-    class Advert < ActiveRecord::Base
-      fields do
-        name :string, limit: 250, null: true
+      class Advert < ActiveRecord::Base
       end
-    end
 
-    up, _ = Generators::DeclareSchema::Migration::Migrator.run.tap do |migrations|
-      expect(migrations).to(
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to migrate_up("").and migrate_down("")
+
+      Generators::DeclareSchema::Migration::Migrator.ignore_tables = ["green_fishes"]
+
+      Advert.connection.schema_cache.clear!
+      Advert.reset_column_information
+
+      class Advert < ActiveRecord::Base
+        fields do
+          name :string, limit: 250, null: true
+        end
+      end
+
+      up, _ = Generators::DeclareSchema::Migration::Migrator.run.tap do |migrations|
+        expect(migrations).to(
+          migrate_up(<<~EOS.strip)
+            create_table :adverts, id: :bigint do |t|
+              t.string :name, limit: 250, null: true#{charset_and_collation}
+            end#{charset_alter_table}
+          EOS
+          .and migrate_down("drop_table :adverts")
+        )
+      end
+
+      ActiveRecord::Migration.class_eval(up)
+      expect(Advert.columns.map(&:name)).to eq(["id", "name"])
+
+      if Rails::VERSION::MAJOR < 5
+        # Rails 4 drivers don't always create PK properly. Fix that by dropping and recreating.
+        ActiveRecord::Base.connection.execute("drop table adverts")
+        if defined?(Mysql2)
+          ActiveRecord::Base.connection.execute("CREATE TABLE adverts (id integer PRIMARY KEY AUTO_INCREMENT NOT NULL, name varchar(250)) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin")
+        else
+          ActiveRecord::Base.connection.execute("CREATE TABLE adverts (id integer PRIMARY KEY AUTOINCREMENT  NOT NULL, name varchar(250))")
+        end
+      end
+
+      class Advert < ActiveRecord::Base
+        fields do
+          name :string, limit: 250, null: true
+          body :text, null: true
+          published_at :datetime, null: true
+        end
+      end
+
+      Advert.connection.schema_cache.clear!
+      Advert.reset_column_information
+
+      expect(migrate).to(
         migrate_up(<<~EOS.strip)
-          create_table :adverts, id: :bigint do |t|
-            t.string :name, limit: 250, null: true#{charset_and_collation}
-          end#{charset_alter_table}
+          add_column :adverts, :body, :text#{text_limit}, null: true#{charset_and_collation}
+          add_column :adverts, :published_at, :datetime, null: true
         EOS
-        .and migrate_down("drop_table :adverts")
+        .and migrate_down(<<~EOS.strip)
+          remove_column :adverts, :body
+          remove_column :adverts, :published_at
+        EOS
       )
-    end
 
-    ActiveRecord::Migration.class_eval(up)
-    expect(Advert.columns.map(&:name)).to eq(["id", "name"])
-
-    if Rails::VERSION::MAJOR < 5
-      # Rails 4 drivers don't always create PK properly. Fix that by dropping and recreating.
-      ActiveRecord::Base.connection.execute("drop table adverts")
-      if defined?(Mysql2)
-        ActiveRecord::Base.connection.execute("CREATE TABLE adverts (id integer PRIMARY KEY AUTO_INCREMENT NOT NULL, name varchar(250)) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin")
-      else
-        ActiveRecord::Base.connection.execute("CREATE TABLE adverts (id integer PRIMARY KEY AUTOINCREMENT  NOT NULL, name varchar(250))")
+      Advert.field_specs.clear # not normally needed
+      class Advert < ActiveRecord::Base
+        fields do
+          name :string, limit: 250, null: true
+          body :text, null: true
+        end
       end
-    end
 
-    class Advert < ActiveRecord::Base
-      fields do
-        name :string, limit: 250, null: true
-        body :text, null: true
-        published_at :datetime, null: true
-      end
-    end
-
-    Advert.connection.schema_cache.clear!
-    Advert.reset_column_information
-
-    expect(migrate).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :body, :text#{text_limit}, null: true#{charset_and_collation}
-        add_column :adverts, :published_at, :datetime, null: true
-      EOS
-      .and migrate_down(<<~EOS.strip)
-        remove_column :adverts, :body
-        remove_column :adverts, :published_at
-      EOS
-    )
-
-    Advert.field_specs.clear # not normally needed
-    class Advert < ActiveRecord::Base
-      fields do
-        name :string, limit: 250, null: true
-        body :text, null: true
-      end
-    end
-
-    expect(migrate).to(
-      migrate_up("remove_column :adverts, :published_at").and(
-        migrate_down("add_column :adverts, :published_at, :datetime#{datetime_precision}, null: true")
+      expect(migrate).to(
+        migrate_up("remove_column :adverts, :published_at").and(
+          migrate_down("add_column :adverts, :published_at, :datetime#{datetime_precision}, null: true")
+        )
       )
-    )
 
-    nuke_model_class(Advert)
-    class Advert < ActiveRecord::Base
-      fields do
-        title :string, limit: 250, null: true
-        body :text, null: true
+      nuke_model_class(Advert)
+      class Advert < ActiveRecord::Base
+        fields do
+          title :string, limit: 250, null: true
+          body :text, null: true
+        end
       end
-    end
 
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-        remove_column :adverts, :name
-      EOS
-      .and migrate_down(<<~EOS.strip)
-        remove_column :adverts, :title
-        add_column :adverts, :name, :string, limit: 250, null: true#{charset_and_collation}
-      EOS
-    )
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: { name: :title })).to(
-      migrate_up("rename_column :adverts, :name, :title").and(
-        migrate_down("rename_column :adverts, :title, :name")
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+          remove_column :adverts, :name
+        EOS
+        .and migrate_down(<<~EOS.strip)
+          remove_column :adverts, :title
+          add_column :adverts, :name, :string, limit: 250, null: true#{charset_and_collation}
+        EOS
       )
-    )
 
-    migrate
-
-    class Advert < ActiveRecord::Base
-      fields do
-        title :text, null: true
-        body :text, null: true
-      end
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up("change_column :adverts, :title, :text#{text_limit}, null: true#{charset_and_collation}").and(
-        migrate_down("change_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}")
+      expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: { name: :title })).to(
+        migrate_up("rename_column :adverts, :name, :title").and(
+          migrate_down("rename_column :adverts, :title, :name")
+        )
       )
-    )
 
-    class Advert < ActiveRecord::Base
-      fields do
-        title :string, default: "Untitled", limit: 250, null: true
-        body :text, null: true
+      migrate
+
+      class Advert < ActiveRecord::Base
+        fields do
+          title :text, null: true
+          body :text, null: true
+        end
       end
-    end
 
-    expect(migrate).to(
-      migrate_up(<<~EOS.strip)
-        change_column :adverts, :title, :string, limit: 250, null: true, default: "Untitled"#{charset_and_collation}
-      EOS
-      .and migrate_down(<<~EOS.strip)
-        change_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-      EOS
-    )
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up("change_column :adverts, :title, :text#{text_limit}, null: true#{charset_and_collation}").and(
+          migrate_down("change_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}")
+        )
+      )
 
-    ### Limits
-
-    class Advert < ActiveRecord::Base
-      fields do
-        price :integer, null: true, limit: 2
+      class Advert < ActiveRecord::Base
+        fields do
+          title :string, default: "Untitled", limit: 250, null: true
+          body :text, null: true
+        end
       end
-    end
 
-    up, _ = Generators::DeclareSchema::Migration::Migrator.run.tap do |migrations|
-      expect(migrations).to migrate_up("add_column :adverts, :price, :integer, limit: 2, null: true")
-    end
+      expect(migrate).to(
+        migrate_up(<<~EOS.strip)
+          change_column :adverts, :title, :string, limit: 250, null: true, default: "Untitled"#{charset_and_collation}
+        EOS
+        .and migrate_down(<<~EOS.strip)
+          change_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+        EOS
+      )
 
-    # Now run the migration, then change the limit:
+      ### Limits
 
-    ActiveRecord::Migration.class_eval(up)
-    class Advert < ActiveRecord::Base
-      fields do
-        price :integer, null: true, limit: 3
+      class Advert < ActiveRecord::Base
+        fields do
+          price :integer, null: true, limit: 2
+        end
       end
-    end
 
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        change_column :adverts, :price, :integer, limit: 3, null: true
-      EOS
-      .and migrate_down(<<~EOS.strip)
-        change_column :adverts, :price, :integer, limit: 2, null: true
-      EOS
-    )
-
-    ActiveRecord::Migration.class_eval("remove_column :adverts, :price")
-    class Advert < ActiveRecord::Base
-      fields do
-        price :decimal, precision: 4, scale: 1, null: true
+      up, _ = Generators::DeclareSchema::Migration::Migrator.run.tap do |migrations|
+        expect(migrations).to migrate_up("add_column :adverts, :price, :integer, limit: 2, null: true")
       end
-    end
 
-    # Limits are generally not needed for `text` fields, because by default, `text` fields will use the maximum size
-    # allowed for that database type (0xffffffff for LONGTEXT in MySQL unlimited in Postgres, 1 billion in Sqlite).
-    # If a `limit` is given, it will only be used in MySQL, to choose the smallest TEXT field that will accommodate
-    # that limit (0xff for TINYTEXT, 0xffff for TEXT, 0xffffff for MEDIUMTEXT, 0xffffffff for LONGTEXT).
+      # Now run the migration, then change the limit:
 
-    if defined?(SQLite3)
-      expect(::DeclareSchema::Model::FieldSpec.mysql_text_limits?).to be_falsey
-    end
-
-    class Advert < ActiveRecord::Base
-      fields do
-        notes :text
-        description :text, limit: 30000
+      ActiveRecord::Migration.class_eval(up)
+      class Advert < ActiveRecord::Base
+        fields do
+          price :integer, null: true, limit: 3
+        end
       end
-    end
 
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :price, :decimal, precision: 4, scale: 1, null: true
-        add_column :adverts, :notes, :text#{text_limit}, null: false#{charset_and_collation}
-        add_column :adverts, :description, :text#{', limit: 65535' if defined?(Mysql2)}, null: false#{charset_and_collation}
-      EOS
-    )
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          change_column :adverts, :price, :integer, limit: 3, null: true
+        EOS
+        .and migrate_down(<<~EOS.strip)
+          change_column :adverts, :price, :integer, limit: 2, null: true
+        EOS
+      )
 
-    Advert.field_specs.delete :price
-    Advert.field_specs.delete :notes
-    Advert.field_specs.delete :description
+      ActiveRecord::Migration.class_eval("remove_column :adverts, :price")
+      class Advert < ActiveRecord::Base
+        fields do
+          price :decimal, precision: 4, scale: 1, null: true
+        end
+      end
 
-    # In MySQL, limits are applied, rounded up:
+      # Limits are generally not needed for `text` fields, because by default, `text` fields will use the maximum size
+      # allowed for that database type (0xffffffff for LONGTEXT in MySQL unlimited in Postgres, 1 billion in Sqlite).
+      # If a `limit` is given, it will only be used in MySQL, to choose the smallest TEXT field that will accommodate
+      # that limit (0xff for TINYTEXT, 0xffff for TEXT, 0xffffff for MEDIUMTEXT, 0xffffffff for LONGTEXT).
 
-    if defined?(Mysql2)
-      expect(::DeclareSchema::Model::FieldSpec.mysql_text_limits?).to be_truthy
+      if defined?(SQLite3)
+        expect(::DeclareSchema::Model::FieldSpec.mysql_text_limits?).to be_falsey
+      end
 
       class Advert < ActiveRecord::Base
         fields do
           notes :text
-          description :text, limit: 250
+          description :text, limit: 30000
         end
       end
 
       expect(Generators::DeclareSchema::Migration::Migrator.run).to(
         migrate_up(<<~EOS.strip)
-          add_column :adverts, :notes, :text, limit: 4294967295, null: false#{charset_and_collation}
-          add_column :adverts, :description, :text, limit: 255, null: false#{charset_and_collation}
+          add_column :adverts, :price, :decimal, precision: 4, scale: 1, null: true
+          add_column :adverts, :notes, :text#{text_limit}, null: false#{charset_and_collation}
+          add_column :adverts, :description, :text#{', limit: 65535' if defined?(Mysql2)}, null: false#{charset_and_collation}
         EOS
       )
 
+      Advert.field_specs.delete :price
       Advert.field_specs.delete :notes
+      Advert.field_specs.delete :description
 
-      # Limits that are too high for MySQL will raise an exception.
+      # In MySQL, limits are applied, rounded up:
 
-      expect do
+      if defined?(Mysql2)
+        expect(::DeclareSchema::Model::FieldSpec.mysql_text_limits?).to be_truthy
+
         class Advert < ActiveRecord::Base
           fields do
             notes :text
-            description :text, limit: 0x1_0000_0000
-          end
-        end
-      end.to raise_exception(ArgumentError, "limit of 4294967296 is too large for MySQL")
-
-      Advert.field_specs.delete :notes
-
-      # And in MySQL, unstated text limits are treated as the maximum (LONGTEXT) limit.
-
-      # To start, we'll set the database schema for `description` to match the above limit of 250.
-
-      Advert.connection.execute "ALTER TABLE adverts ADD COLUMN description TINYTEXT"
-      Advert.connection.schema_cache.clear!
-      Advert.reset_column_information
-      expect(Advert.connection.tables - Generators::DeclareSchema::Migration::Migrator.always_ignore_tables).
-        to eq(["adverts"])
-      expect(Advert.columns.map(&:name)).to eq(["id", "body", "title", "description"])
-
-      # Now migrate to an unstated text limit:
-
-      class Advert < ActiveRecord::Base
-        fields do
-          description :text
-        end
-      end
-
-      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-        migrate_up(<<~EOS.strip)
-          change_column :adverts, :description, :text, limit: 4294967295, null: false#{charset_and_collation}
-        EOS
-        .and migrate_down(<<~EOS.strip)
-          change_column :adverts, :description, :text#{', limit: 255' if defined?(Mysql2)}, null: true#{charset_and_collation}
-        EOS
-      )
-
-      # And migrate to a stated text limit that is the same as the unstated one:
-
-      class Advert < ActiveRecord::Base
-        fields do
-          description :text, limit: 0xffffffff
-        end
-      end
-
-      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-        migrate_up(<<~EOS.strip)
-          change_column :adverts, :description, :text, limit: 4294967295, null: false#{charset_and_collation}
-        EOS
-        .and migrate_down(<<~EOS.strip)
-          change_column :adverts, :description, :text#{', limit: 255' if defined?(Mysql2)}, null: true#{charset_and_collation}
-        EOS
-      )
-    end
-
-    Advert.field_specs.clear
-    Advert.connection.schema_cache.clear!
-    Advert.reset_column_information
-    class Advert < ActiveRecord::Base
-      fields do
-        name :string, limit: 250, null: true
-      end
-    end
-
-    up = Generators::DeclareSchema::Migration::Migrator.run.first
-    ActiveRecord::Migration.class_eval up
-
-    Advert.connection.schema_cache.clear!
-    Advert.reset_column_information
-
-    ### Foreign Keys
-
-    # DeclareSchema extends the `belongs_to` macro so that it also declares the
-    # foreign-key field.  It also generates an index on the field.
-
-    class Category < ActiveRecord::Base; end
-    class Advert < ActiveRecord::Base
-      fields do
-        name :string, limit: 250, null: true
-      end
-      belongs_to :category
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :category_id, :integer, limit: 8, null: false
-
-        add_index :adverts, [:category_id], name: 'on_category_id'
-
-        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" if defined?(Mysql2)}
-      EOS
-      .and migrate_down(<<~EOS.strip)
-        remove_column :adverts, :category_id
-
-        remove_index :adverts, name: :on_category_id rescue ActiveRecord::StatementInvalid
-
-        #{"remove_foreign_key(\"adverts\", name: \"index_adverts_on_category_id\")\n" if defined?(Mysql2)}
-      EOS
-    )
-
-    Advert.field_specs.delete(:category_id)
-    Advert.index_definitions.delete_if { |spec| spec.fields==["category_id"] }
-
-    # If you specify a custom foreign key, the migration generator observes that:
-
-    class Category < ActiveRecord::Base; end
-    class Advert < ActiveRecord::Base
-      fields { }
-      belongs_to :category, foreign_key: "c_id", class_name: 'Category'
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :c_id, :integer, limit: 8, null: false
-
-        add_index :adverts, [:c_id], name: 'on_c_id'
-
-        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
-      EOS
-    )
-
-    Advert.field_specs.delete(:c_id)
-    Advert.index_definitions.delete_if { |spec| spec.fields == ["c_id"] }
-
-    # You can avoid generating the index by specifying `index: false`
-
-    class Category < ActiveRecord::Base; end
-    class Advert < ActiveRecord::Base
-      fields { }
-      belongs_to :category, index: false
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :category_id, :integer, limit: 8, null: false
-
-        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
-      EOS
-    )
-
-    Advert.field_specs.delete(:category_id)
-    Advert.index_definitions.delete_if { |spec| spec.fields == ["category_id"] }
-
-    # You can specify the index name with :index
-
-    class Category < ActiveRecord::Base; end
-    class Advert < ActiveRecord::Base
-      fields { }
-      belongs_to :category, index: 'my_index'
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :category_id, :integer, limit: 8, null: false
-
-        add_index :adverts, [:category_id], name: 'my_index'
-
-        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
-      EOS
-    )
-
-    Advert.field_specs.delete(:category_id)
-    Advert.index_definitions.delete_if { |spec| spec.fields == ["category_id"] }
-
-    ### Timestamps and Optimimistic Locking
-
-    # `updated_at` and `created_at` can be declared with the shorthand `timestamps`.
-    # Similarly, `lock_version` can be declared with the "shorthand" `optimimistic_lock`.
-
-    class Advert < ActiveRecord::Base
-      fields do
-        timestamps
-        optimistic_lock
-      end
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :created_at, :datetime, null: true
-        add_column :adverts, :updated_at, :datetime, null: true
-        add_column :adverts, :lock_version, :integer#{lock_version_limit}, null: false, default: 1
-
-        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
-      EOS
-      .and migrate_down(<<~EOS.strip)
-        remove_column :adverts, :created_at
-        remove_column :adverts, :updated_at
-        remove_column :adverts, :lock_version
-
-        #{"remove_foreign_key(\"adverts\", name: \"index_adverts_on_category_id\")\n" +
-          "remove_foreign_key(\"adverts\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
-      EOS
-    )
-
-    Advert.field_specs.delete(:updated_at)
-    Advert.field_specs.delete(:created_at)
-    Advert.field_specs.delete(:lock_version)
-
-    ### Indices
-
-    # You can add an index to a field definition
-
-    class Advert < ActiveRecord::Base
-      fields do
-        title :string, index: true, limit: 250, null: true
-      end
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-
-        add_index :adverts, [:title], name: 'on_title'
-
-        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
-      EOS
-    )
-
-    Advert.index_definitions.delete_if { |spec| spec.fields==["title"] }
-
-    # You can ask for a unique index
-
-    class Advert < ActiveRecord::Base
-      fields do
-        title :string, index: true, unique: true, null: true, limit: 250
-      end
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-
-        add_index :adverts, [:title], unique: true, name: 'on_title'
-
-        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
-      EOS
-    )
-
-    Advert.index_definitions.delete_if { |spec| spec.fields == ["title"] }
-
-    # You can specify the name for the index
-
-    class Advert < ActiveRecord::Base
-      fields do
-        title :string, index: 'my_index', limit: 250, null: true
-      end
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-
-        add_index :adverts, [:title], name: 'my_index'
-
-        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
-      EOS
-    )
-
-    Advert.index_definitions.delete_if { |spec| spec.fields==["title"] }
-
-    # You can ask for an index outside of the fields block
-
-    class Advert < ActiveRecord::Base
-      index :title
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-
-        add_index :adverts, [:title], name: 'on_title'
-
-        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
-      EOS
-    )
-
-    Advert.index_definitions.delete_if { |spec| spec.fields == ["title"] }
-
-    # The available options for the index function are `:unique` and `:name`
-
-    class Advert < ActiveRecord::Base
-      index :title, unique: true, name: 'my_index'
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-
-        add_index :adverts, [:title], unique: true, name: 'my_index'
-
-        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
-      EOS
-    )
-
-    Advert.index_definitions.delete_if { |spec| spec.fields == ["title"] }
-
-    # You can create an index on more than one field
-
-    class Advert < ActiveRecord::Base
-      index [:title, :category_id]
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-
-        add_index :adverts, [:title, :category_id], name: 'on_title_and_category_id'
-
-        #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
-      EOS
-    )
-
-    Advert.index_definitions.delete_if { |spec| spec.fields==["title", "category_id"] }
-
-    # Finally, you can specify that the migration generator should completely ignore an
-    # index by passing its name to ignore_index in the model.
-    # This is helpful for preserving indices that can't be automatically generated, such as prefix indices in MySQL.
-
-    ### Rename a table
-
-    # The migration generator respects the `set_table_name` declaration, although as before, we need to explicitly tell the generator that we want a rename rather than a create and a drop.
-
-    class Advert < ActiveRecord::Base
-      self.table_name = "ads"
-      fields do
-        title :string, limit: 250, null: true
-        body :text, null: true
-      end
-    end
-
-    Advert.connection.schema_cache.clear!
-    Advert.reset_column_information
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run("adverts" => "ads")).to(
-      migrate_up(<<~EOS.strip)
-        rename_table :adverts, :ads
-
-        add_column :ads, :title, :string, limit: 250, null: true#{charset_and_collation}
-        add_column :ads, :body, :text#{', limit: 4294967295' if defined?(Mysql2)}, null: true#{charset_and_collation}
-
-        #{if defined?(SQLite3)
-            "add_index :ads, [:id], unique: true, name: 'PRIMARY'\n"
-          elsif defined?(Mysql2)
-            "execute \"ALTER TABLE ads DROP PRIMARY KEY, ADD PRIMARY KEY (id)\"\n\n" +
-            "add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
-            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")"
-          end}
-      EOS
-      .and migrate_down(<<~EOS.strip)
-        remove_column :ads, :title
-        remove_column :ads, :body
-
-        rename_table :ads, :adverts
-
-        #{if defined?(SQLite3)
-            "add_index :adverts, [:id], unique: true, name: 'PRIMARY'\n"
-          elsif defined?(Mysql2)
-            "execute \"ALTER TABLE adverts DROP PRIMARY KEY, ADD PRIMARY KEY (id)\"\n\n" +
-            "remove_foreign_key(\"adverts\", name: \"index_adverts_on_category_id\")\n" +
-            "remove_foreign_key(\"adverts\", name: \"index_adverts_on_c_id\")"
-          end}
-      EOS
-    )
-
-    # Set the table name back to what it should be and confirm we're in sync:
-
-    nuke_model_class(Advert)
-
-    class Advert < ActiveRecord::Base
-      self.table_name = "adverts"
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to eq(["", ""])
-
-    ### Rename a table
-
-    # As with renaming columns, we have to tell the migration generator about the rename. Here we create a new class 'Advertisement', and tell ActiveRecord to forget about the Advert class. This requires code that shouldn't be shown to impressionable children.
-
-    nuke_model_class(Advert)
-
-    class Advertisement < ActiveRecord::Base
-      fields do
-        title :string, limit: 250, null: true
-        body :text, null: true
-      end
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run("adverts" => "advertisements")).to(
-      migrate_up(<<~EOS.strip)
-        rename_table :adverts, :advertisements
-
-        add_column :advertisements, :title, :string, limit: 250, null: true#{charset_and_collation}
-        add_column :advertisements, :body, :text#{', limit: 4294967295' if defined?(Mysql2)}, null: true#{charset_and_collation}
-        remove_column :advertisements, :name
-
-        #{if defined?(SQLite3)
-            "add_index :advertisements, [:id], unique: true, name: 'PRIMARY'"
-          elsif defined?(Mysql2)
-            "execute \"ALTER TABLE advertisements DROP PRIMARY KEY, ADD PRIMARY KEY (id)\""
-          end}
-      EOS
-      .and migrate_down(<<~EOS.strip)
-        remove_column :advertisements, :title
-        remove_column :advertisements, :body
-        add_column :adverts, :name, :string, limit: 250, null: true#{charset_and_collation}
-
-        rename_table :advertisements, :adverts
-
-        #{if defined?(SQLite3)
-            "add_index :adverts, [:id], unique: true, name: 'PRIMARY'"
-          elsif defined?(Mysql2)
-            "execute \"ALTER TABLE adverts DROP PRIMARY KEY, ADD PRIMARY KEY (id)\""
-          end}
-      EOS
-    )
-
-    ### Drop a table
-
-    nuke_model_class(Advertisement)
-
-    # If you delete a model, the migration generator will create a `drop_table` migration.
-
-    # Dropping tables is where the automatic down-migration really comes in handy:
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to(
-      migrate_up(<<~EOS.strip)
-        drop_table :adverts
-      EOS
-      .and migrate_down(<<~EOS.strip)
-        create_table "adverts"#{table_options}, force: :cascade do |t|
-          t.string "name", limit: 250#{charset_and_collation}
-        end
-      EOS
-    )
-
-    ## STI
-
-    ### Adding an STI subclass
-
-    # Adding a subclass or two should introduce the 'type' column and no other changes
-
-    class Advert < ActiveRecord::Base
-      fields do
-        body :text, null: true
-        title :string, default: "Untitled", limit: 250, null: true
-      end
-    end
-    up = Generators::DeclareSchema::Migration::Migrator.run.first
-    ActiveRecord::Migration.class_eval(up)
-
-    class FancyAdvert < Advert
-    end
-    class SuperFancyAdvert < FancyAdvert
-    end
-
-    up, _ = Generators::DeclareSchema::Migration::Migrator.run do |migrations|
-      expect(migrations).to(
-        migrate_up(<<~EOS.strip)
-          add_column :adverts, :type, :string, limit: 250, null: true#{charset_and_collation}
-
-          add_index :adverts, [:type], name: 'on_type'
-        EOS
-        .and migrate_down(<<~EOS.strip)
-          remove_column :adverts, :type
-
-          remove_index :adverts, name: :on_type rescue ActiveRecord::StatementInvalid
-        EOS
-      )
-    end
-
-    Advert.field_specs.delete(:type)
-    nuke_model_class(SuperFancyAdvert)
-    nuke_model_class(FancyAdvert)
-    Advert.index_definitions.delete_if { |spec| spec.fields==["type"] }
-
-    ## Coping with multiple changes
-
-    # The migration generator is designed to create complete migrations even if many changes to the models have taken place.
-
-    # First let's confirm we're in a known state. One model, 'Advert', with a string 'title' and text 'body':
-
-    ActiveRecord::Migration.class_eval up.gsub(/.*type.*/, '')
-    Advert.connection.schema_cache.clear!
-    Advert.reset_column_information
-
-    expect(Advert.connection.tables - Generators::DeclareSchema::Migration::Migrator.always_ignore_tables).
-      to eq(["adverts"])
-    expect(Advert.columns.map(&:name).sort).to eq(["body", "id", "title"])
-    expect(Generators::DeclareSchema::Migration::Migrator.run).to eq(["", ""])
-
-
-    ### Rename a column and change the default
-
-    Advert.field_specs.clear
-
-    class Advert < ActiveRecord::Base
-      fields do
-        name :string, default: "No Name", limit: 250, null: true
-        body :text, null: true
-      end
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: { title: :name })).to(
-      migrate_up(<<~EOS.strip)
-        rename_column :adverts, :title, :name
-        change_column :adverts, :name, :string, limit: 250, null: true, default: "No Name"#{charset_and_collation}
-      EOS
-      .and migrate_down(<<~EOS.strip)
-        rename_column :adverts, :name, :title
-        change_column :adverts, :title, :string, limit: 250, null: true, default: "Untitled"#{charset_and_collation}
-      EOS
-    )
-
-    ### Rename a table and add a column
-
-    nuke_model_class(Advert)
-    class Ad < ActiveRecord::Base
-      fields do
-        title      :string, default: "Untitled", limit: 250
-        body       :text, null: true
-        created_at :datetime
-      end
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: :ads)).to(
-      migrate_up(<<~EOS.strip)
-        rename_table :adverts, :ads
-
-        add_column :ads, :created_at, :datetime, null: false
-        change_column :ads, :title, :string, limit: 250, null: false, default: \"Untitled\"#{charset_and_collation}
-
-        #{if defined?(SQLite3)
-            "add_index :ads, [:id], unique: true, name: 'PRIMARY'"
-          elsif defined?(Mysql2)
-            'execute "ALTER TABLE ads DROP PRIMARY KEY, ADD PRIMARY KEY (id)"'
-          end}
-      EOS
-    )
-
-    class Advert < ActiveRecord::Base
-      fields do
-        body :text, null: true
-        title :string, default: "Untitled", limit: 250, null: true
-      end
-    end
-
-    ## Legacy Keys
-
-    # DeclareSchema has some support for legacy keys.
-
-    nuke_model_class(Ad)
-
-    class Advert < ActiveRecord::Base
-      fields do
-        body :text, null: true
-      end
-      self.primary_key = "advert_id"
-    end
-
-    expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: { id: :advert_id })).to(
-      migrate_up(<<~EOS.strip)
-        rename_column :adverts, :id, :advert_id
-
-        #{if defined?(SQLite3)
-            "add_index :adverts, [:advert_id], unique: true, name: 'PRIMARY'"
-          elsif defined?(Mysql2)
-          'execute "ALTER TABLE adverts DROP PRIMARY KEY, ADD PRIMARY KEY (advert_id)"'
-          end}
-      EOS
-    )
-
-    nuke_model_class(Advert)
-    ActiveRecord::Base.connection.execute("drop table `adverts`;")
-
-    ## DSL
-
-    # The DSL allows lambdas and constants
-
-    class User < ActiveRecord::Base
-      fields do
-        company :string, limit: 250, ruby_default: -> { "BigCorp" }
-      end
-    end
-    expect(User.field_specs.keys).to eq(['company'])
-    expect(User.field_specs['company'].options[:ruby_default]&.call).to eq("BigCorp")
-
-    ## validates
-
-    # DeclareSchema can accept a validates hash in the field options.
-
-    class Ad < ActiveRecord::Base
-      class << self
-        def validates(field_name, options)
-        end
-      end
-    end
-    expect(Ad).to receive(:validates).with(:company, presence: true, uniqueness: { case_sensitive: false })
-    class Ad < ActiveRecord::Base
-      fields do
-        company :string, limit: 250, index: true, unique: true, validates: { presence: true, uniqueness: { case_sensitive: false } }
-      end
-      self.primary_key = "advert_id"
-    end
-    up, _down = Generators::DeclareSchema::Migration::Migrator.run
-    ActiveRecord::Migration.class_eval(up)
-    expect(Ad.field_specs['company'].options[:validates].inspect).to eq("{:presence=>true, :uniqueness=>{:case_sensitive=>false}}")
-  end
-
-  describe 'serialize' do
-    before do
-      class Ad < ActiveRecord::Base
-        @serialize_args = []
-
-        class << self
-          attr_reader :serialize_args
-
-          def serialize(*args)
-            @serialize_args << args
-          end
-        end
-      end
-    end
-
-    describe 'untyped' do
-      it 'allows serialize: true' do
-        class Ad < ActiveRecord::Base
-          fields do
-            allow_list :text, limit: 0xFFFF, serialize: true
+            description :text, limit: 250
           end
         end
 
-        expect(Ad.serialize_args).to eq([[:allow_list]])
-      end
+        expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+          migrate_up(<<~EOS.strip)
+            add_column :adverts, :notes, :text, limit: 4294967295, null: false#{charset_and_collation}
+            add_column :adverts, :description, :text, limit: 255, null: false#{charset_and_collation}
+          EOS
+        )
 
-      it 'converts defaults with .to_yaml' do
-        class Ad < ActiveRecord::Base
-          fields do
-            allow_list :string, limit: 250, serialize: true, null: true, default: []
-            allow_hash :string, limit: 250, serialize: true, null: true, default: {}
-            allow_string :string, limit: 250, serialize: true, null: true, default: ['abc']
-            allow_null :string, limit: 250, serialize: true, null: true, default: nil
+        Advert.field_specs.delete :notes
+
+        # Limits that are too high for MySQL will raise an exception.
+
+        expect do
+          class Advert < ActiveRecord::Base
+            fields do
+              notes :text
+              description :text, limit: 0x1_0000_0000
+            end
           end
-        end
+        end.to raise_exception(ArgumentError, "limit of 4294967296 is too large for MySQL")
 
-        expect(Ad.field_specs['allow_list'].default).to eq("--- []\n")
-        expect(Ad.field_specs['allow_hash'].default).to eq("--- {}\n")
-        expect(Ad.field_specs['allow_string'].default).to eq("---\n- abc\n")
-        expect(Ad.field_specs['allow_null'].default).to eq(nil)
-      end
-    end
+        Advert.field_specs.delete :notes
 
-    describe 'Array' do
-      it 'allows serialize: Array' do
-        class Ad < ActiveRecord::Base
-          fields do
-            allow_list :string, limit: 250, serialize: Array, null: true
-          end
-        end
+        # And in MySQL, unstated text limits are treated as the maximum (LONGTEXT) limit.
 
-        expect(Ad.serialize_args).to eq([[:allow_list, Array]])
-      end
+        # To start, we'll set the database schema for `description` to match the above limit of 250.
 
-      it 'allows Array defaults' do
-        class Ad < ActiveRecord::Base
-          fields do
-            allow_list :string, limit: 250, serialize: Array, null: true, default: [2]
-            allow_string :string, limit: 250, serialize: Array, null: true, default: ['abc']
-            allow_empty :string, limit: 250, serialize: Array, null: true, default: []
-            allow_null :string, limit: 250, serialize: Array, null: true, default: nil
-          end
-        end
+        Advert.connection.execute "ALTER TABLE adverts ADD COLUMN description TINYTEXT"
+        Advert.connection.schema_cache.clear!
+        Advert.reset_column_information
+        expect(Advert.connection.tables - Generators::DeclareSchema::Migration::Migrator.always_ignore_tables).
+          to eq(["adverts"])
+        expect(Advert.columns.map(&:name)).to eq(["id", "body", "title", "description"])
 
-        expect(Ad.field_specs['allow_list'].default).to eq("---\n- 2\n")
-        expect(Ad.field_specs['allow_string'].default).to eq("---\n- abc\n")
-        expect(Ad.field_specs['allow_empty'].default).to eq(nil)
-        expect(Ad.field_specs['allow_null'].default).to eq(nil)
-      end
-    end
-
-    describe 'Hash' do
-      it 'allows serialize: Hash' do
-        class Ad < ActiveRecord::Base
-          fields do
-            allow_list :string, limit: 250, serialize: Hash, null: true
-          end
-        end
-
-        expect(Ad.serialize_args).to eq([[:allow_list, Hash]])
-      end
-
-      it 'allows Hash defaults' do
-        class Ad < ActiveRecord::Base
-          fields do
-            allow_loc :string, limit: 250, serialize: Hash, null: true, default: { 'state' => 'CA' }
-            allow_hash :string, limit: 250, serialize: Hash, null: true, default: {}
-            allow_null :string, limit: 250, serialize: Hash, null: true, default: nil
-          end
-        end
-
-        expect(Ad.field_specs['allow_loc'].default).to eq("---\nstate: CA\n")
-        expect(Ad.field_specs['allow_hash'].default).to eq(nil)
-        expect(Ad.field_specs['allow_null'].default).to eq(nil)
-      end
-    end
-
-    describe 'JSON' do
-      it 'allows serialize: JSON' do
-        class Ad < ActiveRecord::Base
-          fields do
-            allow_list :string, limit: 250, serialize: JSON
-          end
-        end
-
-        expect(Ad.serialize_args).to eq([[:allow_list, JSON]])
-      end
-
-      it 'allows JSON defaults' do
-        class Ad < ActiveRecord::Base
-          fields do
-            allow_hash :string, limit: 250, serialize: JSON, null: true, default: { 'state' => 'CA' }
-            allow_empty_array :string, limit: 250, serialize: JSON, null: true, default: []
-            allow_empty_hash :string, limit: 250, serialize: JSON, null: true, default: {}
-            allow_null :string, limit: 250, serialize: JSON, null: true, default: nil
-          end
-        end
-
-        expect(Ad.field_specs['allow_hash'].default).to eq("{\"state\":\"CA\"}")
-        expect(Ad.field_specs['allow_empty_array'].default).to eq("[]")
-        expect(Ad.field_specs['allow_empty_hash'].default).to eq("{}")
-        expect(Ad.field_specs['allow_null'].default).to eq(nil)
-      end
-    end
-
-    class ValueClass
-      delegate :present?, :inspect, to: :@value
-
-      def initialize(value)
-        @value = value
-      end
-
-      class << self
-        def dump(object)
-          if object&.present?
-            object.inspect
-          end
-        end
-
-        def load(serialized)
-          if serialized
-            raise 'not used ???'
-          end
-        end
-      end
-    end
-
-    describe 'custom coder' do
-      it 'allows serialize: ValueClass' do
-        class Ad < ActiveRecord::Base
-          fields do
-            allow_list :string, limit: 250, serialize: ValueClass
-          end
-        end
-
-        expect(Ad.serialize_args).to eq([[:allow_list, ValueClass]])
-      end
-
-      it 'allows ValueClass defaults' do
-        class Ad < ActiveRecord::Base
-          fields do
-            allow_hash :string, limit: 250, serialize: ValueClass, null: true, default: ValueClass.new([2])
-            allow_empty_array :string, limit: 250, serialize: ValueClass, null: true, default: ValueClass.new([])
-            allow_null :string, limit: 250, serialize: ValueClass, null: true, default: nil
-          end
-        end
-
-        expect(Ad.field_specs['allow_hash'].default).to eq("[2]")
-        expect(Ad.field_specs['allow_empty_array'].default).to eq(nil)
-        expect(Ad.field_specs['allow_null'].default).to eq(nil)
-      end
-    end
-
-    it 'disallows serialize: with a non-string column type' do
-      expect do
-        class Ad < ActiveRecord::Base
-          fields do
-            allow_list :integer, limit: 8, serialize: true
-          end
-        end
-      end.to raise_exception(ArgumentError, /must be :string or :text/)
-    end
-  end
-
-  context "for Rails #{Rails::VERSION::MAJOR}" do
-    if Rails::VERSION::MAJOR >= 5
-      let(:optional_true) { { optional: true } }
-      let(:optional_false) { { optional: false } }
-    else
-      let(:optional_true) { {} }
-      let(:optional_false) { {} }
-    end
-    let(:optional_flag) { { false => optional_false, true => optional_true } }
-
-    describe 'belongs_to' do
-      before do
-        unless defined?(AdCategory)
-          class AdCategory < ActiveRecord::Base
-            fields { }
-          end
-        end
+        # Now migrate to an unstated text limit:
 
         class Advert < ActiveRecord::Base
           fields do
-            name :string, limit: 250, null: true
-            category_id :integer, limit: 8
-            nullable_category_id :integer, limit: 8, null: true
+            description :text
           end
         end
-        up = Generators::DeclareSchema::Migration::Migrator.run.first
-        ActiveRecord::Migration.class_eval(up)
-      end
 
-      it 'passes through optional: when given' do
-        class AdvertBelongsTo < ActiveRecord::Base
-          self.table_name = 'adverts'
-          fields { }
-          reset_column_information
-          belongs_to :ad_category, optional: true
+        expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+          migrate_up(<<~EOS.strip)
+            change_column :adverts, :description, :text, limit: 4294967295, null: false#{charset_and_collation}
+          EOS
+          .and migrate_down(<<~EOS.strip)
+            change_column :adverts, :description, :text#{', limit: 255' if defined?(Mysql2)}, null: true#{charset_and_collation}
+          EOS
+        )
+
+        # And migrate to a stated text limit that is the same as the unstated one:
+
+        class Advert < ActiveRecord::Base
+          fields do
+            description :text, limit: 0xffffffff
+          end
         end
-        expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_true)
+
+        expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+          migrate_up(<<~EOS.strip)
+            change_column :adverts, :description, :text, limit: 4294967295, null: false#{charset_and_collation}
+          EOS
+          .and migrate_down(<<~EOS.strip)
+            change_column :adverts, :description, :text#{', limit: 255' if defined?(Mysql2)}, null: true#{charset_and_collation}
+          EOS
+        )
       end
 
-      describe 'contradictory settings' do # contradictory settings are ok--for example, during migration
-        it 'passes through optional: true, null: false' do
+      Advert.field_specs.clear
+      Advert.connection.schema_cache.clear!
+      Advert.reset_column_information
+      class Advert < ActiveRecord::Base
+        fields do
+          name :string, limit: 250, null: true
+        end
+      end
+
+      up = Generators::DeclareSchema::Migration::Migrator.run.first
+      ActiveRecord::Migration.class_eval up
+
+      Advert.connection.schema_cache.clear!
+      Advert.reset_column_information
+
+      ### Foreign Keys
+
+      # DeclareSchema extends the `belongs_to` macro so that it also declares the
+      # foreign-key field.  It also generates an index on the field.
+
+      class Category < ActiveRecord::Base; end
+      class Advert < ActiveRecord::Base
+        fields do
+          name :string, limit: 250, null: true
+        end
+        belongs_to :category
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :category_id, :integer, limit: 8, null: false
+  
+          add_index :adverts, [:category_id], name: 'on_category_id'
+  
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" if defined?(Mysql2)}
+        EOS
+        .and migrate_down(<<~EOS.strip)
+          remove_column :adverts, :category_id
+  
+          remove_index :adverts, name: :on_category_id rescue ActiveRecord::StatementInvalid
+  
+          #{"remove_foreign_key(\"adverts\", name: \"index_adverts_on_category_id\")\n" if defined?(Mysql2)}
+        EOS
+      )
+
+      Advert.field_specs.delete(:category_id)
+      Advert.index_definitions.delete_if { |spec| spec.fields==["category_id"] }
+
+      # If you specify a custom foreign key, the migration generator observes that:
+
+      class Category < ActiveRecord::Base; end
+      class Advert < ActiveRecord::Base
+        fields { }
+        belongs_to :category, foreign_key: "c_id", class_name: 'Category'
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :c_id, :integer, limit: 8, null: false
+  
+          add_index :adverts, [:c_id], name: 'on_c_id'
+  
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+        EOS
+      )
+
+      Advert.field_specs.delete(:c_id)
+      Advert.index_definitions.delete_if { |spec| spec.fields == ["c_id"] }
+
+      # You can avoid generating the index by specifying `index: false`
+
+      class Category < ActiveRecord::Base; end
+      class Advert < ActiveRecord::Base
+        fields { }
+        belongs_to :category, index: false
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :category_id, :integer, limit: 8, null: false
+  
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+        EOS
+      )
+
+      Advert.field_specs.delete(:category_id)
+      Advert.index_definitions.delete_if { |spec| spec.fields == ["category_id"] }
+
+      # You can specify the index name with :index
+
+      class Category < ActiveRecord::Base; end
+      class Advert < ActiveRecord::Base
+        fields { }
+        belongs_to :category, index: 'my_index'
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :category_id, :integer, limit: 8, null: false
+  
+          add_index :adverts, [:category_id], name: 'my_index'
+  
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+        EOS
+      )
+
+      Advert.field_specs.delete(:category_id)
+      Advert.index_definitions.delete_if { |spec| spec.fields == ["category_id"] }
+
+      ### Timestamps and Optimimistic Locking
+
+      # `updated_at` and `created_at` can be declared with the shorthand `timestamps`.
+      # Similarly, `lock_version` can be declared with the "shorthand" `optimimistic_lock`.
+
+      class Advert < ActiveRecord::Base
+        fields do
+          timestamps
+          optimistic_lock
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :created_at, :datetime, null: true
+          add_column :adverts, :updated_at, :datetime, null: true
+          add_column :adverts, :lock_version, :integer#{lock_version_limit}, null: false, default: 1
+  
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+        EOS
+        .and migrate_down(<<~EOS.strip)
+          remove_column :adverts, :created_at
+          remove_column :adverts, :updated_at
+          remove_column :adverts, :lock_version
+  
+          #{"remove_foreign_key(\"adverts\", name: \"index_adverts_on_category_id\")\n" +
+            "remove_foreign_key(\"adverts\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+        EOS
+      )
+
+      Advert.field_specs.delete(:updated_at)
+      Advert.field_specs.delete(:created_at)
+      Advert.field_specs.delete(:lock_version)
+
+      ### Indices
+
+      # You can add an index to a field definition
+
+      class Advert < ActiveRecord::Base
+        fields do
+          title :string, index: true, limit: 250, null: true
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+  
+          add_index :adverts, [:title], name: 'on_title'
+  
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+        EOS
+      )
+
+      Advert.index_definitions.delete_if { |spec| spec.fields==["title"] }
+
+      # You can ask for a unique index
+
+      class Advert < ActiveRecord::Base
+        fields do
+          title :string, index: true, unique: true, null: true, limit: 250
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+  
+          add_index :adverts, [:title], unique: true, name: 'on_title'
+  
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+        EOS
+      )
+
+      Advert.index_definitions.delete_if { |spec| spec.fields == ["title"] }
+
+      # You can specify the name for the index
+
+      class Advert < ActiveRecord::Base
+        fields do
+          title :string, index: 'my_index', limit: 250, null: true
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+  
+          add_index :adverts, [:title], name: 'my_index'
+  
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+        EOS
+      )
+
+      Advert.index_definitions.delete_if { |spec| spec.fields==["title"] }
+
+      # You can ask for an index outside of the fields block
+
+      class Advert < ActiveRecord::Base
+        index :title
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+  
+          add_index :adverts, [:title], name: 'on_title'
+  
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+        EOS
+      )
+
+      Advert.index_definitions.delete_if { |spec| spec.fields == ["title"] }
+
+      # The available options for the index function are `:unique` and `:name`
+
+      class Advert < ActiveRecord::Base
+        index :title, unique: true, name: 'my_index'
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+  
+          add_index :adverts, [:title], unique: true, name: 'my_index'
+  
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+        EOS
+      )
+
+      Advert.index_definitions.delete_if { |spec| spec.fields == ["title"] }
+
+      # You can create an index on more than one field
+
+      class Advert < ActiveRecord::Base
+        index [:title, :category_id]
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+  
+          add_index :adverts, [:title, :category_id], name: 'on_title_and_category_id'
+  
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+            "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+        EOS
+      )
+
+      Advert.index_definitions.delete_if { |spec| spec.fields==["title", "category_id"] }
+
+      # Finally, you can specify that the migration generator should completely ignore an
+      # index by passing its name to ignore_index in the model.
+      # This is helpful for preserving indices that can't be automatically generated, such as prefix indices in MySQL.
+
+      ### Rename a table
+
+      # The migration generator respects the `set_table_name` declaration, although as before, we need to explicitly tell the generator that we want a rename rather than a create and a drop.
+
+      class Advert < ActiveRecord::Base
+        self.table_name = "ads"
+        fields do
+          title :string, limit: 250, null: true
+          body :text, null: true
+        end
+      end
+
+      Advert.connection.schema_cache.clear!
+      Advert.reset_column_information
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run("adverts" => "ads")).to(
+        migrate_up(<<~EOS.strip)
+          rename_table :adverts, :ads
+  
+          add_column :ads, :title, :string, limit: 250, null: true#{charset_and_collation}
+          add_column :ads, :body, :text#{', limit: 4294967295' if defined?(Mysql2)}, null: true#{charset_and_collation}
+  
+          #{if defined?(SQLite3)
+              "add_index :ads, [:id], unique: true, name: 'PRIMARY'\n"
+            elsif defined?(Mysql2)
+              "execute \"ALTER TABLE ads DROP PRIMARY KEY, ADD PRIMARY KEY (id)\"\n\n" +
+              "add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+              "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")"
+            end}
+        EOS
+        .and migrate_down(<<~EOS.strip)
+          remove_column :ads, :title
+          remove_column :ads, :body
+  
+          rename_table :ads, :adverts
+  
+          #{if defined?(SQLite3)
+              "add_index :adverts, [:id], unique: true, name: 'PRIMARY'\n"
+            elsif defined?(Mysql2)
+              "execute \"ALTER TABLE adverts DROP PRIMARY KEY, ADD PRIMARY KEY (id)\"\n\n" +
+              "remove_foreign_key(\"adverts\", name: \"index_adverts_on_category_id\")\n" +
+              "remove_foreign_key(\"adverts\", name: \"index_adverts_on_c_id\")"
+            end}
+        EOS
+      )
+
+      # Set the table name back to what it should be and confirm we're in sync:
+
+      nuke_model_class(Advert)
+
+      class Advert < ActiveRecord::Base
+        self.table_name = "adverts"
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to eq(["", ""])
+
+      ### Rename a table
+
+      # As with renaming columns, we have to tell the migration generator about the rename. Here we create a new class 'Advertisement', and tell ActiveRecord to forget about the Advert class. This requires code that shouldn't be shown to impressionable children.
+
+      nuke_model_class(Advert)
+
+      class Advertisement < ActiveRecord::Base
+        fields do
+          title :string, limit: 250, null: true
+          body :text, null: true
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run("adverts" => "advertisements")).to(
+        migrate_up(<<~EOS.strip)
+          rename_table :adverts, :advertisements
+  
+          add_column :advertisements, :title, :string, limit: 250, null: true#{charset_and_collation}
+          add_column :advertisements, :body, :text#{', limit: 4294967295' if defined?(Mysql2)}, null: true#{charset_and_collation}
+          remove_column :advertisements, :name
+  
+          #{if defined?(SQLite3)
+              "add_index :advertisements, [:id], unique: true, name: 'PRIMARY'"
+            elsif defined?(Mysql2)
+              "execute \"ALTER TABLE advertisements DROP PRIMARY KEY, ADD PRIMARY KEY (id)\""
+            end}
+        EOS
+        .and migrate_down(<<~EOS.strip)
+          remove_column :advertisements, :title
+          remove_column :advertisements, :body
+          add_column :adverts, :name, :string, limit: 250, null: true#{charset_and_collation}
+  
+          rename_table :advertisements, :adverts
+  
+          #{if defined?(SQLite3)
+              "add_index :adverts, [:id], unique: true, name: 'PRIMARY'"
+            elsif defined?(Mysql2)
+              "execute \"ALTER TABLE adverts DROP PRIMARY KEY, ADD PRIMARY KEY (id)\""
+            end}
+        EOS
+      )
+
+      ### Drop a table
+
+      nuke_model_class(Advertisement)
+
+      # If you delete a model, the migration generator will create a `drop_table` migration.
+
+      # Dropping tables is where the automatic down-migration really comes in handy:
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          drop_table :adverts
+        EOS
+        .and migrate_down(<<~EOS.strip)
+          create_table "adverts"#{table_options}, force: :cascade do |t|
+            t.string "name", limit: 250#{charset_and_collation}
+          end
+        EOS
+      )
+
+      ## STI
+
+      ### Adding an STI subclass
+
+      # Adding a subclass or two should introduce the 'type' column and no other changes
+
+      class Advert < ActiveRecord::Base
+        fields do
+          body :text, null: true
+          title :string, default: "Untitled", limit: 250, null: true
+        end
+      end
+      up = Generators::DeclareSchema::Migration::Migrator.run.first
+      ActiveRecord::Migration.class_eval(up)
+
+      class FancyAdvert < Advert
+      end
+      class SuperFancyAdvert < FancyAdvert
+      end
+
+      up, _ = Generators::DeclareSchema::Migration::Migrator.run do |migrations|
+        expect(migrations).to(
+          migrate_up(<<~EOS.strip)
+            add_column :adverts, :type, :string, limit: 250, null: true#{charset_and_collation}
+  
+            add_index :adverts, [:type], name: 'on_type'
+          EOS
+          .and migrate_down(<<~EOS.strip)
+            remove_column :adverts, :type
+  
+            remove_index :adverts, name: :on_type rescue ActiveRecord::StatementInvalid
+          EOS
+        )
+      end
+
+      Advert.field_specs.delete(:type)
+      nuke_model_class(SuperFancyAdvert)
+      nuke_model_class(FancyAdvert)
+      Advert.index_definitions.delete_if { |spec| spec.fields==["type"] }
+
+      ## Coping with multiple changes
+
+      # The migration generator is designed to create complete migrations even if many changes to the models have taken place.
+
+      # First let's confirm we're in a known state. One model, 'Advert', with a string 'title' and text 'body':
+
+      ActiveRecord::Migration.class_eval up.gsub(/.*type.*/, '')
+      Advert.connection.schema_cache.clear!
+      Advert.reset_column_information
+
+      expect(Advert.connection.tables - Generators::DeclareSchema::Migration::Migrator.always_ignore_tables).
+        to eq(["adverts"])
+      expect(Advert.columns.map(&:name).sort).to eq(["body", "id", "title"])
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to eq(["", ""])
+
+
+      ### Rename a column and change the default
+
+      Advert.field_specs.clear
+
+      class Advert < ActiveRecord::Base
+        fields do
+          name :string, default: "No Name", limit: 250, null: true
+          body :text, null: true
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: { title: :name })).to(
+        migrate_up(<<~EOS.strip)
+          rename_column :adverts, :title, :name
+          change_column :adverts, :name, :string, limit: 250, null: true, default: "No Name"#{charset_and_collation}
+        EOS
+        .and migrate_down(<<~EOS.strip)
+          rename_column :adverts, :name, :title
+          change_column :adverts, :title, :string, limit: 250, null: true, default: "Untitled"#{charset_and_collation}
+        EOS
+      )
+
+      ### Rename a table and add a column
+
+      nuke_model_class(Advert)
+      class Ad < ActiveRecord::Base
+        fields do
+          title      :string, default: "Untitled", limit: 250
+          body       :text, null: true
+          created_at :datetime
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: :ads)).to(
+        migrate_up(<<~EOS.strip)
+          rename_table :adverts, :ads
+  
+          add_column :ads, :created_at, :datetime, null: false
+          change_column :ads, :title, :string, limit: 250, null: false, default: \"Untitled\"#{charset_and_collation}
+  
+          #{if defined?(SQLite3)
+              "add_index :ads, [:id], unique: true, name: 'PRIMARY'"
+            elsif defined?(Mysql2)
+              'execute "ALTER TABLE ads DROP PRIMARY KEY, ADD PRIMARY KEY (id)"'
+            end}
+        EOS
+      )
+
+      class Advert < ActiveRecord::Base
+        fields do
+          body :text, null: true
+          title :string, default: "Untitled", limit: 250, null: true
+        end
+      end
+
+      ## Legacy Keys
+
+      # DeclareSchema has some support for legacy keys.
+
+      nuke_model_class(Ad)
+
+      class Advert < ActiveRecord::Base
+        fields do
+          body :text, null: true
+        end
+        self.primary_key = "advert_id"
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: { id: :advert_id })).to(
+        migrate_up(<<~EOS.strip)
+          rename_column :adverts, :id, :advert_id
+  
+          #{if defined?(SQLite3)
+              "add_index :adverts, [:advert_id], unique: true, name: 'PRIMARY'"
+            elsif defined?(Mysql2)
+            'execute "ALTER TABLE adverts DROP PRIMARY KEY, ADD PRIMARY KEY (advert_id)"'
+            end}
+        EOS
+      )
+
+      nuke_model_class(Advert)
+      ActiveRecord::Base.connection.execute("drop table `adverts`;")
+
+      ## DSL
+
+      # The DSL allows lambdas and constants
+
+      class User < ActiveRecord::Base
+        fields do
+          company :string, limit: 250, ruby_default: -> { "BigCorp" }
+        end
+      end
+      expect(User.field_specs.keys).to eq(['company'])
+      expect(User.field_specs['company'].options[:ruby_default]&.call).to eq("BigCorp")
+
+      ## validates
+
+      # DeclareSchema can accept a validates hash in the field options.
+
+      class Ad < ActiveRecord::Base
+        class << self
+          def validates(field_name, options)
+          end
+        end
+      end
+      expect(Ad).to receive(:validates).with(:company, presence: true, uniqueness: { case_sensitive: false })
+      class Ad < ActiveRecord::Base
+        fields do
+          company :string, limit: 250, index: true, unique: true, validates: { presence: true, uniqueness: { case_sensitive: false } }
+        end
+        self.primary_key = "advert_id"
+      end
+      up, _down = Generators::DeclareSchema::Migration::Migrator.run
+      ActiveRecord::Migration.class_eval(up)
+      expect(Ad.field_specs['company'].options[:validates].inspect).to eq("{:presence=>true, :uniqueness=>{:case_sensitive=>false}}")
+    end
+
+    describe 'serialize' do
+      before do
+        class Ad < ActiveRecord::Base
+          @serialize_args = []
+
+          class << self
+            attr_reader :serialize_args
+
+            def serialize(*args)
+              @serialize_args << args
+            end
+          end
+        end
+      end
+
+      describe 'untyped' do
+        it 'allows serialize: true' do
+          class Ad < ActiveRecord::Base
+            fields do
+              allow_list :text, limit: 0xFFFF, serialize: true
+            end
+          end
+
+          expect(Ad.serialize_args).to eq([[:allow_list]])
+        end
+
+        it 'converts defaults with .to_yaml' do
+          class Ad < ActiveRecord::Base
+            fields do
+              allow_list :string, limit: 250, serialize: true, null: true, default: []
+              allow_hash :string, limit: 250, serialize: true, null: true, default: {}
+              allow_string :string, limit: 250, serialize: true, null: true, default: ['abc']
+              allow_null :string, limit: 250, serialize: true, null: true, default: nil
+            end
+          end
+
+          expect(Ad.field_specs['allow_list'].default).to eq("--- []\n")
+          expect(Ad.field_specs['allow_hash'].default).to eq("--- {}\n")
+          expect(Ad.field_specs['allow_string'].default).to eq("---\n- abc\n")
+          expect(Ad.field_specs['allow_null'].default).to eq(nil)
+        end
+      end
+
+      describe 'Array' do
+        it 'allows serialize: Array' do
+          class Ad < ActiveRecord::Base
+            fields do
+              allow_list :string, limit: 250, serialize: Array, null: true
+            end
+          end
+
+          expect(Ad.serialize_args).to eq([[:allow_list, Array]])
+        end
+
+        it 'allows Array defaults' do
+          class Ad < ActiveRecord::Base
+            fields do
+              allow_list :string, limit: 250, serialize: Array, null: true, default: [2]
+              allow_string :string, limit: 250, serialize: Array, null: true, default: ['abc']
+              allow_empty :string, limit: 250, serialize: Array, null: true, default: []
+              allow_null :string, limit: 250, serialize: Array, null: true, default: nil
+            end
+          end
+
+          expect(Ad.field_specs['allow_list'].default).to eq("---\n- 2\n")
+          expect(Ad.field_specs['allow_string'].default).to eq("---\n- abc\n")
+          expect(Ad.field_specs['allow_empty'].default).to eq(nil)
+          expect(Ad.field_specs['allow_null'].default).to eq(nil)
+        end
+      end
+
+      describe 'Hash' do
+        it 'allows serialize: Hash' do
+          class Ad < ActiveRecord::Base
+            fields do
+              allow_list :string, limit: 250, serialize: Hash, null: true
+            end
+          end
+
+          expect(Ad.serialize_args).to eq([[:allow_list, Hash]])
+        end
+
+        it 'allows Hash defaults' do
+          class Ad < ActiveRecord::Base
+            fields do
+              allow_loc :string, limit: 250, serialize: Hash, null: true, default: { 'state' => 'CA' }
+              allow_hash :string, limit: 250, serialize: Hash, null: true, default: {}
+              allow_null :string, limit: 250, serialize: Hash, null: true, default: nil
+            end
+          end
+
+          expect(Ad.field_specs['allow_loc'].default).to eq("---\nstate: CA\n")
+          expect(Ad.field_specs['allow_hash'].default).to eq(nil)
+          expect(Ad.field_specs['allow_null'].default).to eq(nil)
+        end
+      end
+
+      describe 'JSON' do
+        it 'allows serialize: JSON' do
+          class Ad < ActiveRecord::Base
+            fields do
+              allow_list :string, limit: 250, serialize: JSON
+            end
+          end
+
+          expect(Ad.serialize_args).to eq([[:allow_list, JSON]])
+        end
+
+        it 'allows JSON defaults' do
+          class Ad < ActiveRecord::Base
+            fields do
+              allow_hash :string, limit: 250, serialize: JSON, null: true, default: { 'state' => 'CA' }
+              allow_empty_array :string, limit: 250, serialize: JSON, null: true, default: []
+              allow_empty_hash :string, limit: 250, serialize: JSON, null: true, default: {}
+              allow_null :string, limit: 250, serialize: JSON, null: true, default: nil
+            end
+          end
+
+          expect(Ad.field_specs['allow_hash'].default).to eq("{\"state\":\"CA\"}")
+          expect(Ad.field_specs['allow_empty_array'].default).to eq("[]")
+          expect(Ad.field_specs['allow_empty_hash'].default).to eq("{}")
+          expect(Ad.field_specs['allow_null'].default).to eq(nil)
+        end
+      end
+
+      class ValueClass
+        delegate :present?, :inspect, to: :@value
+
+        def initialize(value)
+          @value = value
+        end
+
+        class << self
+          def dump(object)
+            if object&.present?
+              object.inspect
+            end
+          end
+
+          def load(serialized)
+            if serialized
+              raise 'not used ???'
+            end
+          end
+        end
+      end
+
+      describe 'custom coder' do
+        it 'allows serialize: ValueClass' do
+          class Ad < ActiveRecord::Base
+            fields do
+              allow_list :string, limit: 250, serialize: ValueClass
+            end
+          end
+
+          expect(Ad.serialize_args).to eq([[:allow_list, ValueClass]])
+        end
+
+        it 'allows ValueClass defaults' do
+          class Ad < ActiveRecord::Base
+            fields do
+              allow_hash :string, limit: 250, serialize: ValueClass, null: true, default: ValueClass.new([2])
+              allow_empty_array :string, limit: 250, serialize: ValueClass, null: true, default: ValueClass.new([])
+              allow_null :string, limit: 250, serialize: ValueClass, null: true, default: nil
+            end
+          end
+
+          expect(Ad.field_specs['allow_hash'].default).to eq("[2]")
+          expect(Ad.field_specs['allow_empty_array'].default).to eq(nil)
+          expect(Ad.field_specs['allow_null'].default).to eq(nil)
+        end
+      end
+
+      it 'disallows serialize: with a non-string column type' do
+        expect do
+          class Ad < ActiveRecord::Base
+            fields do
+              allow_list :integer, limit: 8, serialize: true
+            end
+          end
+        end.to raise_exception(ArgumentError, /must be :string or :text/)
+      end
+    end
+
+    context "for Rails #{Rails::VERSION::MAJOR}" do
+      if Rails::VERSION::MAJOR >= 5
+        let(:optional_true) { { optional: true } }
+        let(:optional_false) { { optional: false } }
+      else
+        let(:optional_true) { {} }
+        let(:optional_false) { {} }
+      end
+      let(:optional_flag) { { false => optional_false, true => optional_true } }
+
+      describe 'belongs_to' do
+        before do
+          unless defined?(AdCategory)
+            class AdCategory < ActiveRecord::Base
+              fields { }
+            end
+          end
+
+          class Advert < ActiveRecord::Base
+            fields do
+              name :string, limit: 250, null: true
+              category_id :integer, limit: 8
+              nullable_category_id :integer, limit: 8, null: true
+            end
+          end
+          up = Generators::DeclareSchema::Migration::Migrator.run.first
+          ActiveRecord::Migration.class_eval(up)
+        end
+
+        it 'passes through optional: when given' do
           class AdvertBelongsTo < ActiveRecord::Base
             self.table_name = 'adverts'
             fields { }
             reset_column_information
-            belongs_to :ad_category, optional: true, null: false
+            belongs_to :ad_category, optional: true
           end
           expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_true)
-          expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(false)
         end
 
-        it 'passes through optional: false, null: true' do
-          class AdvertBelongsTo < ActiveRecord::Base
-            self.table_name = 'adverts'
-            fields { }
-            reset_column_information
-            belongs_to :ad_category, optional: false, null: true
+        describe 'contradictory settings' do # contradictory settings are ok--for example, during migration
+          it 'passes through optional: true, null: false' do
+            class AdvertBelongsTo < ActiveRecord::Base
+              self.table_name = 'adverts'
+              fields { }
+              reset_column_information
+              belongs_to :ad_category, optional: true, null: false
+            end
+            expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_true)
+            expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(false)
           end
-          expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_false)
-          expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(true)
+
+          it 'passes through optional: false, null: true' do
+            class AdvertBelongsTo < ActiveRecord::Base
+              self.table_name = 'adverts'
+              fields { }
+              reset_column_information
+              belongs_to :ad_category, optional: false, null: true
+            end
+            expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_false)
+            expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(true)
+          end
         end
-      end
 
-      [false, true].each do |nullable|
-        context "nullable=#{nullable}" do
-          it 'infers optional: from null:' do
-            eval <<~EOS
-              class AdvertBelongsTo < ActiveRecord::Base
-                fields { }
-                belongs_to :ad_category, null: #{nullable}
-              end
-            EOS
-            expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_flag[nullable])
-            expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(nullable)
-          end
+        [false, true].each do |nullable|
+          context "nullable=#{nullable}" do
+            it 'infers optional: from null:' do
+              eval <<~EOS
+                class AdvertBelongsTo < ActiveRecord::Base
+                  fields { }
+                  belongs_to :ad_category, null: #{nullable}
+                end
+              EOS
+              expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_flag[nullable])
+              expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(nullable)
+            end
 
-          it 'infers null: from optional:' do
-            eval <<~EOS
-              class AdvertBelongsTo < ActiveRecord::Base
-                fields { }
-                belongs_to :ad_category, optional: #{nullable}
-              end
-            EOS
-            expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_flag[nullable])
-            expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(nullable)
+            it 'infers null: from optional:' do
+              eval <<~EOS
+                class AdvertBelongsTo < ActiveRecord::Base
+                  fields { }
+                  belongs_to :ad_category, optional: #{nullable}
+                end
+              EOS
+              expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_flag[nullable])
+              expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(nullable)
+            end
           end
         end
       end
     end
-  end
 
-  describe 'migration base class' do
-    it 'adapts to Rails 4' do
-      class Advert < active_record_base_class.constantize
-        fields do
-          title :string, limit: 100
-        end
-      end
-
-      generate_migrations '-n', '-m'
-
-      migrations = Dir.glob('db/migrate/*declare_schema_migration*.rb')
-      expect(migrations.size).to eq(1), migrations.inspect
-
-      migration_content = File.read(migrations.first)
-      first_line = migration_content.split("\n").first
-      base_class = first_line.split(' < ').last
-      expect(base_class).to eq("(Rails::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration)")
-    end
-  end
-
-  context 'Does not generate migrations' do
-    it 'for aliased fields bigint -> integer limit 8' do
-      if Rails::VERSION::MAJOR >= 5 || !ActiveRecord::Base.connection.class.name.match?(/SQLite3Adapter/)
+    describe 'migration base class' do
+      it 'adapts to Rails 4' do
         class Advert < active_record_base_class.constantize
           fields do
-            price :bigint
+            title :string, limit: 100
           end
         end
 
@@ -1210,17 +1190,1211 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         migrations = Dir.glob('db/migrate/*declare_schema_migration*.rb')
         expect(migrations.size).to eq(1), migrations.inspect
 
-        if defined?(Mysql2) && Rails::VERSION::MAJOR < 5
-          ActiveRecord::Base.connection.execute("ALTER TABLE adverts ADD PRIMARY KEY (id)")
-        end
+        migration_content = File.read(migrations.first)
+        first_line = migration_content.split("\n").first
+        base_class = first_line.split(' < ').last
+        expect(base_class).to eq("(Rails::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration)")
+      end
+    end
 
-        class Advert < active_record_base_class.constantize
-          fields do
-            price :integer, limit: 8
+    context 'Does not generate migrations' do
+      it 'for aliased fields bigint -> integer limit 8' do
+        if Rails::VERSION::MAJOR >= 5 || !ActiveRecord::Base.connection.class.name.match?(/SQLite3Adapter/)
+          class Advert < active_record_base_class.constantize
+            fields do
+              price :bigint
+            end
+          end
+
+          generate_migrations '-n', '-m'
+
+          migrations = Dir.glob('db/migrate/*declare_schema_migration*.rb')
+          expect(migrations.size).to eq(1), migrations.inspect
+
+          if defined?(Mysql2) && Rails::VERSION::MAJOR < 5
+            ActiveRecord::Base.connection.execute("ALTER TABLE adverts ADD PRIMARY KEY (id)")
+          end
+
+          class Advert < active_record_base_class.constantize
+            fields do
+              price :integer, limit: 8
+            end
+          end
+
+          expect { generate_migrations '-n', '-g' }.to output("Database and models match -- nothing to change\n").to_stdout
+        end
+      end
+    end
+  end
+
+  context 'Using declare_schema' do
+    # DeclareSchema - Migration Generator
+    it 'generates migrations' do
+      ## The migration generator -- introduction
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to migrate_up("").and migrate_down("")
+
+      class Advert < ActiveRecord::Base
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to migrate_up("").and migrate_down("")
+
+      Generators::DeclareSchema::Migration::Migrator.ignore_tables = ["green_fishes"]
+
+      Advert.connection.schema_cache.clear!
+      Advert.reset_column_information
+
+      class Advert < ActiveRecord::Base
+        declare_schema do
+          string :name, limit: 250, null: true
+        end
+      end
+
+      up, _ = Generators::DeclareSchema::Migration::Migrator.run.tap do |migrations|
+        expect(migrations).to(
+            migrate_up(<<~EOS.strip)
+            create_table :adverts, id: :bigint do |t|
+              t.string :name, limit: 250, null: true#{charset_and_collation}
+            end#{charset_alter_table}
+            EOS
+                .and migrate_down("drop_table :adverts")
+        )
+      end
+
+      ActiveRecord::Migration.class_eval(up)
+      expect(Advert.columns.map(&:name)).to eq(["id", "name"])
+
+      if Rails::VERSION::MAJOR < 5
+        # Rails 4 drivers don't always create PK properly. Fix that by dropping and recreating.
+        ActiveRecord::Base.connection.execute("drop table adverts")
+        if defined?(Mysql2)
+          ActiveRecord::Base.connection.execute("CREATE TABLE adverts (id integer PRIMARY KEY AUTO_INCREMENT NOT NULL, name varchar(250)) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin")
+        else
+          ActiveRecord::Base.connection.execute("CREATE TABLE adverts (id integer PRIMARY KEY AUTOINCREMENT  NOT NULL, name varchar(250))")
+        end
+      end
+
+      class Advert < ActiveRecord::Base
+        declare_schema do
+          string :name, limit: 250, null: true
+          text :body, null: true
+          datetime :published_at, null: true
+        end
+      end
+
+      Advert.connection.schema_cache.clear!
+      Advert.reset_column_information
+
+      expect(migrate).to(
+          migrate_up(<<~EOS.strip)
+          add_column :adverts, :body, :text#{text_limit}, null: true#{charset_and_collation}
+          add_column :adverts, :published_at, :datetime, null: true
+          EOS
+              .and migrate_down(<<~EOS.strip)
+          remove_column :adverts, :body
+          remove_column :adverts, :published_at
+      EOS
+      )
+
+      Advert.field_specs.clear # not normally needed
+      class Advert < ActiveRecord::Base
+        declare_schema do
+          string :name, limit: 250, null: true
+          text :body, null: true
+        end
+      end
+
+      expect(migrate).to(
+          migrate_up("remove_column :adverts, :published_at").and(
+              migrate_down("add_column :adverts, :published_at, :datetime#{datetime_precision}, null: true")
+          )
+      )
+
+      nuke_model_class(Advert)
+      class Advert < ActiveRecord::Base
+        declare_schema do
+          string :title, limit: 250, null: true
+          text :body, null: true
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+          migrate_up(<<~EOS.strip)
+          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+          remove_column :adverts, :name
+          EOS
+              .and migrate_down(<<~EOS.strip)
+          remove_column :adverts, :title
+          add_column :adverts, :name, :string, limit: 250, null: true#{charset_and_collation}
+      EOS
+      )
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: { name: :title })).to(
+          migrate_up("rename_column :adverts, :name, :title").and(
+              migrate_down("rename_column :adverts, :title, :name")
+          )
+      )
+
+      migrate
+
+      class Advert < ActiveRecord::Base
+        declare_schema do
+          text :title, null: true
+          text :body, null: true
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+          migrate_up("change_column :adverts, :title, :text#{text_limit}, null: true#{charset_and_collation}").and(
+              migrate_down("change_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}")
+          )
+      )
+
+      class Advert < ActiveRecord::Base
+        declare_schema do
+          string :title, default: "Untitled", limit: 250, null: true
+          text :body, null: true
+        end
+      end
+
+      expect(migrate).to(
+          migrate_up(<<~EOS.strip)
+          change_column :adverts, :title, :string, limit: 250, null: true, default: "Untitled"#{charset_and_collation}
+          EOS
+              .and migrate_down(<<~EOS.strip)
+          change_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+      EOS
+      )
+
+      ### Limits
+
+      class Advert < ActiveRecord::Base
+        declare_schema do
+          integer :price, null: true, limit: 2
+        end
+      end
+
+      up, _ = Generators::DeclareSchema::Migration::Migrator.run.tap do |migrations|
+        expect(migrations).to migrate_up("add_column :adverts, :price, :integer, limit: 2, null: true")
+      end
+
+      # Now run the migration, then change the limit:
+
+      ActiveRecord::Migration.class_eval(up)
+      class Advert < ActiveRecord::Base
+        declare_schema do
+          integer :price, null: true, limit: 3
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+          migrate_up(<<~EOS.strip)
+          change_column :adverts, :price, :integer, limit: 3, null: true
+          EOS
+              .and migrate_down(<<~EOS.strip)
+          change_column :adverts, :price, :integer, limit: 2, null: true
+      EOS
+      )
+
+      ActiveRecord::Migration.class_eval("remove_column :adverts, :price")
+      class Advert < ActiveRecord::Base
+        declare_schema do
+          decimal :price, precision: 4, scale: 1, null: true
+        end
+      end
+
+      # Limits are generally not needed for `text` fields, because by default, `text` fields will use the maximum size
+      # allowed for that database type (0xffffffff for LONGTEXT in MySQL unlimited in Postgres, 1 billion in Sqlite).
+      # If a `limit` is given, it will only be used in MySQL, to choose the smallest TEXT field that will accommodate
+      # that limit (0xff for TINYTEXT, 0xffff for TEXT, 0xffffff for MEDIUMTEXT, 0xffffffff for LONGTEXT).
+
+      if defined?(SQLite3)
+        expect(::DeclareSchema::Model::FieldSpec.mysql_text_limits?).to be_falsey
+      end
+
+      class Advert < ActiveRecord::Base
+        declare_schema do
+          text :notes
+          text :description, limit: 30000
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+          migrate_up(<<~EOS.strip)
+          add_column :adverts, :price, :decimal, precision: 4, scale: 1, null: true
+          add_column :adverts, :notes, :text#{text_limit}, null: false#{charset_and_collation}
+          add_column :adverts, :description, :text#{', limit: 65535' if defined?(Mysql2)}, null: false#{charset_and_collation}
+      EOS
+      )
+
+      Advert.field_specs.delete :price
+      Advert.field_specs.delete :notes
+      Advert.field_specs.delete :description
+
+      # In MySQL, limits are applied, rounded up:
+
+      if defined?(Mysql2)
+        expect(::DeclareSchema::Model::FieldSpec.mysql_text_limits?).to be_truthy
+
+        class Advert < ActiveRecord::Base
+          declare_schema do
+            text :notes
+            text :description, limit: 250
           end
         end
 
-        expect { generate_migrations '-n', '-g' }.to output("Database and models match -- nothing to change\n").to_stdout
+        expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+            migrate_up(<<~EOS.strip)
+            add_column :adverts, :notes, :text, limit: 4294967295, null: false#{charset_and_collation}
+            add_column :adverts, :description, :text, limit: 255, null: false#{charset_and_collation}
+        EOS
+        )
+
+        Advert.field_specs.delete :notes
+
+        # Limits that are too high for MySQL will raise an exception.
+
+        expect do
+          class Advert < ActiveRecord::Base
+            declare_schema do
+              text :notes
+              text :description, limit: 0x1_0000_0000
+            end
+          end
+        end.to raise_exception(ArgumentError, "limit of 4294967296 is too large for MySQL")
+
+        Advert.field_specs.delete :notes
+
+        # And in MySQL, unstated text limits are treated as the maximum (LONGTEXT) limit.
+
+        # To start, we'll set the database schema for `description` to match the above limit of 250.
+
+        Advert.connection.execute "ALTER TABLE adverts ADD COLUMN description TINYTEXT"
+        Advert.connection.schema_cache.clear!
+        Advert.reset_column_information
+        expect(Advert.connection.tables - Generators::DeclareSchema::Migration::Migrator.always_ignore_tables).
+            to eq(["adverts"])
+        expect(Advert.columns.map(&:name)).to eq(["id", "body", "title", "description"])
+
+        # Now migrate to an unstated text limit:
+
+        class Advert < ActiveRecord::Base
+          declare_schema do
+            text :description
+          end
+        end
+
+        expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+            migrate_up(<<~EOS.strip)
+            change_column :adverts, :description, :text, limit: 4294967295, null: false#{charset_and_collation}
+            EOS
+                .and migrate_down(<<~EOS.strip)
+            change_column :adverts, :description, :text#{', limit: 255' if defined?(Mysql2)}, null: true#{charset_and_collation}
+        EOS
+        )
+
+        # And migrate to a stated text limit that is the same as the unstated one:
+
+        class Advert < ActiveRecord::Base
+          declare_schema do
+            text :description, limit: 0xffffffff
+          end
+        end
+
+        expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+            migrate_up(<<~EOS.strip)
+            change_column :adverts, :description, :text, limit: 4294967295, null: false#{charset_and_collation}
+            EOS
+                .and migrate_down(<<~EOS.strip)
+            change_column :adverts, :description, :text#{', limit: 255' if defined?(Mysql2)}, null: true#{charset_and_collation}
+        EOS
+        )
+      end
+
+      Advert.field_specs.clear
+      Advert.connection.schema_cache.clear!
+      Advert.reset_column_information
+      class Advert < ActiveRecord::Base
+        declare_schema do
+          string :name, limit: 250, null: true
+        end
+      end
+
+      up = Generators::DeclareSchema::Migration::Migrator.run.first
+      ActiveRecord::Migration.class_eval up
+
+      Advert.connection.schema_cache.clear!
+      Advert.reset_column_information
+
+      ### Foreign Keys
+
+      # DeclareSchema extends the `belongs_to` macro so that it also declares the
+      # foreign-key field.  It also generates an index on the field.
+
+      class Category < ActiveRecord::Base; end
+      class Advert < ActiveRecord::Base
+        declare_schema do
+          string :name, limit: 250, null: true
+        end
+        belongs_to :category
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+          migrate_up(<<~EOS.strip)
+          add_column :adverts, :category_id, :integer, limit: 8, null: false
+  
+          add_index :adverts, [:category_id], name: 'on_category_id'
+  
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" if defined?(Mysql2)}
+          EOS
+              .and migrate_down(<<~EOS.strip)
+          remove_column :adverts, :category_id
+  
+          remove_index :adverts, name: :on_category_id rescue ActiveRecord::StatementInvalid
+  
+          #{"remove_foreign_key(\"adverts\", name: \"index_adverts_on_category_id\")\n" if defined?(Mysql2)}
+      EOS
+      )
+
+      Advert.field_specs.delete(:category_id)
+      Advert.index_definitions.delete_if { |spec| spec.fields==["category_id"] }
+
+      # If you specify a custom foreign key, the migration generator observes that:
+
+      class Category < ActiveRecord::Base; end
+      class Advert < ActiveRecord::Base
+        declare_schema { }
+        belongs_to :category, foreign_key: "c_id", class_name: 'Category'
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+          migrate_up(<<~EOS.strip)
+          add_column :adverts, :c_id, :integer, limit: 8, null: false
+  
+          add_index :adverts, [:c_id], name: 'on_c_id'
+  
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+      EOS
+      )
+
+      Advert.field_specs.delete(:c_id)
+      Advert.index_definitions.delete_if { |spec| spec.fields == ["c_id"] }
+
+      # You can avoid generating the index by specifying `index: false`
+
+      class Category < ActiveRecord::Base; end
+      class Advert < ActiveRecord::Base
+        declare_schema { }
+        belongs_to :category, index: false
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+          migrate_up(<<~EOS.strip)
+          add_column :adverts, :category_id, :integer, limit: 8, null: false
+  
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+      EOS
+      )
+
+      Advert.field_specs.delete(:category_id)
+      Advert.index_definitions.delete_if { |spec| spec.fields == ["category_id"] }
+
+      # You can specify the index name with :index
+
+      class Category < ActiveRecord::Base; end
+      class Advert < ActiveRecord::Base
+        declare_schema { }
+        belongs_to :category, index: 'my_index'
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+          migrate_up(<<~EOS.strip)
+          add_column :adverts, :category_id, :integer, limit: 8, null: false
+  
+          add_index :adverts, [:category_id], name: 'my_index'
+  
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+      EOS
+      )
+
+      Advert.field_specs.delete(:category_id)
+      Advert.index_definitions.delete_if { |spec| spec.fields == ["category_id"] }
+
+      ### Timestamps and Optimimistic Locking
+
+      # `updated_at` and `created_at` can be declared with the shorthand `timestamps`.
+      # Similarly, `lock_version` can be declared with the "shorthand" `optimimistic_lock`.
+
+      class Advert < ActiveRecord::Base
+        declare_schema do
+          timestamps
+          optimistic_lock
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+          migrate_up(<<~EOS.strip)
+          add_column :adverts, :created_at, :datetime, null: true
+          add_column :adverts, :updated_at, :datetime, null: true
+          add_column :adverts, :lock_version, :integer#{lock_version_limit}, null: false, default: 1
+  
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+              "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+          EOS
+              .and migrate_down(<<~EOS.strip)
+          remove_column :adverts, :created_at
+          remove_column :adverts, :updated_at
+          remove_column :adverts, :lock_version
+  
+          #{"remove_foreign_key(\"adverts\", name: \"index_adverts_on_category_id\")\n" +
+          "remove_foreign_key(\"adverts\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+      EOS
+      )
+
+      Advert.field_specs.delete(:updated_at)
+      Advert.field_specs.delete(:created_at)
+      Advert.field_specs.delete(:lock_version)
+
+      ### Indices
+
+      # You can add an index to a field definition
+
+      class Advert < ActiveRecord::Base
+        declare_schema do
+          string :title, index: true, limit: 250, null: true
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+          migrate_up(<<~EOS.strip)
+          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+  
+          add_index :adverts, [:title], name: 'on_title'
+  
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+      EOS
+      )
+
+      Advert.index_definitions.delete_if { |spec| spec.fields==["title"] }
+
+      # You can ask for a unique index
+
+      class Advert < ActiveRecord::Base
+        declare_schema do
+          string :title, index: true, unique: true, null: true, limit: 250
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+          migrate_up(<<~EOS.strip)
+          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+  
+          add_index :adverts, [:title], unique: true, name: 'on_title'
+  
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+      EOS
+      )
+
+      Advert.index_definitions.delete_if { |spec| spec.fields == ["title"] }
+
+      # You can specify the name for the index
+
+      class Advert < ActiveRecord::Base
+        declare_schema do
+          string :title, index: 'my_index', limit: 250, null: true
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+          migrate_up(<<~EOS.strip)
+          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+  
+          add_index :adverts, [:title], name: 'my_index'
+  
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+      EOS
+      )
+
+      Advert.index_definitions.delete_if { |spec| spec.fields==["title"] }
+
+      # You can ask for an index outside of the fields block
+
+      class Advert < ActiveRecord::Base
+        index :title
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+          migrate_up(<<~EOS.strip)
+          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+  
+          add_index :adverts, [:title], name: 'on_title'
+  
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+      EOS
+      )
+
+      Advert.index_definitions.delete_if { |spec| spec.fields == ["title"] }
+
+      # The available options for the index function are `:unique` and `:name`
+
+      class Advert < ActiveRecord::Base
+        index :title, unique: true, name: 'my_index'
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+          migrate_up(<<~EOS.strip)
+          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+  
+          add_index :adverts, [:title], unique: true, name: 'my_index'
+  
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+      EOS
+      )
+
+      Advert.index_definitions.delete_if { |spec| spec.fields == ["title"] }
+
+      # You can create an index on more than one field
+
+      class Advert < ActiveRecord::Base
+        index [:title, :category_id]
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+          migrate_up(<<~EOS.strip)
+          add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
+  
+          add_index :adverts, [:title, :category_id], name: 'on_title_and_category_id'
+  
+          #{"add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+          "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")" if defined?(Mysql2)}
+      EOS
+      )
+
+      Advert.index_definitions.delete_if { |spec| spec.fields==["title", "category_id"] }
+
+      # Finally, you can specify that the migration generator should completely ignore an
+      # index by passing its name to ignore_index in the model.
+      # This is helpful for preserving indices that can't be automatically generated, such as prefix indices in MySQL.
+
+      ### Rename a table
+
+      # The migration generator respects the `set_table_name` declaration, although as before, we need to explicitly tell the generator that we want a rename rather than a create and a drop.
+
+      class Advert < ActiveRecord::Base
+        self.table_name = "ads"
+        declare_schema do
+          string :title, limit: 250, null: true
+          text :body, null: true
+        end
+      end
+
+      Advert.connection.schema_cache.clear!
+      Advert.reset_column_information
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run("adverts" => "ads")).to(
+          migrate_up(<<~EOS.strip)
+          rename_table :adverts, :ads
+  
+          add_column :ads, :title, :string, limit: 250, null: true#{charset_and_collation}
+          add_column :ads, :body, :text#{', limit: 4294967295' if defined?(Mysql2)}, null: true#{charset_and_collation}
+  
+          #{if defined?(SQLite3)
+                                                                                                                                                                                                                               "add_index :ads, [:id], unique: true, name: 'PRIMARY'\n"
+            elsif defined?(Mysql2)
+              "execute \"ALTER TABLE ads DROP PRIMARY KEY, ADD PRIMARY KEY (id)\"\n\n" +
+                  "add_foreign_key(\"adverts\", \"categories\", column: \"category_id\", name: \"index_adverts_on_category_id\")\n" +
+                  "add_foreign_key(\"adverts\", \"categories\", column: \"c_id\", name: \"index_adverts_on_c_id\")"
+            end}
+          EOS
+              .and migrate_down(<<~EOS.strip)
+          remove_column :ads, :title
+          remove_column :ads, :body
+  
+          rename_table :ads, :adverts
+  
+          #{if defined?(SQLite3)
+              "add_index :adverts, [:id], unique: true, name: 'PRIMARY'\n"
+            elsif defined?(Mysql2)
+              "execute \"ALTER TABLE adverts DROP PRIMARY KEY, ADD PRIMARY KEY (id)\"\n\n" +
+                  "remove_foreign_key(\"adverts\", name: \"index_adverts_on_category_id\")\n" +
+                  "remove_foreign_key(\"adverts\", name: \"index_adverts_on_c_id\")"
+            end}
+      EOS
+      )
+
+      # Set the table name back to what it should be and confirm we're in sync:
+
+      nuke_model_class(Advert)
+
+      class Advert < ActiveRecord::Base
+        self.table_name = "adverts"
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to eq(["", ""])
+
+      ### Rename a table
+
+      # As with renaming columns, we have to tell the migration generator about the rename. Here we create a new class 'Advertisement', and tell ActiveRecord to forget about the Advert class. This requires code that shouldn't be shown to impressionable children.
+
+      nuke_model_class(Advert)
+
+      class Advertisement < ActiveRecord::Base
+        declare_schema do
+          string :title, limit: 250, null: true
+          text :body, null: true
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run("adverts" => "advertisements")).to(
+          migrate_up(<<~EOS.strip)
+          rename_table :adverts, :advertisements
+  
+          add_column :advertisements, :title, :string, limit: 250, null: true#{charset_and_collation}
+          add_column :advertisements, :body, :text#{', limit: 4294967295' if defined?(Mysql2)}, null: true#{charset_and_collation}
+          remove_column :advertisements, :name
+  
+          #{if defined?(SQLite3)
+                                                                                                                                                                                                                                                     "add_index :advertisements, [:id], unique: true, name: 'PRIMARY'"
+            elsif defined?(Mysql2)
+              "execute \"ALTER TABLE advertisements DROP PRIMARY KEY, ADD PRIMARY KEY (id)\""
+            end}
+          EOS
+              .and migrate_down(<<~EOS.strip)
+          remove_column :advertisements, :title
+          remove_column :advertisements, :body
+          add_column :adverts, :name, :string, limit: 250, null: true#{charset_and_collation}
+  
+          rename_table :advertisements, :adverts
+  
+          #{if defined?(SQLite3)
+                                                                                                           "add_index :adverts, [:id], unique: true, name: 'PRIMARY'"
+            elsif defined?(Mysql2)
+              "execute \"ALTER TABLE adverts DROP PRIMARY KEY, ADD PRIMARY KEY (id)\""
+            end}
+      EOS
+      )
+
+      ### Drop a table
+
+      nuke_model_class(Advertisement)
+
+      # If you delete a model, the migration generator will create a `drop_table` migration.
+
+      # Dropping tables is where the automatic down-migration really comes in handy:
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+          migrate_up(<<~EOS.strip)
+          drop_table :adverts
+          EOS
+              .and migrate_down(<<~EOS.strip)
+          create_table "adverts"#{table_options}, force: :cascade do |t|
+            t.string "name", limit: 250#{charset_and_collation}
+          end
+      EOS
+      )
+
+      ## STI
+
+      ### Adding an STI subclass
+
+      # Adding a subclass or two should introduce the 'type' column and no other changes
+
+      class Advert < ActiveRecord::Base
+        declare_schema do
+          text :body, null: true
+          string :title, default: "Untitled", limit: 250, null: true
+        end
+      end
+      up = Generators::DeclareSchema::Migration::Migrator.run.first
+      ActiveRecord::Migration.class_eval(up)
+
+      class FancyAdvert < Advert
+      end
+      class SuperFancyAdvert < FancyAdvert
+      end
+
+      up, _ = Generators::DeclareSchema::Migration::Migrator.run do |migrations|
+        expect(migrations).to(
+            migrate_up(<<~EOS.strip)
+            add_column :adverts, :type, :string, limit: 250, null: true#{charset_and_collation}
+  
+            add_index :adverts, [:type], name: 'on_type'
+            EOS
+                .and migrate_down(<<~EOS.strip)
+            remove_column :adverts, :type
+  
+            remove_index :adverts, name: :on_type rescue ActiveRecord::StatementInvalid
+        EOS
+        )
+      end
+
+      Advert.field_specs.delete(:type)
+      nuke_model_class(SuperFancyAdvert)
+      nuke_model_class(FancyAdvert)
+      Advert.index_definitions.delete_if { |spec| spec.fields==["type"] }
+
+      ## Coping with multiple changes
+
+      # The migration generator is designed to create complete migrations even if many changes to the models have taken place.
+
+      # First let's confirm we're in a known state. One model, 'Advert', with a string 'title' and text 'body':
+
+      ActiveRecord::Migration.class_eval up.gsub(/.*type.*/, '')
+      Advert.connection.schema_cache.clear!
+      Advert.reset_column_information
+
+      expect(Advert.connection.tables - Generators::DeclareSchema::Migration::Migrator.always_ignore_tables).
+          to eq(["adverts"])
+      expect(Advert.columns.map(&:name).sort).to eq(["body", "id", "title"])
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to eq(["", ""])
+
+
+      ### Rename a column and change the default
+
+      Advert.field_specs.clear
+
+      class Advert < ActiveRecord::Base
+        declare_schema do
+          string :name, default: "No Name", limit: 250, null: true
+          text :body, null: true
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: { title: :name })).to(
+          migrate_up(<<~EOS.strip)
+          rename_column :adverts, :title, :name
+          change_column :adverts, :name, :string, limit: 250, null: true, default: "No Name"#{charset_and_collation}
+          EOS
+              .and migrate_down(<<~EOS.strip)
+          rename_column :adverts, :name, :title
+          change_column :adverts, :title, :string, limit: 250, null: true, default: "Untitled"#{charset_and_collation}
+      EOS
+      )
+
+      ### Rename a table and add a column
+
+      nuke_model_class(Advert)
+      class Ad < ActiveRecord::Base
+        declare_schema do
+          string   :title, default: "Untitled", limit: 250
+          text     :body, null: true
+          datetime :created_at
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: :ads)).to(
+          migrate_up(<<~EOS.strip)
+          rename_table :adverts, :ads
+  
+          add_column :ads, :created_at, :datetime, null: false
+          change_column :ads, :title, :string, limit: 250, null: false, default: \"Untitled\"#{charset_and_collation}
+  
+          #{if defined?(SQLite3)
+                                                                                                                                   "add_index :ads, [:id], unique: true, name: 'PRIMARY'"
+            elsif defined?(Mysql2)
+              'execute "ALTER TABLE ads DROP PRIMARY KEY, ADD PRIMARY KEY (id)"'
+            end}
+      EOS
+      )
+
+      class Advert < ActiveRecord::Base
+        declare_schema do
+          text :body, null: true
+          string :title, default: "Untitled", limit: 250, null: true
+        end
+      end
+
+      ## Legacy Keys
+
+      # DeclareSchema has some support for legacy keys.
+
+      nuke_model_class(Ad)
+
+      class Advert < ActiveRecord::Base
+        declare_schema do
+          text :body, null: true
+        end
+        self.primary_key = "advert_id"
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run(adverts: { id: :advert_id })).to(
+          migrate_up(<<~EOS.strip)
+          rename_column :adverts, :id, :advert_id
+  
+          #{if defined?(SQLite3)
+              "add_index :adverts, [:advert_id], unique: true, name: 'PRIMARY'"
+            elsif defined?(Mysql2)
+              'execute "ALTER TABLE adverts DROP PRIMARY KEY, ADD PRIMARY KEY (advert_id)"'
+            end}
+      EOS
+      )
+
+      nuke_model_class(Advert)
+      ActiveRecord::Base.connection.execute("drop table `adverts`;")
+
+      ## DSL
+
+      # The DSL allows lambdas and constants
+
+      class User < ActiveRecord::Base
+        declare_schema do
+          string :company, limit: 250, ruby_default: -> { "BigCorp" }
+        end
+      end
+      expect(User.field_specs.keys).to eq(['company'])
+      expect(User.field_specs['company'].options[:ruby_default]&.call).to eq("BigCorp")
+
+      ## validates
+
+      # DeclareSchema can accept a validates hash in the field options.
+
+      class Ad < ActiveRecord::Base
+        class << self
+          def validates(field_name, options)
+          end
+        end
+      end
+      expect(Ad).to receive(:validates).with(:company, presence: true, uniqueness: { case_sensitive: false })
+      class Ad < ActiveRecord::Base
+        declare_schema do
+          string :company, limit: 250, index: true, unique: true, validates: { presence: true, uniqueness: { case_sensitive: false } }
+        end
+        self.primary_key = "advert_id"
+      end
+      up, _down = Generators::DeclareSchema::Migration::Migrator.run
+      ActiveRecord::Migration.class_eval(up)
+      expect(Ad.field_specs['company'].options[:validates].inspect).to eq("{:presence=>true, :uniqueness=>{:case_sensitive=>false}}")
+    end
+
+    describe 'serialize' do
+      before do
+        class Ad < ActiveRecord::Base
+          @serialize_args = []
+
+          class << self
+            attr_reader :serialize_args
+
+            def serialize(*args)
+              @serialize_args << args
+            end
+          end
+        end
+      end
+
+      describe 'untyped' do
+        it 'allows serialize: true' do
+          class Ad < ActiveRecord::Base
+            declare_schema do
+              text :allow_list, limit: 0xFFFF, serialize: true
+            end
+          end
+
+          expect(Ad.serialize_args).to eq([[:allow_list]])
+        end
+
+        it 'converts defaults with .to_yaml' do
+          class Ad < ActiveRecord::Base
+            declare_schema do
+              string :allow_list, limit: 250, serialize: true, null: true, default: []
+              string :allow_hash, limit: 250, serialize: true, null: true, default: {}
+              string :allow_string, limit: 250, serialize: true, null: true, default: ['abc']
+              string :allow_null, limit: 250, serialize: true, null: true, default: nil
+            end
+          end
+
+          expect(Ad.field_specs['allow_list'].default).to eq("--- []\n")
+          expect(Ad.field_specs['allow_hash'].default).to eq("--- {}\n")
+          expect(Ad.field_specs['allow_string'].default).to eq("---\n- abc\n")
+          expect(Ad.field_specs['allow_null'].default).to eq(nil)
+        end
+      end
+
+      describe 'Array' do
+        it 'allows serialize: Array' do
+          class Ad < ActiveRecord::Base
+            declare_schema do
+              string :allow_list, limit: 250, serialize: Array, null: true
+            end
+          end
+
+          expect(Ad.serialize_args).to eq([[:allow_list, Array]])
+        end
+
+        it 'allows Array defaults' do
+          class Ad < ActiveRecord::Base
+            declare_schema do
+              string :allow_list, limit: 250, serialize: Array, null: true, default: [2]
+              string :allow_string, limit: 250, serialize: Array, null: true, default: ['abc']
+              string :allow_empty, limit: 250, serialize: Array, null: true, default: []
+              string :allow_null, limit: 250, serialize: Array, null: true, default: nil
+            end
+          end
+
+          expect(Ad.field_specs['allow_list'].default).to eq("---\n- 2\n")
+          expect(Ad.field_specs['allow_string'].default).to eq("---\n- abc\n")
+          expect(Ad.field_specs['allow_empty'].default).to eq(nil)
+          expect(Ad.field_specs['allow_null'].default).to eq(nil)
+        end
+      end
+
+      describe 'Hash' do
+        it 'allows serialize: Hash' do
+          class Ad < ActiveRecord::Base
+            declare_schema do
+              string :allow_list, limit: 250, serialize: Hash, null: true
+            end
+          end
+
+          expect(Ad.serialize_args).to eq([[:allow_list, Hash]])
+        end
+
+        it 'allows Hash defaults' do
+          class Ad < ActiveRecord::Base
+            declare_schema do
+              string :allow_loc, limit: 250, serialize: Hash, null: true, default: { 'state' => 'CA' }
+              string :allow_hash, limit: 250, serialize: Hash, null: true, default: {}
+              string :allow_null, limit: 250, serialize: Hash, null: true, default: nil
+            end
+          end
+
+          expect(Ad.field_specs['allow_loc'].default).to eq("---\nstate: CA\n")
+          expect(Ad.field_specs['allow_hash'].default).to eq(nil)
+          expect(Ad.field_specs['allow_null'].default).to eq(nil)
+        end
+      end
+
+      describe 'JSON' do
+        it 'allows serialize: JSON' do
+          class Ad < ActiveRecord::Base
+            declare_schema do
+              string :allow_list, limit: 250, serialize: JSON
+            end
+          end
+
+          expect(Ad.serialize_args).to eq([[:allow_list, JSON]])
+        end
+
+        it 'allows JSON defaults' do
+          class Ad < ActiveRecord::Base
+            declare_schema do
+              string :allow_hash, limit: 250, serialize: JSON, null: true, default: { 'state' => 'CA' }
+              string :allow_empty_array, limit: 250, serialize: JSON, null: true, default: []
+              string :allow_empty_hash, limit: 250, serialize: JSON, null: true, default: {}
+              string :allow_null, limit: 250, serialize: JSON, null: true, default: nil
+            end
+          end
+
+          expect(Ad.field_specs['allow_hash'].default).to eq("{\"state\":\"CA\"}")
+          expect(Ad.field_specs['allow_empty_array'].default).to eq("[]")
+          expect(Ad.field_specs['allow_empty_hash'].default).to eq("{}")
+          expect(Ad.field_specs['allow_null'].default).to eq(nil)
+        end
+      end
+
+      class ValueClass
+        delegate :present?, :inspect, to: :@value
+
+        def initialize(value)
+          @value = value
+        end
+
+        class << self
+          def dump(object)
+            if object&.present?
+              object.inspect
+            end
+          end
+
+          def load(serialized)
+            if serialized
+              raise 'not used ???'
+            end
+          end
+        end
+      end
+
+      describe 'custom coder' do
+        it 'allows serialize: ValueClass' do
+          class Ad < ActiveRecord::Base
+            declare_schema do
+              string :allow_list, limit: 250, serialize: ValueClass
+            end
+          end
+
+          expect(Ad.serialize_args).to eq([[:allow_list, ValueClass]])
+        end
+
+        it 'allows ValueClass defaults' do
+          class Ad < ActiveRecord::Base
+            declare_schema do
+              string :allow_hash, limit: 250, serialize: ValueClass, null: true, default: ValueClass.new([2])
+              string :allow_empty_array, limit: 250, serialize: ValueClass, null: true, default: ValueClass.new([])
+              string :allow_null, limit: 250, serialize: ValueClass, null: true, default: nil
+            end
+          end
+
+          expect(Ad.field_specs['allow_hash'].default).to eq("[2]")
+          expect(Ad.field_specs['allow_empty_array'].default).to eq(nil)
+          expect(Ad.field_specs['allow_null'].default).to eq(nil)
+        end
+      end
+
+      it 'disallows serialize: with a non-string column type' do
+        expect do
+          class Ad < ActiveRecord::Base
+            declare_schema do
+              integer :allow_list, limit: 8, serialize: true
+            end
+          end
+        end.to raise_exception(ArgumentError, /must be :string or :text/)
+      end
+    end
+
+    context "for Rails #{Rails::VERSION::MAJOR}" do
+      if Rails::VERSION::MAJOR >= 5
+        let(:optional_true) { { optional: true } }
+        let(:optional_false) { { optional: false } }
+      else
+        let(:optional_true) { {} }
+        let(:optional_false) { {} }
+      end
+      let(:optional_flag) { { false => optional_false, true => optional_true } }
+
+      describe 'belongs_to' do
+        before do
+          unless defined?(AdCategory)
+            class AdCategory < ActiveRecord::Base
+              declare_schema { }
+            end
+          end
+
+          class Advert < ActiveRecord::Base
+            declare_schema do
+              string :name, limit: 250, null: true
+              integer :category_id, limit: 8
+              integer :nullable_category_id, limit: 8, null: true
+            end
+          end
+          up = Generators::DeclareSchema::Migration::Migrator.run.first
+          ActiveRecord::Migration.class_eval(up)
+        end
+
+        it 'passes through optional: when given' do
+          class AdvertBelongsTo < ActiveRecord::Base
+            self.table_name = 'adverts'
+            declare_schema { }
+            reset_column_information
+            belongs_to :ad_category, optional: true
+          end
+          expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_true)
+        end
+
+        describe 'contradictory settings' do # contradictory settings are ok--for example, during migration
+          it 'passes through optional: true, null: false' do
+            class AdvertBelongsTo < ActiveRecord::Base
+              self.table_name = 'adverts'
+              declare_schema { }
+              reset_column_information
+              belongs_to :ad_category, optional: true, null: false
+            end
+            expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_true)
+            expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(false)
+          end
+
+          it 'passes through optional: false, null: true' do
+            class AdvertBelongsTo < ActiveRecord::Base
+              self.table_name = 'adverts'
+              declare_schema { }
+              reset_column_information
+              belongs_to :ad_category, optional: false, null: true
+            end
+            expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_false)
+            expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(true)
+          end
+        end
+
+        [false, true].each do |nullable|
+          context "nullable=#{nullable}" do
+            it 'infers optional: from null:' do
+              eval <<~EOS
+                class AdvertBelongsTo < ActiveRecord::Base
+                  declare_schema { }
+                  belongs_to :ad_category, null: #{nullable}
+                end
+              EOS
+              expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_flag[nullable])
+              expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(nullable)
+            end
+
+            it 'infers null: from optional:' do
+              eval <<~EOS
+                class AdvertBelongsTo < ActiveRecord::Base
+                  declare_schema { }
+                  belongs_to :ad_category, optional: #{nullable}
+                end
+              EOS
+              expect(AdvertBelongsTo.reflections['ad_category'].options).to eq(optional_flag[nullable])
+              expect(AdvertBelongsTo.field_specs['ad_category_id'].options&.[](:null)).to eq(nullable)
+            end
+          end
+        end
+      end
+    end
+
+    describe 'migration base class' do
+      it 'adapts to Rails 4' do
+        class Advert < active_record_base_class.constantize
+          declare_schema do
+            string :title, limit: 100
+          end
+        end
+
+        generate_migrations '-n', '-m'
+
+        migrations = Dir.glob('db/migrate/*declare_schema_migration*.rb')
+        expect(migrations.size).to eq(1), migrations.inspect
+
+        migration_content = File.read(migrations.first)
+        first_line = migration_content.split("\n").first
+        base_class = first_line.split(' < ').last
+        expect(base_class).to eq("(Rails::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration)")
+      end
+    end
+
+    context 'Does not generate migrations' do
+      it 'for aliased fields bigint -> integer limit 8' do
+        if Rails::VERSION::MAJOR >= 5 || !ActiveRecord::Base.connection.class.name.match?(/SQLite3Adapter/)
+          class Advert < active_record_base_class.constantize
+            declare_schema do
+              bigint :price
+            end
+          end
+
+          generate_migrations '-n', '-m'
+
+          migrations = Dir.glob('db/migrate/*declare_schema_migration*.rb')
+          expect(migrations.size).to eq(1), migrations.inspect
+
+          if defined?(Mysql2) && Rails::VERSION::MAJOR < 5
+            ActiveRecord::Base.connection.execute("ALTER TABLE adverts ADD PRIMARY KEY (id)")
+          end
+
+          class Advert < active_record_base_class.constantize
+            declare_schema do
+              integer :price, limit: 8
+            end
+          end
+
+          expect { generate_migrations '-n', '-g' }.to output("Database and models match -- nothing to change\n").to_stdout
+        end
       end
     end
   end

--- a/spec/lib/declare_schema/model/column_spec.rb
+++ b/spec/lib/declare_schema/model/column_spec.rb
@@ -101,30 +101,30 @@ RSpec.describe DeclareSchema::Model::Column do
     subject { described_class.new(model, current_table_name, column) }
 
     context 'Using fields' do
-    before do
-      class ColumnTestModel < ActiveRecord::Base
-        fields do
-          title :string, limit: 127, null: false
-          count :integer, null: false
+      before do
+        class ColumnTestModel < ActiveRecord::Base
+          fields do
+            title :string, limit: 127, null: false
+            count :integer, null: false
+          end
         end
       end
-    end
 
-    describe '#type' do
-      it 'returns type' do
-        expect(subject.type).to eq(type)
-      end
-    end
-
-    describe '#schema_attributes' do
-      it 'returns a hash with relevant key/values' do
-        if defined?(Mysql2)
-          expect(subject.schema_attributes).to eq(type: :integer, null: false, limit: 4)
-        else
-          expect(subject.schema_attributes).to eq(type: :integer, null: false)
+      describe '#type' do
+        it 'returns type' do
+          expect(subject.type).to eq(type)
         end
       end
-    end
+
+      describe '#schema_attributes' do
+        it 'returns a hash with relevant key/values' do
+          if defined?(Mysql2)
+            expect(subject.schema_attributes).to eq(type: :integer, null: false, limit: 4)
+          else
+            expect(subject.schema_attributes).to eq(type: :integer, null: false)
+          end
+        end
+      end
     end
 
     context 'Using declare_schema' do

--- a/spec/lib/declare_schema/model/column_spec.rb
+++ b/spec/lib/declare_schema/model/column_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe DeclareSchema::Model::Column do
   describe 'instance methods' do
     before do
       class ColumnTestModel < ActiveRecord::Base
-        declare_schema do
+        fields do
           title :string, limit: 127, null: false
           count :integer, null: false
         end

--- a/spec/lib/declare_schema/model/column_spec.rb
+++ b/spec/lib/declare_schema/model/column_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe DeclareSchema::Model::Column do
   describe 'instance methods' do
     before do
       class ColumnTestModel < ActiveRecord::Base
-        fields do
+        declare_schema do
           title :string, limit: 127, null: false
           count :integer, null: false
         end

--- a/spec/lib/declare_schema/model/column_spec.rb
+++ b/spec/lib/declare_schema/model/column_spec.rb
@@ -115,30 +115,30 @@ RSpec.describe DeclareSchema::Model::Column do
     subject { described_class.new(model, current_table_name, column) }
 
     context 'Using fields' do
-      before do
-        class ColumnTestModel < ActiveRecord::Base
-          fields do
-            title :string, limit: 127, null: false
-            count :integer, null: false
-          end
+    before do
+      class ColumnTestModel < ActiveRecord::Base
+        fields do
+          title :string, limit: 127, null: false
+          count :integer, null: false
         end
       end
+    end
 
-      describe '#sql_type' do
-        it 'returns sql type' do
-          expect(subject.sql_type).to match(/int/)
-        end
+    describe '#sql_type' do
+      it 'returns sql type' do
+        expect(subject.sql_type).to match(/int/)
       end
+    end
 
-      describe '#schema_attributes' do
-        it 'returns a hash with relevant key/values' do
-          if defined?(Mysql2)
-            expect(subject.schema_attributes).to eq(type: :integer, null: false, limit: 4)
-          else
-            expect(subject.schema_attributes).to eq(type: :integer, null: false)
-          end
+    describe '#schema_attributes' do
+      it 'returns a hash with relevant key/values' do
+        if defined?(Mysql2)
+          expect(subject.schema_attributes).to eq(type: :integer, null: false, limit: 4)
+        else
+          expect(subject.schema_attributes).to eq(type: :integer, null: false)
         end
       end
+    end
     end
 
     context 'Using declare_schema' do

--- a/spec/lib/declare_schema/model/foreign_key_definition_spec.rb
+++ b/spec/lib/declare_schema/model/foreign_key_definition_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe DeclareSchema::Model::ForeignKeyDefinition do
     load File.expand_path('../prepare_testapp.rb', __dir__)
 
     class Network < ActiveRecord::Base
-      fields do
+      declare_schema do
         name :string, limit: 127, index: true
 
         timestamps

--- a/spec/lib/declare_schema/model/foreign_key_definition_spec.rb
+++ b/spec/lib/declare_schema/model/foreign_key_definition_spec.rb
@@ -3,89 +3,178 @@
 require_relative '../../../../lib/declare_schema/model/foreign_key_definition'
 
 RSpec.describe DeclareSchema::Model::ForeignKeyDefinition do
-  before do
-    load File.expand_path('../prepare_testapp.rb', __dir__)
-
-    class Network < ActiveRecord::Base
-      fields do
-        name :string, limit: 127, index: true
-
-        timestamps
-      end
-    end
-  end
-
   let(:model_class) { Network }
 
-  describe 'instance methods' do
-    let(:connection) { instance_double(ActiveRecord::Base.connection.class) }
-    let(:model) { instance_double('Model', table_name: 'models', connection: connection) }
-    let(:foreign_key) { :network_id }
-    let(:options) { {} }
-    subject { described_class.new(model, foreign_key, options)}
-
+  context 'Using fields' do
     before do
-      allow(connection).to receive(:index_name).with('models', column: 'network_id') { 'on_network_id' }
-    end
+      load File.expand_path('../prepare_testapp.rb', __dir__)
 
-    describe '#initialize' do
-      it 'normalizes symbols to strings' do
-        expect(subject.foreign_key).to eq('network_id')
-        expect(subject.parent_table_name).to eq('networks')
-      end
+      class Network < ActiveRecord::Base
+        fields do
+          name :string, limit: 127, index: true
 
-      context 'when most options passed' do
-        let(:options) { { parent_table: :networks, foreign_key: :the_network_id, index_name: :index_on_network_id } }
-
-        it 'normalizes symbols to strings' do
-          expect(subject.foreign_key).to eq('network_id')
-          expect(subject.foreign_key_name).to eq('the_network_id')
-          expect(subject.parent_table_name).to eq('networks')
-          expect(subject.foreign_key).to eq('network_id')
-          expect(subject.constraint_name).to eq('index_on_network_id')
-          expect(subject.on_delete_cascade).to be_falsey
-        end
-      end
-
-      context 'when all options passed' do
-        let(:foreign_key) { nil }
-        let(:options) { { parent_table: :networks, foreign_key: :the_network_id, index_name: :index_on_network_id,
-                          constraint_name: :constraint_1, dependent: :delete } }
-
-        it 'normalizes symbols to strings' do
-          expect(subject.foreign_key).to be_nil
-          expect(subject.foreign_key_name).to eq('the_network_id')
-          expect(subject.parent_table_name).to eq('networks')
-          expect(subject.constraint_name).to eq('constraint_1')
-          expect(subject.on_delete_cascade).to be_truthy
+          timestamps
         end
       end
     end
 
-    describe '#to_add_statement' do
-      it 'returns add_foreign_key command' do
-        expect(subject.to_add_statement).to eq('add_foreign_key("models", "networks", column: "network_id", name: "on_network_id")')
+    describe 'instance methods' do
+      let(:connection) { instance_double(ActiveRecord::Base.connection.class) }
+      let(:model) { instance_double('Model', table_name: 'models', connection: connection) }
+      let(:foreign_key) { :network_id }
+      let(:options) { {} }
+      subject { described_class.new(model, foreign_key, options)}
+
+      before do
+        allow(connection).to receive(:index_name).with('models', column: 'network_id') { 'on_network_id' }
+      end
+
+      describe '#initialize' do
+        it 'normalizes symbols to strings' do
+          expect(subject.foreign_key).to eq('network_id')
+          expect(subject.parent_table_name).to eq('networks')
+        end
+
+        context 'when most options passed' do
+          let(:options) { { parent_table: :networks, foreign_key: :the_network_id, index_name: :index_on_network_id } }
+
+          it 'normalizes symbols to strings' do
+            expect(subject.foreign_key).to eq('network_id')
+            expect(subject.foreign_key_name).to eq('the_network_id')
+            expect(subject.parent_table_name).to eq('networks')
+            expect(subject.foreign_key).to eq('network_id')
+            expect(subject.constraint_name).to eq('index_on_network_id')
+            expect(subject.on_delete_cascade).to be_falsey
+          end
+        end
+
+        context 'when all options passed' do
+          let(:foreign_key) { nil }
+          let(:options) { { parent_table: :networks, foreign_key: :the_network_id, index_name: :index_on_network_id,
+                            constraint_name: :constraint_1, dependent: :delete } }
+
+          it 'normalizes symbols to strings' do
+            expect(subject.foreign_key).to be_nil
+            expect(subject.foreign_key_name).to eq('the_network_id')
+            expect(subject.parent_table_name).to eq('networks')
+            expect(subject.constraint_name).to eq('constraint_1')
+            expect(subject.on_delete_cascade).to be_truthy
+          end
+        end
+      end
+
+      describe '#to_add_statement' do
+        it 'returns add_foreign_key command' do
+          expect(subject.to_add_statement).to eq('add_foreign_key("models", "networks", column: "network_id", name: "on_network_id")')
+        end
+      end
+    end
+
+    describe 'class << self' do
+      let(:connection) { instance_double(ActiveRecord::Base.connection.class) }
+      let(:model) { instance_double('Model', table_name: 'models', connection: connection) }
+      let(:old_table_name) { 'networks' }
+      before do
+        allow(connection).to receive(:quote_table_name).with('networks') { 'networks' }
+        allow(connection).to receive(:select_rows) { [['CONSTRAINT `constraint` FOREIGN KEY (`network_id`) REFERENCES `networks` (`id`)']] }
+        allow(connection).to receive(:index_name).with('models', column: 'network_id') { }
+      end
+
+      describe '.for_model' do
+        subject { described_class.for_model(model, old_table_name) }
+
+        it 'returns new object' do
+          expect(subject.size).to eq(1), subject.inspect
+          expect(subject.first).to be_kind_of(described_class)
+          expect(subject.first.foreign_key).to eq('network_id')
+        end
       end
     end
   end
 
-  describe 'class << self' do
-    let(:connection) { instance_double(ActiveRecord::Base.connection.class) }
-    let(:model) { instance_double('Model', table_name: 'models', connection: connection) }
-    let(:old_table_name) { 'networks' }
+  context 'Using declare_schema' do
     before do
-      allow(connection).to receive(:quote_table_name).with('networks') { 'networks' }
-      allow(connection).to receive(:select_rows) { [['CONSTRAINT `constraint` FOREIGN KEY (`network_id`) REFERENCES `networks` (`id`)']] }
-      allow(connection).to receive(:index_name).with('models', column: 'network_id') { }
+      load File.expand_path('../prepare_testapp.rb', __dir__)
+
+      class Network < ActiveRecord::Base
+        declare_schema do
+          string :name, limit: 127, index: true
+
+          timestamps
+        end
+      end
     end
 
-    describe '.for_model' do
-      subject { described_class.for_model(model, old_table_name) }
+    describe 'instance methods' do
+      let(:connection) { instance_double(ActiveRecord::Base.connection.class) }
+      let(:model) { instance_double('Model', table_name: 'models', connection: connection) }
+      let(:foreign_key) { :network_id }
+      let(:options) { {} }
+      subject { described_class.new(model, foreign_key, options)}
 
-      it 'returns new object' do
-        expect(subject.size).to eq(1), subject.inspect
-        expect(subject.first).to be_kind_of(described_class)
-        expect(subject.first.foreign_key).to eq('network_id')
+      before do
+        allow(connection).to receive(:index_name).with('models', column: 'network_id') { 'on_network_id' }
+      end
+
+      describe '#initialize' do
+        it 'normalizes symbols to strings' do
+          expect(subject.foreign_key).to eq('network_id')
+          expect(subject.parent_table_name).to eq('networks')
+        end
+
+        context 'when most options passed' do
+          let(:options) { { parent_table: :networks, foreign_key: :the_network_id, index_name: :index_on_network_id } }
+
+          it 'normalizes symbols to strings' do
+            expect(subject.foreign_key).to eq('network_id')
+            expect(subject.foreign_key_name).to eq('the_network_id')
+            expect(subject.parent_table_name).to eq('networks')
+            expect(subject.foreign_key).to eq('network_id')
+            expect(subject.constraint_name).to eq('index_on_network_id')
+            expect(subject.on_delete_cascade).to be_falsey
+          end
+        end
+
+        context 'when all options passed' do
+          let(:foreign_key) { nil }
+          let(:options) { { parent_table: :networks, foreign_key: :the_network_id, index_name: :index_on_network_id,
+                            constraint_name: :constraint_1, dependent: :delete } }
+
+          it 'normalizes symbols to strings' do
+            expect(subject.foreign_key).to be_nil
+            expect(subject.foreign_key_name).to eq('the_network_id')
+            expect(subject.parent_table_name).to eq('networks')
+            expect(subject.constraint_name).to eq('constraint_1')
+            expect(subject.on_delete_cascade).to be_truthy
+          end
+        end
+      end
+
+      describe '#to_add_statement' do
+        it 'returns add_foreign_key command' do
+          expect(subject.to_add_statement).to eq('add_foreign_key("models", "networks", column: "network_id", name: "on_network_id")')
+        end
+      end
+    end
+
+    describe 'class << self' do
+      let(:connection) { instance_double(ActiveRecord::Base.connection.class) }
+      let(:model) { instance_double('Model', table_name: 'models', connection: connection) }
+      let(:old_table_name) { 'networks' }
+      before do
+        allow(connection).to receive(:quote_table_name).with('networks') { 'networks' }
+        allow(connection).to receive(:select_rows) { [['CONSTRAINT `constraint` FOREIGN KEY (`network_id`) REFERENCES `networks` (`id`)']] }
+        allow(connection).to receive(:index_name).with('models', column: 'network_id') { }
+      end
+
+      describe '.for_model' do
+        subject { described_class.for_model(model, old_table_name) }
+
+        it 'returns new object' do
+          expect(subject.size).to eq(1), subject.inspect
+          expect(subject.first).to be_kind_of(described_class)
+          expect(subject.first.foreign_key).to eq('network_id')
+        end
       end
     end
   end

--- a/spec/lib/declare_schema/model/foreign_key_definition_spec.rb
+++ b/spec/lib/declare_schema/model/foreign_key_definition_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe DeclareSchema::Model::ForeignKeyDefinition do
     load File.expand_path('../prepare_testapp.rb', __dir__)
 
     class Network < ActiveRecord::Base
-      declare_schema do
+      fields do
         name :string, limit: 127, index: true
 
         timestamps

--- a/spec/lib/declare_schema/model/index_definition_spec.rb
+++ b/spec/lib/declare_schema/model/index_definition_spec.rb
@@ -13,112 +13,112 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
   let(:model_class) { IndexDefinitionTestModel }
 
   context 'Using fields' do
+  before do
+    load File.expand_path('../prepare_testapp.rb', __dir__)
+
+    class IndexDefinitionTestModel < ActiveRecord::Base
+      fields do
+        name :string, limit: 127, index: true
+
+        timestamps
+      end
+    end
+
+    class IndexDefinitionCompoundIndexModel < ActiveRecord::Base
+      fields do
+        fk1_id :integer
+        fk2_id :integer
+
+        timestamps
+      end
+    end
+  end
+
+  describe 'instance methods' do
+  let(:model) { model_class.new }
+  subject { declared_class.new(model_class) }
+
+  it 'has index_definitions' do
+    expect(model_class.index_definitions).to be_kind_of(Array)
+    expect(model_class.index_definitions.map(&:name)).to eq(['on_name'])
+    expect([:name, :fields, :unique].map { |attr| model_class.index_definitions[0].send(attr)}).to eq(
+      ['on_name', ['name'], false]
+    )
+  end
+
+  it 'has index_definitions_with_primary_key' do
+    expect(model_class.index_definitions_with_primary_key).to be_kind_of(Array)
+    result = model_class.index_definitions_with_primary_key.sort_by(&:name)
+    expect(result.map(&:name)).to eq(['PRIMARY', 'on_name'])
+    expect([:name, :fields, :unique].map { |attr| result[0].send(attr)}).to eq(
+      ['PRIMARY', ['id'], true]
+    )
+    expect([:name, :fields, :unique].map { |attr| result[1].send(attr)}).to eq(
+      ['on_name', ['name'], false]
+    )
+  end
+end
+
+  describe 'class << self' do
+  context 'with a migrated database' do
     before do
-      load File.expand_path('../prepare_testapp.rb', __dir__)
+      ActiveRecord::Base.connection.execute <<~EOS
+          CREATE TABLE index_definition_test_models (
+            id INTEGER NOT NULL PRIMARY KEY,
+            name #{if defined?(Sqlite3) then 'TEXT' else 'VARCHAR(255)' end} NOT NULL
+          )
+      EOS
+      ActiveRecord::Base.connection.execute <<~EOS
+        CREATE UNIQUE INDEX index_definition_test_models_on_name ON index_definition_test_models(name)
+      EOS
+      ActiveRecord::Base.connection.execute <<~EOS
+          CREATE TABLE index_definition_compound_index_models (
+            fk1_id INTEGER NOT NULL,
+            fk2_id INTEGER NOT NULL,
+            PRIMARY KEY (fk1_id, fk2_id)
+          )
+      EOS
+      ActiveRecord::Base.connection.schema_cache.clear!
+    end
 
-      class IndexDefinitionTestModel < ActiveRecord::Base
-        fields do
-          name :string, limit: 127, index: true
+    describe 'for_model' do
+      subject { described_class.for_model(model_class) }
 
-          timestamps
+      context 'with single-column PK' do
+        it 'returns the indexes for the model' do
+          expect(subject.size).to eq(2), subject.inspect
+          expect([:name, :columns, :unique].map { |attr| subject[0].send(attr) }).to eq(
+            ['index_definition_test_models_on_name', ['name'], true]
+          )
+          expect([:name, :columns, :unique].map { |attr| subject[1].send(attr) }).to eq(
+            ['PRIMARY', ['id'], true]
+          )
         end
       end
 
-      class IndexDefinitionCompoundIndexModel < ActiveRecord::Base
-        fields do
-          fk1_id :integer
-          fk2_id :integer
+      context 'with compound-column PK' do
+        let(:model_class) { IndexDefinitionCompoundIndexModel }
 
-          timestamps
-        end
-      end
-    end
+        it 'returns the indexes for the model' do
+          if Rails::VERSION::MAJOR < 5
+            expect(model_class.connection).to receive(:primary_key).with('index_definition_compound_index_models').and_return(nil)
+            connection_stub = instance_double(ActiveRecord::Base.connection.class, "connection")
+            expect(connection_stub).to receive(:indexes).
+              with('index_definition_compound_index_models').
+              and_return([DeclareSchema::Model::IndexDefinition.new(model_class, ['fk1_id', 'fk2_id'], name: 'PRIMARY')])
 
-    describe 'instance methods' do
-    let(:model) { model_class.new }
-    subject { declared_class.new(model_class) }
-
-    it 'has index_definitions' do
-      expect(model_class.index_definitions).to be_kind_of(Array)
-      expect(model_class.index_definitions.map(&:name)).to eq(['on_name'])
-      expect([:name, :fields, :unique].map { |attr| model_class.index_definitions[0].send(attr)}).to eq(
-        ['on_name', ['name'], false]
-      )
-    end
-
-    it 'has index_definitions_with_primary_key' do
-      expect(model_class.index_definitions_with_primary_key).to be_kind_of(Array)
-      result = model_class.index_definitions_with_primary_key.sort_by(&:name)
-      expect(result.map(&:name)).to eq(['PRIMARY', 'on_name'])
-      expect([:name, :fields, :unique].map { |attr| result[0].send(attr)}).to eq(
-        ['PRIMARY', ['id'], true]
-      )
-      expect([:name, :fields, :unique].map { |attr| result[1].send(attr)}).to eq(
-        ['on_name', ['name'], false]
-      )
-    end
-  end
-
-    describe 'class << self' do
-    context 'with a migrated database' do
-      before do
-        ActiveRecord::Base.connection.execute <<~EOS
-            CREATE TABLE index_definition_test_models (
-              id INTEGER NOT NULL PRIMARY KEY,
-              name #{if defined?(Sqlite3) then 'TEXT' else 'VARCHAR(255)' end} NOT NULL
-            )
-        EOS
-        ActiveRecord::Base.connection.execute <<~EOS
-          CREATE UNIQUE INDEX index_definition_test_models_on_name ON index_definition_test_models(name)
-        EOS
-        ActiveRecord::Base.connection.execute <<~EOS
-            CREATE TABLE index_definition_compound_index_models (
-              fk1_id INTEGER NOT NULL,
-              fk2_id INTEGER NOT NULL,
-              PRIMARY KEY (fk1_id, fk2_id)
-            )
-        EOS
-        ActiveRecord::Base.connection.schema_cache.clear!
-      end
-
-      describe 'for_model' do
-        subject { described_class.for_model(model_class) }
-
-        context 'with single-column PK' do
-          it 'returns the indexes for the model' do
-            expect(subject.size).to eq(2), subject.inspect
-            expect([:name, :columns, :unique].map { |attr| subject[0].send(attr) }).to eq(
-              ['index_definition_test_models_on_name', ['name'], true]
-            )
-            expect([:name, :columns, :unique].map { |attr| subject[1].send(attr) }).to eq(
-              ['PRIMARY', ['id'], true]
-            )
+            expect(model_class.connection).to receive(:dup).and_return(connection_stub)
           end
-        end
 
-        context 'with compound-column PK' do
-          let(:model_class) { IndexDefinitionCompoundIndexModel }
-
-          it 'returns the indexes for the model' do
-            if Rails::VERSION::MAJOR < 5
-              expect(model_class.connection).to receive(:primary_key).with('index_definition_compound_index_models').and_return(nil)
-              connection_stub = instance_double(ActiveRecord::Base.connection.class, "connection")
-              expect(connection_stub).to receive(:indexes).
-                with('index_definition_compound_index_models').
-                and_return([DeclareSchema::Model::IndexDefinition.new(model_class, ['fk1_id', 'fk2_id'], name: 'PRIMARY')])
-
-              expect(model_class.connection).to receive(:dup).and_return(connection_stub)
-            end
-
-            expect(subject.size).to eq(1), subject.inspect
-            expect([:name, :columns, :unique].map { |attr| subject[0].send(attr) }).to eq(
-              ['PRIMARY', ['fk1_id', 'fk2_id'], true]
-            )
-          end
+          expect(subject.size).to eq(1), subject.inspect
+          expect([:name, :columns, :unique].map { |attr| subject[0].send(attr) }).to eq(
+            ['PRIMARY', ['fk1_id', 'fk2_id'], true]
+          )
         end
       end
     end
   end
+end
   end
 
   context 'Using declare_schema' do

--- a/spec/lib/declare_schema/model/index_definition_spec.rb
+++ b/spec/lib/declare_schema/model/index_definition_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
     load File.expand_path('../prepare_testapp.rb', __dir__)
 
     class IndexDefinitionTestModel < ActiveRecord::Base
-      fields do
+      declare_schema do
         name :string, limit: 127, index: true
 
         timestamps
@@ -22,7 +22,7 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
     end
 
     class IndexDefinitionCompoundIndexModel < ActiveRecord::Base
-      fields do
+      declare_schema do
         fk1_id :integer
         fk2_id :integer
 

--- a/spec/lib/declare_schema/model/index_definition_spec.rb
+++ b/spec/lib/declare_schema/model/index_definition_spec.rb
@@ -35,90 +35,90 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
   end
 
   describe 'instance methods' do
-  let(:model) { model_class.new }
-  subject { declared_class.new(model_class) }
+    let(:model) { model_class.new }
+    subject { declared_class.new(model_class) }
 
-  it 'has index_definitions' do
-    expect(model_class.index_definitions).to be_kind_of(Array)
-    expect(model_class.index_definitions.map(&:name)).to eq(['on_name'])
-    expect([:name, :fields, :unique].map { |attr| model_class.index_definitions[0].send(attr)}).to eq(
-      ['on_name', ['name'], false]
-    )
-  end
+    it 'has index_definitions' do
+      expect(model_class.index_definitions).to be_kind_of(Array)
+      expect(model_class.index_definitions.map(&:name)).to eq(['on_name'])
+      expect([:name, :fields, :unique].map { |attr| model_class.index_definitions[0].send(attr)}).to eq(
+        ['on_name', ['name'], false]
+      )
+    end
 
-  it 'has index_definitions_with_primary_key' do
-    expect(model_class.index_definitions_with_primary_key).to be_kind_of(Array)
-    result = model_class.index_definitions_with_primary_key.sort_by(&:name)
-    expect(result.map(&:name)).to eq(['PRIMARY', 'on_name'])
-    expect([:name, :fields, :unique].map { |attr| result[0].send(attr)}).to eq(
-      ['PRIMARY', ['id'], true]
-    )
-    expect([:name, :fields, :unique].map { |attr| result[1].send(attr)}).to eq(
-      ['on_name', ['name'], false]
-    )
+    it 'has index_definitions_with_primary_key' do
+      expect(model_class.index_definitions_with_primary_key).to be_kind_of(Array)
+      result = model_class.index_definitions_with_primary_key.sort_by(&:name)
+      expect(result.map(&:name)).to eq(['PRIMARY', 'on_name'])
+      expect([:name, :fields, :unique].map { |attr| result[0].send(attr)}).to eq(
+        ['PRIMARY', ['id'], true]
+      )
+      expect([:name, :fields, :unique].map { |attr| result[1].send(attr)}).to eq(
+        ['on_name', ['name'], false]
+      )
+    end
   end
-end
 
   describe 'class << self' do
-  context 'with a migrated database' do
-    before do
-      ActiveRecord::Base.connection.execute <<~EOS
-          CREATE TABLE index_definition_test_models (
-            id INTEGER NOT NULL PRIMARY KEY,
-            name #{if defined?(Sqlite3) then 'TEXT' else 'VARCHAR(255)' end} NOT NULL
-          )
-      EOS
-      ActiveRecord::Base.connection.execute <<~EOS
-        CREATE UNIQUE INDEX index_definition_test_models_on_name ON index_definition_test_models(name)
-      EOS
-      ActiveRecord::Base.connection.execute <<~EOS
-          CREATE TABLE index_definition_compound_index_models (
-            fk1_id INTEGER NOT NULL,
-            fk2_id INTEGER NOT NULL,
-            PRIMARY KEY (fk1_id, fk2_id)
-          )
-      EOS
-      ActiveRecord::Base.connection.schema_cache.clear!
-    end
-
-    describe 'for_model' do
-      subject { described_class.for_model(model_class) }
-
-      context 'with single-column PK' do
-        it 'returns the indexes for the model' do
-          expect(subject.size).to eq(2), subject.inspect
-          expect([:name, :columns, :unique].map { |attr| subject[0].send(attr) }).to eq(
-            ['index_definition_test_models_on_name', ['name'], true]
-          )
-          expect([:name, :columns, :unique].map { |attr| subject[1].send(attr) }).to eq(
-            ['PRIMARY', ['id'], true]
-          )
-        end
+    context 'with a migrated database' do
+      before do
+        ActiveRecord::Base.connection.execute <<~EOS
+            CREATE TABLE index_definition_test_models (
+              id INTEGER NOT NULL PRIMARY KEY,
+              name #{if defined?(Sqlite3) then 'TEXT' else 'VARCHAR(255)' end} NOT NULL
+            )
+        EOS
+        ActiveRecord::Base.connection.execute <<~EOS
+          CREATE UNIQUE INDEX index_definition_test_models_on_name ON index_definition_test_models(name)
+        EOS
+        ActiveRecord::Base.connection.execute <<~EOS
+            CREATE TABLE index_definition_compound_index_models (
+              fk1_id INTEGER NOT NULL,
+              fk2_id INTEGER NOT NULL,
+              PRIMARY KEY (fk1_id, fk2_id)
+            )
+        EOS
+        ActiveRecord::Base.connection.schema_cache.clear!
       end
 
-      context 'with compound-column PK' do
-        let(:model_class) { IndexDefinitionCompoundIndexModel }
+      describe 'for_model' do
+        subject { described_class.for_model(model_class) }
 
-        it 'returns the indexes for the model' do
-          if Rails::VERSION::MAJOR < 5
-            expect(model_class.connection).to receive(:primary_key).with('index_definition_compound_index_models').and_return(nil)
-            connection_stub = instance_double(ActiveRecord::Base.connection.class, "connection")
-            expect(connection_stub).to receive(:indexes).
-              with('index_definition_compound_index_models').
-              and_return([DeclareSchema::Model::IndexDefinition.new(model_class, ['fk1_id', 'fk2_id'], name: 'PRIMARY')])
-
-            expect(model_class.connection).to receive(:dup).and_return(connection_stub)
+        context 'with single-column PK' do
+          it 'returns the indexes for the model' do
+            expect(subject.size).to eq(2), subject.inspect
+            expect([:name, :columns, :unique].map { |attr| subject[0].send(attr) }).to eq(
+              ['index_definition_test_models_on_name', ['name'], true]
+            )
+            expect([:name, :columns, :unique].map { |attr| subject[1].send(attr) }).to eq(
+              ['PRIMARY', ['id'], true]
+            )
           end
+        end
 
-          expect(subject.size).to eq(1), subject.inspect
-          expect([:name, :columns, :unique].map { |attr| subject[0].send(attr) }).to eq(
-            ['PRIMARY', ['fk1_id', 'fk2_id'], true]
-          )
+        context 'with compound-column PK' do
+          let(:model_class) { IndexDefinitionCompoundIndexModel }
+
+          it 'returns the indexes for the model' do
+            if Rails::VERSION::MAJOR < 5
+              expect(model_class.connection).to receive(:primary_key).with('index_definition_compound_index_models').and_return(nil)
+              connection_stub = instance_double(ActiveRecord::Base.connection.class, "connection")
+              expect(connection_stub).to receive(:indexes).
+                with('index_definition_compound_index_models').
+                and_return([DeclareSchema::Model::IndexDefinition.new(model_class, ['fk1_id', 'fk2_id'], name: 'PRIMARY')])
+
+              expect(model_class.connection).to receive(:dup).and_return(connection_stub)
+            end
+
+            expect(subject.size).to eq(1), subject.inspect
+            expect([:name, :columns, :unique].map { |attr| subject[0].send(attr) }).to eq(
+              ['PRIMARY', ['fk1_id', 'fk2_id'], true]
+            )
+          end
         end
       end
     end
   end
-end
   end
 
   context 'Using declare_schema' do

--- a/spec/lib/declare_schema/model/index_definition_spec.rb
+++ b/spec/lib/declare_schema/model/index_definition_spec.rb
@@ -10,30 +10,31 @@ require_relative '../../../../lib/declare_schema/model/index_definition'
 # unless you manually create any Sqlite tables with UNIQUE constraints.
 
 RSpec.describe DeclareSchema::Model::IndexDefinition do
-  before do
-    load File.expand_path('../prepare_testapp.rb', __dir__)
-
-    class IndexDefinitionTestModel < ActiveRecord::Base
-      fields do
-        name :string, limit: 127, index: true
-
-        timestamps
-      end
-    end
-
-    class IndexDefinitionCompoundIndexModel < ActiveRecord::Base
-      fields do
-        fk1_id :integer
-        fk2_id :integer
-
-        timestamps
-      end
-    end
-  end
-
   let(:model_class) { IndexDefinitionTestModel }
 
-  describe 'instance methods' do
+  context 'Using fields' do
+    before do
+      load File.expand_path('../prepare_testapp.rb', __dir__)
+
+      class IndexDefinitionTestModel < ActiveRecord::Base
+        fields do
+          name :string, limit: 127, index: true
+
+          timestamps
+        end
+      end
+
+      class IndexDefinitionCompoundIndexModel < ActiveRecord::Base
+        fields do
+          fk1_id :integer
+          fk2_id :integer
+
+          timestamps
+        end
+      end
+    end
+
+    describe 'instance methods' do
     let(:model) { model_class.new }
     subject { declared_class.new(model_class) }
 
@@ -58,7 +59,7 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
     end
   end
 
-  describe 'class << self' do
+    describe 'class << self' do
     context 'with a migrated database' do
       before do
         ActiveRecord::Base.connection.execute <<~EOS
@@ -113,6 +114,116 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
             expect([:name, :columns, :unique].map { |attr| subject[0].send(attr) }).to eq(
               ['PRIMARY', ['fk1_id', 'fk2_id'], true]
             )
+          end
+        end
+      end
+    end
+  end
+  end
+
+  context 'Using declare_schema' do
+    before do
+      load File.expand_path('../prepare_testapp.rb', __dir__)
+
+      class IndexDefinitionTestModel < ActiveRecord::Base
+        declare_schema do
+          string :name, limit: 127, index: true
+
+          timestamps
+        end
+      end
+
+      class IndexDefinitionCompoundIndexModel < ActiveRecord::Base
+        declare_schema do
+          integer :fk1_id
+          integer :fk2_id
+
+          timestamps
+        end
+      end
+    end
+
+    describe 'instance methods' do
+      let(:model) { model_class.new }
+      subject { declared_class.new(model_class) }
+
+      it 'has index_definitions' do
+        expect(model_class.index_definitions).to be_kind_of(Array)
+        expect(model_class.index_definitions.map(&:name)).to eq(['on_name'])
+        expect([:name, :fields, :unique].map { |attr| model_class.index_definitions[0].send(attr)}).to eq(
+                                                                                                           ['on_name', ['name'], false]
+                                                                                                       )
+      end
+
+      it 'has index_definitions_with_primary_key' do
+        expect(model_class.index_definitions_with_primary_key).to be_kind_of(Array)
+        result = model_class.index_definitions_with_primary_key.sort_by(&:name)
+        expect(result.map(&:name)).to eq(['PRIMARY', 'on_name'])
+        expect([:name, :fields, :unique].map { |attr| result[0].send(attr)}).to eq(
+                                                                                    ['PRIMARY', ['id'], true]
+                                                                                )
+        expect([:name, :fields, :unique].map { |attr| result[1].send(attr)}).to eq(
+                                                                                    ['on_name', ['name'], false]
+                                                                                )
+      end
+    end
+
+    describe 'class << self' do
+      context 'with a migrated database' do
+        before do
+          ActiveRecord::Base.connection.execute <<~EOS
+            CREATE TABLE index_definition_test_models (
+              id INTEGER NOT NULL PRIMARY KEY,
+              name #{if defined?(Sqlite3) then 'TEXT' else 'VARCHAR(255)' end} NOT NULL
+            )
+          EOS
+          ActiveRecord::Base.connection.execute <<~EOS
+          CREATE UNIQUE INDEX index_definition_test_models_on_name ON index_definition_test_models(name)
+          EOS
+          ActiveRecord::Base.connection.execute <<~EOS
+            CREATE TABLE index_definition_compound_index_models (
+              fk1_id INTEGER NOT NULL,
+              fk2_id INTEGER NOT NULL,
+              PRIMARY KEY (fk1_id, fk2_id)
+            )
+          EOS
+          ActiveRecord::Base.connection.schema_cache.clear!
+        end
+
+        describe 'for_model' do
+          subject { described_class.for_model(model_class) }
+
+          context 'with single-column PK' do
+            it 'returns the indexes for the model' do
+              expect(subject.size).to eq(2), subject.inspect
+              expect([:name, :columns, :unique].map { |attr| subject[0].send(attr) }).to eq(
+                                                                                             ['index_definition_test_models_on_name', ['name'], true]
+                                                                                         )
+              expect([:name, :columns, :unique].map { |attr| subject[1].send(attr) }).to eq(
+                                                                                             ['PRIMARY', ['id'], true]
+                                                                                         )
+            end
+          end
+
+          context 'with compound-column PK' do
+            let(:model_class) { IndexDefinitionCompoundIndexModel }
+
+            it 'returns the indexes for the model' do
+              if Rails::VERSION::MAJOR < 5
+                expect(model_class.connection).to receive(:primary_key).with('index_definition_compound_index_models').and_return(nil)
+                connection_stub = instance_double(ActiveRecord::Base.connection.class, "connection")
+                expect(connection_stub).to receive(:indexes).
+                    with('index_definition_compound_index_models').
+                    and_return([DeclareSchema::Model::IndexDefinition.new(model_class, ['fk1_id', 'fk2_id'], name: 'PRIMARY')])
+
+                expect(model_class.connection).to receive(:dup).and_return(connection_stub)
+              end
+
+              expect(subject.size).to eq(1), subject.inspect
+              expect([:name, :columns, :unique].map { |attr| subject[0].send(attr) }).to eq(
+                                                                                             ['PRIMARY', ['fk1_id', 'fk2_id'], true]
+                                                                                         )
+            end
           end
         end
       end

--- a/spec/lib/declare_schema/model/index_definition_spec.rb
+++ b/spec/lib/declare_schema/model/index_definition_spec.rb
@@ -13,122 +13,122 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
   let(:model_class) { IndexDefinitionTestModel }
 
   context 'Using fields' do
-  before do
-    load File.expand_path('../prepare_testapp.rb', __dir__)
+    before do
+      load File.expand_path('../prepare_testapp.rb', __dir__)
 
-    class IndexDefinitionTestModel < ActiveRecord::Base
-      fields do
-        name :string, limit: 127, index: true
+      class IndexDefinitionTestModel < ActiveRecord::Base
+        fields do
+          name :string, limit: 127, index: true
 
-        timestamps
+          timestamps
+        end
+      end
+
+      class IndexDefinitionCompoundIndexModel < ActiveRecord::Base
+        fields do
+          fk1_id :integer
+          fk2_id :integer
+
+          timestamps
+        end
       end
     end
 
-    class IndexDefinitionCompoundIndexModel < ActiveRecord::Base
-      fields do
-        fk1_id :integer
-        fk2_id :integer
+    describe 'instance methods' do
+      let(:model) { model_class.new }
+      subject { declared_class.new(model_class) }
 
-        timestamps
-      end
-    end
-  end
-
-  describe 'instance methods' do
-    let(:model) { model_class.new }
-    subject { declared_class.new(model_class) }
-
-    it 'has index_definitions' do
-      expect(model_class.index_definitions).to be_kind_of(Array)
-      expect(model_class.index_definitions.map(&:name)).to eq(['on_name'])
-      expect([:name, :fields, :unique].map { |attr| model_class.index_definitions[0].send(attr)}).to eq(
-        ['on_name', ['name'], false]
-      )
-    end
-
-    it 'has index_definitions_with_primary_key' do
-      expect(model_class.index_definitions_with_primary_key).to be_kind_of(Array)
-      result = model_class.index_definitions_with_primary_key.sort_by(&:name)
-      expect(result.map(&:name)).to eq(['PRIMARY', 'on_name'])
-      expect([:name, :fields, :unique].map { |attr| result[0].send(attr)}).to eq(
-        ['PRIMARY', ['id'], true]
-      )
-      expect([:name, :fields, :unique].map { |attr| result[1].send(attr)}).to eq(
-        ['on_name', ['name'], false]
-      )
-    end
-  end
-
-  describe 'class methods' do
-    describe 'index_name' do
-      it 'works with a single column' do
-        expect(described_class.index_name('parent_id')).to eq('on_parent_id')
+      it 'has index_definitions' do
+        expect(model_class.index_definitions).to be_kind_of(Array)
+        expect(model_class.index_definitions.map(&:name)).to eq(['on_name'])
+        expect([:name, :fields, :unique].map { |attr| model_class.index_definitions[0].send(attr)}).to eq(
+          ['on_name', ['name'], false]
+        )
       end
 
-      it 'works with many columns' do
-        expect(described_class.index_name(['a', 'b', 'c'])).to eq('on_a_and_b_and_c')
+      it 'has index_definitions_with_primary_key' do
+        expect(model_class.index_definitions_with_primary_key).to be_kind_of(Array)
+        result = model_class.index_definitions_with_primary_key.sort_by(&:name)
+        expect(result.map(&:name)).to eq(['PRIMARY', 'on_name'])
+        expect([:name, :fields, :unique].map { |attr| result[0].send(attr)}).to eq(
+          ['PRIMARY', ['id'], true]
+        )
+        expect([:name, :fields, :unique].map { |attr| result[1].send(attr)}).to eq(
+          ['on_name', ['name'], false]
+        )
       end
     end
 
-    context 'with a migrated database' do
-      before do
-        ActiveRecord::Base.connection.execute <<~EOS
-            CREATE TABLE index_definition_test_models (
-              id INTEGER NOT NULL PRIMARY KEY,
-              name #{if defined?(Sqlite3) then 'TEXT' else 'VARCHAR(255)' end} NOT NULL
-            )
-        EOS
-        ActiveRecord::Base.connection.execute <<~EOS
-          CREATE UNIQUE INDEX index_definition_test_models_on_name ON index_definition_test_models(name)
-        EOS
-        ActiveRecord::Base.connection.execute <<~EOS
-            CREATE TABLE index_definition_compound_index_models (
-              fk1_id INTEGER NOT NULL,
-              fk2_id INTEGER NOT NULL,
-              PRIMARY KEY (fk1_id, fk2_id)
-            )
-        EOS
-        ActiveRecord::Base.connection.schema_cache.clear!
-      end
-
-      describe 'for_model' do
-        subject { described_class.for_model(model_class) }
-
-        context 'with single-column PK' do
-          it 'returns the indexes for the model' do
-            expect(subject.size).to eq(2), subject.inspect
-            expect([:name, :columns, :unique].map { |attr| subject[0].send(attr) }).to eq(
-              ['index_definition_test_models_on_name', ['name'], true]
-            )
-            expect([:name, :columns, :unique].map { |attr| subject[1].send(attr) }).to eq(
-              ['PRIMARY', ['id'], true]
-            )
-          end
+    describe 'class methods' do
+      describe 'index_name' do
+        it 'works with a single column' do
+          expect(described_class.index_name('parent_id')).to eq('on_parent_id')
         end
 
-        context 'with compound-column PK' do
-          let(:model_class) { IndexDefinitionCompoundIndexModel }
+        it 'works with many columns' do
+          expect(described_class.index_name(['a', 'b', 'c'])).to eq('on_a_and_b_and_c')
+        end
+      end
 
-          it 'returns the indexes for the model' do
-            if Rails::VERSION::MAJOR < 5
-              expect(model_class.connection).to receive(:primary_key).with('index_definition_compound_index_models').and_return(nil)
-              connection_stub = instance_double(ActiveRecord::Base.connection.class, "connection")
-              expect(connection_stub).to receive(:indexes).
-                with('index_definition_compound_index_models').
-                and_return([DeclareSchema::Model::IndexDefinition.new(model_class, ['fk1_id', 'fk2_id'], name: 'PRIMARY')])
+      context 'with a migrated database' do
+        before do
+          ActiveRecord::Base.connection.execute <<~EOS
+              CREATE TABLE index_definition_test_models (
+                id INTEGER NOT NULL PRIMARY KEY,
+                name #{if defined?(Sqlite3) then 'TEXT' else 'VARCHAR(255)' end} NOT NULL
+              )
+          EOS
+          ActiveRecord::Base.connection.execute <<~EOS
+            CREATE UNIQUE INDEX index_definition_test_models_on_name ON index_definition_test_models(name)
+          EOS
+          ActiveRecord::Base.connection.execute <<~EOS
+              CREATE TABLE index_definition_compound_index_models (
+                fk1_id INTEGER NOT NULL,
+                fk2_id INTEGER NOT NULL,
+                PRIMARY KEY (fk1_id, fk2_id)
+              )
+          EOS
+          ActiveRecord::Base.connection.schema_cache.clear!
+        end
 
-              expect(model_class.connection).to receive(:dup).and_return(connection_stub)
+        describe 'for_model' do
+          subject { described_class.for_model(model_class) }
+
+          context 'with single-column PK' do
+            it 'returns the indexes for the model' do
+              expect(subject.size).to eq(2), subject.inspect
+              expect([:name, :columns, :unique].map { |attr| subject[0].send(attr) }).to eq(
+                ['index_definition_test_models_on_name', ['name'], true]
+              )
+              expect([:name, :columns, :unique].map { |attr| subject[1].send(attr) }).to eq(
+                ['PRIMARY', ['id'], true]
+              )
             end
+          end
 
-            expect(subject.size).to eq(1), subject.inspect
-            expect([:name, :columns, :unique].map { |attr| subject[0].send(attr) }).to eq(
-              ['PRIMARY', ['fk1_id', 'fk2_id'], true]
-            )
+          context 'with compound-column PK' do
+            let(:model_class) { IndexDefinitionCompoundIndexModel }
+
+            it 'returns the indexes for the model' do
+              if Rails::VERSION::MAJOR < 5
+                expect(model_class.connection).to receive(:primary_key).with('index_definition_compound_index_models').and_return(nil)
+                connection_stub = instance_double(ActiveRecord::Base.connection.class, "connection")
+                expect(connection_stub).to receive(:indexes).
+                  with('index_definition_compound_index_models').
+                  and_return([DeclareSchema::Model::IndexDefinition.new(model_class, ['fk1_id', 'fk2_id'], name: 'PRIMARY')])
+
+                expect(model_class.connection).to receive(:dup).and_return(connection_stub)
+              end
+
+              expect(subject.size).to eq(1), subject.inspect
+              expect([:name, :columns, :unique].map { |attr| subject[0].send(attr) }).to eq(
+                ['PRIMARY', ['fk1_id', 'fk2_id'], true]
+              )
+            end
           end
         end
       end
     end
-  end
   end
 
   context 'Using declare_schema' do

--- a/spec/lib/declare_schema/model/index_definition_spec.rb
+++ b/spec/lib/declare_schema/model/index_definition_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
     load File.expand_path('../prepare_testapp.rb', __dir__)
 
     class IndexDefinitionTestModel < ActiveRecord::Base
-      declare_schema do
+      fields do
         name :string, limit: 127, index: true
 
         timestamps
@@ -22,7 +22,7 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
     end
 
     class IndexDefinitionCompoundIndexModel < ActiveRecord::Base
-      declare_schema do
+      fields do
         fk1_id :integer
         fk2_id :integer
 

--- a/spec/lib/declare_schema/model/table_options_definition_spec.rb
+++ b/spec/lib/declare_schema/model/table_options_definition_spec.rb
@@ -8,19 +8,20 @@ end
 require_relative '../../../../lib/declare_schema/model/table_options_definition'
 
 RSpec.describe DeclareSchema::Model::TableOptionsDefinition do
-  before do
-    load File.expand_path('../prepare_testapp.rb', __dir__)
-
-    class TableOptionsDefinitionTestModel < ActiveRecord::Base
-      fields do
-        name :string, limit: 127, index: true
-      end
-    end
-  end
-
   let(:model_class) { TableOptionsDefinitionTestModel }
 
-  context 'instance methods' do
+  context 'Using fields' do
+    before do
+      load File.expand_path('../prepare_testapp.rb', __dir__)
+
+      class TableOptionsDefinitionTestModel < ActiveRecord::Base
+        fields do
+          name :string, limit: 127, index: true
+        end
+      end
+    end
+
+    context 'instance methods' do
     let(:table_options) { { charset: "utf8", collation: "utf8_general"} }
     let(:model) { described_class.new('table_options_definition_test_models', table_options) }
 
@@ -50,8 +51,7 @@ RSpec.describe DeclareSchema::Model::TableOptionsDefinition do
     end
   end
 
-
-  context 'class << self' do
+    context 'class << self' do
     describe '#for_model' do
       context 'when database migrated' do
         let(:options) do
@@ -68,6 +68,70 @@ RSpec.describe DeclareSchema::Model::TableOptionsDefinition do
         end
 
         it { should eq(described_class.new(model_class.table_name, options)) }
+      end
+    end
+    end
+  end
+
+  context 'Using declare_schema' do
+    before do
+      load File.expand_path('../prepare_testapp.rb', __dir__)
+
+      class TableOptionsDefinitionTestModel < ActiveRecord::Base
+        declare_schema do
+          string :name, limit: 127, index: true
+        end
+      end
+    end
+
+    context 'instance methods' do
+      let(:table_options) { { charset: "utf8", collation: "utf8_general"} }
+      let(:model) { described_class.new('table_options_definition_test_models', table_options) }
+
+      describe '#to_key' do
+        subject { model.to_key }
+        it { should eq(['table_options_definition_test_models', '{:charset=>"utf8", :collation=>"utf8_general"}']) }
+      end
+
+      describe '#settings' do
+        subject { model.settings }
+        it { should eq("CHARACTER SET utf8 COLLATE utf8_general") }
+      end
+
+      describe '#hash' do
+        subject { model.hash }
+        it { should eq(['table_options_definition_test_models', '{:charset=>"utf8", :collation=>"utf8_general"}'].hash) }
+      end
+
+      describe '#to_s' do
+        subject { model.to_s }
+        it { should eq("CHARACTER SET utf8 COLLATE utf8_general") }
+      end
+
+      describe '#alter_table_statement' do
+        subject { model.alter_table_statement }
+        it { should match(/execute "ALTER TABLE .*table_options_definition_test_models.* CHARACTER SET utf8 COLLATE utf8_general"/) }
+      end
+    end
+
+    context 'class << self' do
+      describe '#for_model' do
+        context 'when database migrated' do
+          let(:options) do
+            if defined?(Mysql2)
+              { charset: "utf8mb4", collation: "utf8mb4_bin" }
+            else
+              { }
+            end
+          end
+          subject { described_class.for_model(model_class) }
+
+          before do
+            generate_migrations '-n', '-m'
+          end
+
+          it { should eq(described_class.new(model_class.table_name, options)) }
+        end
       end
     end
   end

--- a/spec/lib/declare_schema/model/table_options_definition_spec.rb
+++ b/spec/lib/declare_schema/model/table_options_definition_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe DeclareSchema::Model::TableOptionsDefinition do
     load File.expand_path('../prepare_testapp.rb', __dir__)
 
     class TableOptionsDefinitionTestModel < ActiveRecord::Base
-      fields do
+      declare_schema do
         name :string, limit: 127, index: true
       end
     end

--- a/spec/lib/declare_schema/model/table_options_definition_spec.rb
+++ b/spec/lib/declare_schema/model/table_options_definition_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe DeclareSchema::Model::TableOptionsDefinition do
     load File.expand_path('../prepare_testapp.rb', __dir__)
 
     class TableOptionsDefinitionTestModel < ActiveRecord::Base
-      declare_schema do
+      fields do
         name :string, limit: 127, index: true
       end
     end

--- a/test_responses.txt
+++ b/test_responses.txt
@@ -1,2 +1,0 @@
-id
-drop id


### PR DESCRIPTION
## [0.10.0]
### Deprecated
- The `fields` dsl method is being deprecated.

### Added
- Added the `declare_schema` method to replace `fields`. We now expect a column's type to come before the name
i.e. `declare schema { string :title }`. Otherwise, there is no difference between `fields` and `declare_schema`.