### PR TITLE
Tech 5413 fix bug where constraint is not globally unique

### DIFF
--- a/lib/declare_schema/model/foreign_key_definition.rb
+++ b/lib/declare_schema/model/foreign_key_definition.rb
@@ -20,7 +20,6 @@ module DeclareSchema
         @foreign_key_name = options[:foreign_key]&.to_s || @foreign_key
 
         @constraint_name = options[:constraint_name]&.to_s.presence ||
-                             options[:index_name]&.to_s ||
                              model.connection.index_name(model.table_name, column: @foreign_key_name)
         @on_delete_cascade = options[:dependent] == :delete
       end

--- a/lib/declare_schema/model/foreign_key_definition.rb
+++ b/lib/declare_schema/model/foreign_key_definition.rb
@@ -19,9 +19,9 @@ module DeclareSchema
         @parent_table_name = options[:parent_table]&.to_s
         @foreign_key_name = options[:foreign_key]&.to_s || @foreign_key
 
-        @constraint_name = options[:constraint_name]&.to_s ||
+        @constraint_name = options[:constraint_name]&.to_s.presence ||
                              options[:index_name]&.to_s ||
-                             IndexDefinition.index_name(@foreign_key_name)
+                             model.connection.index_name(model.table_name, column: @foreign_key_name)
         @on_delete_cascade = options[:dependent] == :delete
       end
 

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -855,6 +855,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         belongs_to :category, limit: 8
       end
     end
+
     it 'will genereate unique constraint names' do
       expect(Generators::DeclareSchema::Migration::Migrator.run).to(
         migrate_up(<<~EOS.strip)
@@ -871,8 +872,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
           end
           add_index :advertisers, [:category_id], name: :on_category_id
           add_index :affiliates, [:category_id], name: :on_category_id
-          #{"add_foreign_key :advertisers, :categories, column: :category_id, name: :index_advertisers_on_category_id"}
-          #{"add_foreign_key :affiliates, :categories, column: :category_id, name: :index_affiliates_on_category_id"}
+          add_foreign_key :advertisers, :categories, column: :category_id, name: :index_advertisers_on_category_id
+          add_foreign_key :affiliates, :categories, column: :category_id, name: :index_affiliates_on_category_id
           EOS
       )
       migrate
@@ -880,7 +881,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       nuke_model_class(Advertiser)
       nuke_model_class(Affiliate)
     end
-  end if defined?(Mysql2)
+  end if !defined?(Sqlite3)
 
   describe 'serialize' do
     before do

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -365,10 +365,10 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       migrate_up(<<~EOS.strip)
         add_column :adverts, :category_id, :integer, limit: 8, null: false
         add_index :adverts, [:category_id], name: :on_category_id
-        #{"add_foreign_key :adverts, :categories, column: :category_id, name: :on_category_id" if defined?(Mysql2)}
+        #{"add_foreign_key :adverts, :categories, column: :category_id, name: :index_adverts_on_category_id" if defined?(Mysql2)}
       EOS
       .and migrate_down(<<~EOS.strip)
-        #{"remove_foreign_key :adverts, name: :on_category_id" if defined?(Mysql2)}
+        #{"remove_foreign_key :adverts, name: :index_adverts_on_category_id" if defined?(Mysql2)}
         remove_index :adverts, name: :on_category_id
         remove_column :adverts, :category_id
       EOS
@@ -389,8 +389,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       migrate_up(<<~EOS.strip)
         add_column :adverts, :c_id, :integer, limit: 8, null: false
         add_index :adverts, [:c_id], name: :on_c_id
-        #{"add_foreign_key :adverts, :categories, column: :category_id, name: :on_category_id\n" +
-          "add_foreign_key :adverts, :categories, column: :c_id, name: :on_c_id" if defined?(Mysql2)}
+        #{"add_foreign_key :adverts, :categories, column: :category_id, name: :index_adverts_on_category_id\n" +
+          "add_foreign_key :adverts, :categories, column: :c_id, name: :index_adverts_on_c_id" if defined?(Mysql2)}
       EOS
     )
 
@@ -408,8 +408,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     expect(Generators::DeclareSchema::Migration::Migrator.run).to(
       migrate_up(<<~EOS.strip)
         add_column :adverts, :category_id, :integer, limit: 8, null: false
-        #{"add_foreign_key :adverts, :categories, column: :category_id, name: :on_category_id\n" +
-          "add_foreign_key :adverts, :categories, column: :c_id, name: :on_c_id" if defined?(Mysql2)}
+        #{"add_foreign_key :adverts, :categories, column: :category_id, name: :index_adverts_on_category_id\n" +
+          "add_foreign_key :adverts, :categories, column: :c_id, name: :index_adverts_on_c_id" if defined?(Mysql2)}
       EOS
     )
 
@@ -428,8 +428,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       migrate_up(<<~EOS.strip)
         add_column :adverts, :category_id, :integer, limit: 8, null: false
         add_index :adverts, [:category_id], name: :my_index
-        #{"add_foreign_key :adverts, :categories, column: :category_id, name: :on_category_id\n" +
-          "add_foreign_key :adverts, :categories, column: :c_id, name: :on_c_id" if defined?(Mysql2)}
+        #{"add_foreign_key :adverts, :categories, column: :category_id, name: :index_adverts_on_category_id\n" +
+          "add_foreign_key :adverts, :categories, column: :c_id, name: :index_adverts_on_c_id" if defined?(Mysql2)}
       EOS
     )
 
@@ -453,12 +453,12 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         add_column :adverts, :created_at, :datetime, null: true
         add_column :adverts, :updated_at, :datetime, null: true
         add_column :adverts, :lock_version, :integer#{lock_version_limit}, null: false, default: 1
-        #{"add_foreign_key :adverts, :categories, column: :category_id, name: :on_category_id\n" +
-          "add_foreign_key :adverts, :categories, column: :c_id, name: :on_c_id" if defined?(Mysql2)}
+        #{"add_foreign_key :adverts, :categories, column: :category_id, name: :index_adverts_on_category_id\n" +
+          "add_foreign_key :adverts, :categories, column: :c_id, name: :index_adverts_on_c_id" if defined?(Mysql2)}
       EOS
       .and migrate_down(<<~EOS.strip)
-        #{"remove_foreign_key :adverts, name: :on_c_id\n" +
-          "remove_foreign_key :adverts, name: :on_category_id" if defined?(Mysql2)}
+        #{"remove_foreign_key :adverts, name: :index_adverts_on_c_id\n" +
+          "remove_foreign_key :adverts, name: :index_adverts_on_category_id" if defined?(Mysql2)}
         remove_column :adverts, :lock_version
         remove_column :adverts, :updated_at
         remove_column :adverts, :created_at
@@ -483,8 +483,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       migrate_up(<<~EOS.strip)
         add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
         add_index :adverts, [:title], name: :on_title
-        #{"add_foreign_key :adverts, :categories, column: :category_id, name: :on_category_id\n" +
-          "add_foreign_key :adverts, :categories, column: :c_id, name: :on_c_id" if defined?(Mysql2)}
+        #{"add_foreign_key :adverts, :categories, column: :category_id, name: :index_adverts_on_category_id\n" +
+          "add_foreign_key :adverts, :categories, column: :c_id, name: :index_adverts_on_c_id" if defined?(Mysql2)}
       EOS
     )
 
@@ -502,8 +502,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       migrate_up(<<~EOS.strip)
         add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
         add_index :adverts, [:title], name: :on_title, unique: true
-        #{"add_foreign_key :adverts, :categories, column: :category_id, name: :on_category_id\n" +
-          "add_foreign_key :adverts, :categories, column: :c_id, name: :on_c_id" if defined?(Mysql2)}
+        #{"add_foreign_key :adverts, :categories, column: :category_id, name: :index_adverts_on_category_id\n" +
+          "add_foreign_key :adverts, :categories, column: :c_id, name: :index_adverts_on_c_id" if defined?(Mysql2)}
       EOS
     )
 
@@ -521,8 +521,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       migrate_up(<<~EOS.strip)
         add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
         add_index :adverts, [:title], name: :my_index
-        #{"add_foreign_key :adverts, :categories, column: :category_id, name: :on_category_id\n" +
-          "add_foreign_key :adverts, :categories, column: :c_id, name: :on_c_id" if defined?(Mysql2)}
+        #{"add_foreign_key :adverts, :categories, column: :category_id, name: :index_adverts_on_category_id\n" +
+          "add_foreign_key :adverts, :categories, column: :c_id, name: :index_adverts_on_c_id" if defined?(Mysql2)}
       EOS
     )
 
@@ -538,8 +538,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       migrate_up(<<~EOS.strip)
         add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
         add_index :adverts, [:title], name: :on_title
-        #{"add_foreign_key :adverts, :categories, column: :category_id, name: :on_category_id\n" +
-          "add_foreign_key :adverts, :categories, column: :c_id, name: :on_c_id" if defined?(Mysql2)}
+        #{"add_foreign_key :adverts, :categories, column: :category_id, name: :index_adverts_on_category_id\n" +
+          "add_foreign_key :adverts, :categories, column: :c_id, name: :index_adverts_on_c_id" if defined?(Mysql2)}
       EOS
     )
 
@@ -555,8 +555,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       migrate_up(<<~EOS.strip)
         add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
         add_index :adverts, [:title], name: :my_index, unique: true
-        #{"add_foreign_key :adverts, :categories, column: :category_id, name: :on_category_id\n" +
-          "add_foreign_key :adverts, :categories, column: :c_id, name: :on_c_id" if defined?(Mysql2)}
+        #{"add_foreign_key :adverts, :categories, column: :category_id, name: :index_adverts_on_category_id\n" +
+          "add_foreign_key :adverts, :categories, column: :c_id, name: :index_adverts_on_c_id" if defined?(Mysql2)}
       EOS
     )
 
@@ -572,8 +572,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       migrate_up(<<~EOS.strip)
         add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
         add_index :adverts, [:title, :category_id], name: :on_title_and_category_id
-        #{"add_foreign_key :adverts, :categories, column: :category_id, name: :on_category_id\n" +
-          "add_foreign_key :adverts, :categories, column: :c_id, name: :on_c_id" if defined?(Mysql2)}
+        #{"add_foreign_key :adverts, :categories, column: :category_id, name: :index_adverts_on_category_id\n" +
+          "add_foreign_key :adverts, :categories, column: :c_id, name: :index_adverts_on_c_id" if defined?(Mysql2)}
       EOS
     )
 
@@ -605,14 +605,14 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         add_column :ads, :title, :string, limit: 250, null: true#{charset_and_collation}
         add_column :ads, :body, :text#{', limit: 4294967295' if defined?(Mysql2)}, null: true#{charset_and_collation}
         #{if defined?(Mysql2)
-            "add_foreign_key :adverts, :categories, column: :category_id, name: :on_category_id\n" +
-            "add_foreign_key :adverts, :categories, column: :c_id, name: :on_c_id"
+            "add_foreign_key :adverts, :categories, column: :category_id, name: :index_adverts_on_category_id\n" +
+            "add_foreign_key :adverts, :categories, column: :c_id, name: :index_adverts_on_c_id"
           end}
       EOS
       .and migrate_down(<<~EOS.strip)
         #{if defined?(Mysql2)
-            "remove_foreign_key :adverts, name: :on_c_id\n" +
-            "remove_foreign_key :adverts, name: :on_category_id"
+            "remove_foreign_key :adverts, name: :index_adverts_on_c_id\n" +
+            "remove_foreign_key :adverts, name: :index_adverts_on_category_id"
           end}
         remove_column :ads, :body
         remove_column :ads, :title
@@ -871,8 +871,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
           end
           add_index :advertisers, [:category_id], name: :on_category_id
           add_index :affiliates, [:category_id], name: :on_category_id
-          #{"add_foreign_key :advertisers, :categories, column: :category_id, name: :on_category_id" if defined?(Mysql2)}
-          #{"add_foreign_key :affiliates, :categories, column: :category_id, name: :on_category_id" if defined?(Mysql2)}
+          #{"add_foreign_key :advertisers, :categories, column: :category_id, name: :index_advertisers_on_category_id" if defined?(Mysql2)}
+          #{"add_foreign_key :affiliates, :categories, column: :category_id, name: :index_affiliates_on_category_id" if defined?(Mysql2)}
           EOS
       )
       migrate

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -6,6 +6,11 @@ begin
 rescue LoadError
 end
 
+begin
+  require 'sqlite3'
+rescue LoadError
+end
+
 RSpec.describe 'DeclareSchema Migration Generator' do
   before do
     load File.expand_path('prepare_testapp.rb', __dir__)

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -871,18 +871,16 @@ RSpec.describe 'DeclareSchema Migration Generator' do
           end
           add_index :advertisers, [:category_id], name: :on_category_id
           add_index :affiliates, [:category_id], name: :on_category_id
-          #{"add_foreign_key :advertisers, :categories, column: :category_id, name: :index_advertisers_on_category_id" if defined?(Mysql2)}
-          #{"add_foreign_key :affiliates, :categories, column: :category_id, name: :index_affiliates_on_category_id" if defined?(Mysql2)}
+          #{"add_foreign_key :advertisers, :categories, column: :category_id, name: :index_advertisers_on_category_id"}
+          #{"add_foreign_key :affiliates, :categories, column: :category_id, name: :index_affiliates_on_category_id"}
           EOS
       )
       migrate
 
-      # Advertiser.field_specs.delete(:category_id)
-      # Advertiser.index_definitions.delete_if { |spec| spec.fields==["category_id"] }
-      # Affiliate.field_specs.delete(:category_id)
-      # Affiliate.index_definitions.delete_if { |spec| spec.fields==["category_id"] }
+      nuke_model_class(Advertiser)
+      nuke_model_class(Affiliate)
     end
-  end
+  end if defined?(Mysql2)
 
   describe 'serialize' do
     before do

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -887,7 +887,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         nuke_model_class(Advertiser)
         nuke_model_class(Affiliate)
       end
-    end if !defined?(SQLite3) and ActiveRecord::VERSION::MAJOR >= 5
+    end if !defined?(SQLite3) && ActiveRecord::VERSION::MAJOR >= 5
 
     describe 'serialize' do
       before do
@@ -2040,12 +2040,13 @@ RSpec.describe 'DeclareSchema Migration Generator' do
           add_foreign_key :affiliates, :categories, column: :category_id, name: :index_affiliates_on_category_id
         EOS
         )
+        binding.pry
         migrate
 
         nuke_model_class(Advertiser)
         nuke_model_class(Affiliate)
       end
-    end if !defined?(SQLite3) and ActiveRecord::VERSION::MAJOR >= 5
+    end if !defined?(SQLite3) && ActiveRecord::VERSION::MAJOR >= 5
 
     describe 'serialize' do
       before do

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -887,7 +887,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         nuke_model_class(Advertiser)
         nuke_model_class(Affiliate)
       end
-    end if !defined?(SQLite3)
+    end if !defined?(SQLite3) and ActiveRecord::VERSION::MAJOR >= 5
 
     describe 'serialize' do
       before do
@@ -2045,7 +2045,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         nuke_model_class(Advertiser)
         nuke_model_class(Affiliate)
       end
-    end if !defined?(SQLite3)
+    end if !defined?(SQLite3) and ActiveRecord::VERSION::MAJOR >= 5
 
     describe 'serialize' do
       before do

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -882,7 +882,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         nuke_model_class(Advertiser)
         nuke_model_class(Affiliate)
       end
-    end if !defined?(Sqlite3)
+    end if !defined?(SQLite3)
 
     describe 'serialize' do
       before do
@@ -2040,7 +2040,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         nuke_model_class(Advertiser)
         nuke_model_class(Affiliate)
       end
-    end if !defined?(Sqlite3)
+    end if !defined?(SQLite3)
 
     describe 'serialize' do
       before do

--- a/spec/lib/declare_schema/model/foreign_key_definition_spec.rb
+++ b/spec/lib/declare_schema/model/foreign_key_definition_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe DeclareSchema::Model::ForeignKeyDefinition do
     subject { described_class.new(model, foreign_key, options)}
 
     before do
-      allow(connection).to receive(:index_name).with('models', column: 'network_id') { 'on_network_id' }
+      allow(model.connection).to receive(:index_name).with(model.table_name, column: options[:foreign_key]&.to_s || foreign_key.to_s) { 'index_on_network_id' }
     end
 
     describe '#initialize' do

--- a/spec/lib/declare_schema/model/foreign_key_definition_spec.rb
+++ b/spec/lib/declare_schema/model/foreign_key_definition_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe DeclareSchema::Model::ForeignKeyDefinition do
     subject { described_class.new(model, foreign_key, options)}
 
     before do
-      allow(model.connection).to receive(:index_name).with(model.table_name, column: options[:foreign_key]&.to_s || foreign_key.to_s) { 'index_on_network_id' }
+      allow(model.connection).to receive(:index_name).with(any_args) { 'index_on_network_id' }
     end
 
     describe '#initialize' do
@@ -35,7 +35,7 @@ RSpec.describe DeclareSchema::Model::ForeignKeyDefinition do
       end
 
       context 'when most options passed' do
-        let(:options) { { parent_table: :networks, foreign_key: :the_network_id, index_name: :index_on_network_id } }
+        let(:options) { { parent_table: :networks, foreign_key: :the_network_id } }
 
         it 'normalizes symbols to strings' do
           expect(subject.foreign_key).to eq('network_id')
@@ -49,8 +49,7 @@ RSpec.describe DeclareSchema::Model::ForeignKeyDefinition do
 
       context 'when all options passed' do
         let(:foreign_key) { nil }
-        let(:options) { { parent_table: :networks, foreign_key: :the_network_id, index_name: :index_on_network_id,
-                          constraint_name: :constraint_1, dependent: :delete } }
+        let(:options) { { parent_table: :networks, foreign_key: :the_network_id, constraint_name: :constraint_1, dependent: :delete } }
 
         it 'normalizes symbols to strings' do
           expect(subject.foreign_key).to be_nil
@@ -61,10 +60,15 @@ RSpec.describe DeclareSchema::Model::ForeignKeyDefinition do
         end
       end
 
-      context 'when constraint name passed' do
-        let(:options) { { parent_table: :networks, foreign_key: :the_network_id, index_name: :index_on_network_id,
-                          constraint_name: "", dependent: :delete } }
-        it 'in as ""' do
+      context 'when constraint name passed as empty string' do
+        let(:options) { { constraint_name: "" } }
+        it 'defaults to rails constraint name' do
+          expect(subject.constraint_name).to eq("index_on_network_id")
+        end
+      end
+
+      context 'when no constraint name passed' do
+        it 'defaults to rails constraint name' do
           expect(subject.constraint_name).to eq("index_on_network_id")
         end
       end

--- a/spec/lib/declare_schema/model/foreign_key_definition_spec.rb
+++ b/spec/lib/declare_schema/model/foreign_key_definition_spec.rb
@@ -60,6 +60,14 @@ RSpec.describe DeclareSchema::Model::ForeignKeyDefinition do
           expect(subject.on_delete_cascade).to be_truthy
         end
       end
+
+      context 'when constraint name passed' do
+        let(:options) { { parent_table: :networks, foreign_key: :the_network_id, index_name: :index_on_network_id,
+                          constraint_name: "", dependent: :delete } }
+        it 'in as ""' do
+          expect(subject.constraint_name).to eq("index_on_network_id")
+        end
+      end
     end
   end
 

--- a/spec/lib/declare_schema/model/index_definition_spec.rb
+++ b/spec/lib/declare_schema/model/index_definition_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
           ActiveRecord::Base.connection.execute <<~EOS
               CREATE TABLE index_definition_test_models (
                 id INTEGER NOT NULL PRIMARY KEY,
-                name #{if defined?(Sqlite3) then 'TEXT' else 'VARCHAR(255)' end} NOT NULL
+                name #{if defined?(SQLite3) then 'TEXT' else 'VARCHAR(255)' end} NOT NULL
               )
           EOS
           ActiveRecord::Base.connection.execute <<~EOS
@@ -184,7 +184,7 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
           ActiveRecord::Base.connection.execute <<~EOS
             CREATE TABLE index_definition_test_models (
               id INTEGER NOT NULL PRIMARY KEY,
-              name #{if defined?(Sqlite3) then 'TEXT' else 'VARCHAR(255)' end} NOT NULL
+              name #{if defined?(SQLite3) then 'TEXT' else 'VARCHAR(255)' end} NOT NULL
             )
           EOS
           ActiveRecord::Base.connection.execute <<~EOS


### PR DESCRIPTION
## CHANGELOG
## [0.10.2] - Unreleased
### Fixed
- Fixed bug where foreign key constraint names are not globally unique


## TODO
Fix failing `rails-4-mysql` [test](https://github.com/Invoca/declare_schema/runs/2153066804?check_suite_focus=true): 
```
Mysql2::Error: Cannot add foreign key constraint: ALTER TABLE `advertisers` ADD CONSTRAINT `index_advertisers_on_category_id`
       FOREIGN KEY (`category_id`)
         REFERENCES `categories` (`id`)
```

Failure was due to rails 4 [create_table](https://apidock.com/rails/v4.2.1/ActiveRecord/ConnectionAdapters/SchemaStatements/create_table) not recognizing `bigint` type as primary key. With the move to only support rails 5+ we decided to only run this test on rails >= 5