### PR TITLE
no-jira:drop generate and migrate command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - Unreleased
+### Removed
+- Removed `g|m|c` prompt entirely, since it was confusing. Instead, the migration is
+ always generated; the user may press ^C at the filename prompt to cancel.
+ The migration will be run if `--migrate` is passed; otherwise, the migrate command will be displayed to be run later.
+### Added
+- Added the new configuration option `DeclareSchema.@db_migrate_command =`.
+
 ## [0.10.1] - 2021-03-18
 ### Fixed
 - Migration steps are now generated in a defined dependency order, so that--for example--indexes that depend
@@ -154,6 +162,7 @@ using the appropriate Rails configuration attributes.
 ### Added
 - Initial version from https://github.com/Invoca/hobo_fields v4.1.0.
 
+[0.11.0]: https://github.com/Invoca/declare_schema/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/Invoca/declare_schema/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/Invoca/declare_schema/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/Invoca/declare_schema/compare/v0.8.0...v0.9.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (0.10.1)
+    declare_schema (0.11.0)
       rails (>= 4.2)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ during the initialization of your Rails application.
 
 ### before_generating_migration callback
 
-During the initializtion process for generating migrations, `DeclareSchema` will
+During the initialization process for generating migrations, `DeclareSchema` will
 trigger the `eager_load!` on the `Rails` application and all `Rails::Engine`s loaded
 into scope.  If you need to generate migrations for models that aren't automatically loaded by `eager_load!`,
 load them in the `before_generating_migration` block.
@@ -162,6 +162,16 @@ turn all tables into `utf8mb4` supporting tables:
 
 DeclareSchema.default_charset   = "utf8mb4"
 DeclareSchema.default_collation = "utf8mb4_bin"
+```
+#### db:migrate Command
+`declare_schema` can run the migration once it is generated, if the `--migrate` option is passed.
+If not, it will display the command to run later. By default this command is
+```
+bundle exec rails db:migrate
+```
+If your repo has a different command to run for migrations, you can configure it like this:
+```ruby
+`DeclareSchema.db_migrate_command = "bundle exec rails db:migrate_immediate"`
 ```
 
 ## Declaring Character Set and Collation

--- a/lib/declare_schema.rb
+++ b/lib/declare_schema.rb
@@ -29,7 +29,7 @@ module DeclareSchema
   @default_generate_foreign_keys = true
   @default_generate_indexing     = true
   @db_migrate_command            =
-    if Rails::VERSION::MAJOR < 5
+    if ActiveSupport::VERSION::MAJOR < 5
       "bundle exec rake db:migrate"
     else
       "bundle exec rails db:migrate"

--- a/lib/declare_schema.rb
+++ b/lib/declare_schema.rb
@@ -28,10 +28,16 @@ module DeclareSchema
   @default_null                  = false
   @default_generate_foreign_keys = true
   @default_generate_indexing     = true
+  @db_migrate_command            =
+    if Rails::VERSION::MAJOR < 5
+      "bundle exec rake db:migrate"
+    else
+      "bundle exec rails db:migrate"
+    end
 
   class << self
     attr_reader :default_charset, :default_collation, :default_text_limit, :default_string_limit, :default_null,
-                :default_generate_foreign_keys, :default_generate_indexing
+                :default_generate_foreign_keys, :default_generate_indexing, :db_migrate_command
 
     def to_class(type)
       case type
@@ -77,6 +83,11 @@ module DeclareSchema
     def default_generate_indexing=(generate_indexing)
       generate_indexing.in?([true, false]) or raise ArgumentError, "generate_indexing must be either true or false (got #{generate_indexing.inspect})"
       @default_generate_indexing = generate_indexing
+    end
+
+    def db_migrate_command=(db_migrate_command)
+      db_migrate_command.is_a?(String) or raise ArgumentError, "db_migrate_command must be a string (got #{db_migrate_command.inspect})"
+      @db_migrate_command = db_migrate_command
     end
   end
 end

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails'
-
 require 'declare_schema/extensions/module'
 
 module DeclareSchema
@@ -130,7 +128,7 @@ module DeclareSchema
 
         fk_options[:dependent] = options.delete(:far_end_dependent) if options.has_key?(:far_end_dependent)
 
-        if Rails::VERSION::MAJOR >= 5
+        if ActiveSupport::VERSION::MAJOR >= 5
           super
         else
           super(name, scope, options.except(:optional))
@@ -149,7 +147,7 @@ module DeclareSchema
         end
       end
 
-      if ::Rails::VERSION::MAJOR < 5
+      if ::ActiveSupport::VERSION::MAJOR < 5
         def primary_key
           super || 'id'
         end
@@ -227,7 +225,7 @@ module DeclareSchema
                   ActiveRecord::Coders::JSON
                 elsif [:load, :dump].all? { |x| class_name_or_coder.respond_to?(x) }
                   class_name_or_coder
-                elsif Rails::VERSION::MAJOR >= 5
+                elsif ActiveSupport::VERSION::MAJOR >= 5
                   ActiveRecord::Coders::YAMLColumn.new(attr_name, class_name_or_coder)
                 else
                   ActiveRecord::Coders::YAMLColumn.new(class_name_or_coder)

--- a/lib/declare_schema/model/column.rb
+++ b/lib/declare_schema/model/column.rb
@@ -53,7 +53,7 @@ module DeclareSchema
         def deserialize_default_value(column, type, default_value)
           type or raise ArgumentError, "must pass type; got #{type.inspect}"
 
-          case Rails::VERSION::MAJOR
+          case ActiveSupport::VERSION::MAJOR
           when 4
             # TODO: Delete this Rails 4 support ASAP! This could be wrong, since it's using the type of the old column...which
             # might be getting migrated to a new type. We should be using just type as below. -Colin

--- a/lib/declare_schema/model/index_definition.rb
+++ b/lib/declare_schema/model/index_definition.rb
@@ -68,7 +68,7 @@ module DeclareSchema
 
         # This is the old approach which is still needed for MySQL in Rails 4 and SQLite
         def sqlite_compound_primary_key(model, table)
-          ActiveRecord::Base.connection.class.name.match?(/SQLite3Adapter/) || Rails::VERSION::MAJOR < 5 or return nil
+          ActiveRecord::Base.connection.class.name.match?(/SQLite3Adapter/) || ActiveSupport::VERSION::MAJOR < 5 or return nil
 
           connection = model.connection.dup
 

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "0.10.1"
+  VERSION = "0.11.0"
 end

--- a/lib/generators/declare_schema/migration/USAGE
+++ b/lib/generators/declare_schema/migration/USAGE
@@ -1,47 +1,37 @@
 Description:
 
         This generator compares your existing schema against the
-        schema declared inside your fields declarations in your
-        models.
+        schema declared inside your declare_schema do ... end
+        declarations in your models.
 
         If the generator finds differences, it will display the
-        migration it has created, and ask you if you wish to
-        [g]enerate migration, generate and [m]igrate now or [c]ancel?
-        Enter "g" to just generate the migration but do not run it.
-        Enter "m" to generate the migration and run it, or press "c"
-        to do nothing.
-
-        The generator will then prompt you for the migration name,
+        migration it has created, and prompt you for the migration name,
         supplying a numbered default name.
 
         The generator is conservative and will prompt you to resolve
         any ambiguities.
 
-Examples:
+Example:
 
-        $ rails generate declare_schema:migration
+        $ bundle exec rails generate declare_schema:migration
 
         ---------- Up Migration ----------
-        create_table :foos do |t|
+        create_table :users do |t|
+          t.string :first_name, limit: 50
+          t.string :last_name, limit: 50
           t.datetime :created_at
           t.datetime :updated_at
         end
         ----------------------------------
 
         ---------- Down Migration --------
-        drop_table :foos
+        drop_table :users
         ----------------------------------
-        What now: [g]enerate migration, generate and [m]igrate now or [c]ancel? m
-
-        Migration filename:
-        (you can type spaces instead of '_' -- every little helps)
-        Filename [declare_schema_migration_2]: create_foo
+        Migration filename: (spaces will be converted to _) [declare_schema_migration_2]: create users
               exists  db/migrate
-              create  db/migrate/20091023183838_create_foo.rb
-        (in /work/foo)
-        ==  CreateFoo: migrating ======================================================
-        -- create_table(:yos)
-           -> 0.0856s
-        ==  CreateFoo: migrated (0.0858s) =============================================
+              create  db/migrate/20091023183838_create_users.rb
 
+Not running migration since --migrate not given. When you are ready, run:
+
+   bundle exec rails db:migrate
 

--- a/lib/generators/declare_schema/migration/migration_generator.rb
+++ b/lib/generators/declare_schema/migration/migration_generator.rb
@@ -83,7 +83,7 @@ module DeclareSchema
       if options[:migrate]
         say db_migrate_command
         bare_rails_command = db_migrate_command.sub(/\Abundle exec +/, '').sub(/\Arake +|rails +/, '')
-        if Rails::VERSION::MAJOR < 5
+        if ActiveSupport::VERSION::MAJOR < 5
           rake(bare_rails_command)
         else
           rails_command(bare_rails_command)
@@ -98,7 +98,7 @@ module DeclareSchema
     private
 
     def migrations_pending?
-      migrations = case Rails::VERSION::MAJOR
+      migrations = case ActiveSupport::VERSION::MAJOR
                    when 4
                      ActiveRecord::Migrator.migrations('db/migrate')
                    when 5
@@ -106,7 +106,7 @@ module DeclareSchema
                    else
                      ActiveRecord::MigrationContext.new(ActiveRecord::Migrator.migrations_paths, ActiveRecord::SchemaMigration).migrations
                    end
-      pending_migrations = case Rails::VERSION::MAJOR
+      pending_migrations = case ActiveSupport::VERSION::MAJOR
                            when 4, 5
                              ActiveRecord::Migrator.new(:up, migrations).pending_migrations
                            else

--- a/lib/generators/declare_schema/migration/migration_generator.rb
+++ b/lib/generators/declare_schema/migration/migration_generator.rb
@@ -97,6 +97,13 @@ module DeclareSchema
 
     private
 
+    if ActiveSupport::VERSION::MAJOR < 5
+      def indent(string, columns)
+        whitespace = ' ' * columns
+        string.gsub("\n", "\n#{whitespace}").gsub!(/ +\n/, "\n")
+      end
+    end
+
     def migrations_pending?
       migrations = case ActiveSupport::VERSION::MAJOR
                    when 4

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -47,8 +47,8 @@ module Generators
           deprecate :default_charset=, :default_collation=, :default_charset, :default_collation, deprecator: ActiveSupport::Deprecation.new('1.0', 'declare_schema')
         end
 
-        def initialize(ambiguity_resolver = {}, renames: nil)
-          @ambiguity_resolver = ambiguity_resolver
+        def initialize(renames: nil, &block)
+          @ambiguity_resolver = block
           @drops = []
           @renames = renames
         end

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -483,7 +483,7 @@ module Generators
             parent_columns = connection.columns(parent_table) rescue []
             pk_limit =
               if (pk_column = parent_columns.find { |column| column.name.to_s == "id" }) # right now foreign keys assume id is the target
-                if Rails::VERSION::MAJOR < 5
+                if ActiveSupport::VERSION::MAJOR < 5
                   pk_column.cast_type.limit
                 else
                   pk_column.limit
@@ -549,7 +549,7 @@ module Generators
           end
         end
 
-        SchemaDumper = case Rails::VERSION::MAJOR
+        SchemaDumper = case ActiveSupport::VERSION::MAJOR
                        when 4
                          ActiveRecord::SchemaDumper
                        else

--- a/lib/generators/declare_schema/migration/templates/migration.rb.erb
+++ b/lib/generators/declare_schema/migration/templates/migration.rb.erb
@@ -1,4 +1,4 @@
-class <%= @migration_class_name %> < (Rails::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration)
+class <%= @migration_class_name %> < (ActiveSupport::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration)
   def self.up
     <%= @up %>
   end

--- a/spec/lib/declare_schema/api_spec.rb
+++ b/spec/lib/declare_schema/api_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'DeclareSchema API' do
 
       load_models
 
-      if Rails::VERSION::MAJOR == 5
+      if ActiveSupport::VERSION::MAJOR == 5
         # TODO: get this to work on Travis for Rails 6
         generate_migrations '-n', '-m'
       end

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
   before do
     load File.expand_path('prepare_testapp.rb', __dir__)
 
-    if Rails::VERSION::MAJOR < 5
+    if ActiveSupport::VERSION::MAJOR < 5
       allow(col_spec).to receive(:type_cast_from_database, &:itself)
     end
   end
@@ -184,7 +184,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
 
   describe '#schema_attributes' do
     let(:col_spec) do
-      case Rails::VERSION::MAJOR
+      case ActiveSupport::VERSION::MAJOR
       when 4
         cast_type = ActiveRecord::Type::Integer.new(limit: 8)
         ActiveRecord::ConnectionAdapters::Column.new("price", nil, cast_type, "integer(8)", false)

--- a/spec/lib/declare_schema/generator_spec.rb
+++ b/spec/lib/declare_schema/generator_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       end
     EOS
 
-    case Rails::VERSION::MAJOR
+    case ActiveSupport::VERSION::MAJOR
     when 4, 5
       expect_test_definition_to_eq('alpha/beta', <<~EOS)
         require "test_helper"
@@ -50,7 +50,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       EOS
     end
 
-    case Rails::VERSION::MAJOR
+    case ActiveSupport::VERSION::MAJOR
     when 4
       expect_test_fixture_to_eq('alpha/beta', <<~EOS)
         # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html

--- a/spec/lib/declare_schema/interactive_primary_key_spec.rb
+++ b/spec/lib/declare_schema/interactive_primary_key_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails'
 begin
   require 'mysql2'
 rescue LoadError
@@ -63,7 +62,7 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
         ActiveRecord::Base.connection.execute("CREATE TABLE foos (id integer PRIMARY KEY AUTOINCREMENT NOT NULL)")
       end
 
-      if Rails::VERSION::MAJOR >= 5 && !defined?(Mysql2) # TODO TECH-4814 Put this test back for Mysql2
+      if ActiveSupport::VERSION::MAJOR >= 5 && !defined?(Mysql2) # TODO TECH-4814 Put this test back for Mysql2
         # replace custom primary_key
         class Foo < ActiveRecord::Base
           fields do
@@ -131,7 +130,7 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
         ActiveRecord::Base.connection.execute("CREATE TABLE foos (id integer PRIMARY KEY AUTOINCREMENT NOT NULL)")
       end
 
-      if Rails::VERSION::MAJOR >= 5 && !defined?(Mysql2) # TODO TECH-4814 Put this test back for Mysql2
+      if ActiveSupport::VERSION::MAJOR >= 5 && !defined?(Mysql2) # TODO TECH-4814 Put this test back for Mysql2
         # replace custom primary_key
         class Foo < ActiveRecord::Base
           declare_schema do

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails'
 begin
   require 'mysql2'
 rescue LoadError
@@ -26,20 +25,20 @@ RSpec.describe 'DeclareSchema Migration Generator' do
     end
   end
   let(:datetime_precision) do
-    if defined?(Mysql2) && Rails::VERSION::MAJOR >= 5
+    if defined?(Mysql2) && ActiveSupport::VERSION::MAJOR >= 5
       ', precision: 0'
     end
   end
   let(:table_options) do
     if defined?(Mysql2)
-      ", options: \"#{'ENGINE=InnoDB ' if Rails::VERSION::MAJOR == 5}DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin\"" +
-        if Rails::VERSION::MAJOR >= 6
+      ", options: \"#{'ENGINE=InnoDB ' if ActiveSupport::VERSION::MAJOR == 5}DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin\"" +
+        if ActiveSupport::VERSION::MAJOR >= 6
           ', charset: "utf8mb4", collation: "utf8mb4_bin"'
         else
           ''
         end
     else
-      ", id: :integer" unless Rails::VERSION::MAJOR < 5
+      ", id: :integer" unless ActiveSupport::VERSION::MAJOR < 5
     end
   end
   let(:lock_version_limit) do
@@ -87,7 +86,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       ActiveRecord::Migration.class_eval(up)
       expect(Advert.columns.map(&:name)).to eq(["id", "name"])
 
-      if Rails::VERSION::MAJOR < 5
+      if ActiveSupport::VERSION::MAJOR < 5
         # Rails 4 drivers don't always create PK properly. Fix that by dropping and recreating.
         ActiveRecord::Base.connection.execute("drop table adverts")
         if defined?(Mysql2)
@@ -1020,8 +1019,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       end
     end
 
-    context "for Rails #{Rails::VERSION::MAJOR}" do
-      if Rails::VERSION::MAJOR >= 5
+    context "for Rails #{ActiveSupport::VERSION::MAJOR}" do
+      if ActiveSupport::VERSION::MAJOR >= 5
         let(:optional_true) { { optional: true } }
         let(:optional_false) { { optional: false } }
       else
@@ -1127,13 +1126,13 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         migration_content = File.read(migrations.first)
         first_line = migration_content.split("\n").first
         base_class = first_line.split(' < ').last
-        expect(base_class).to eq("(Rails::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration)")
+        expect(base_class).to eq("(ActiveSupport::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration)")
       end
     end
 
     context 'Does not generate migrations' do
       it 'for aliased fields bigint -> integer limit 8' do
-        if Rails::VERSION::MAJOR >= 5 || !ActiveRecord::Base.connection.class.name.match?(/SQLite3Adapter/)
+        if ActiveSupport::VERSION::MAJOR >= 5 || !ActiveRecord::Base.connection.class.name.match?(/SQLite3Adapter/)
           class Advert < active_record_base_class.constantize
             fields do
               price :bigint
@@ -1145,7 +1144,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
           migrations = Dir.glob('db/migrate/*declare_schema_migration*.rb')
           expect(migrations.size).to eq(1), migrations.inspect
 
-          if defined?(Mysql2) && Rails::VERSION::MAJOR < 5
+          if defined?(Mysql2) && ActiveSupport::VERSION::MAJOR < 5
             ActiveRecord::Base.connection.execute("ALTER TABLE adverts ADD PRIMARY KEY (id)")
           end
 
@@ -1198,7 +1197,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       ActiveRecord::Migration.class_eval(up)
       expect(Advert.columns.map(&:name)).to eq(["id", "name"])
 
-      if Rails::VERSION::MAJOR < 5
+      if ActiveSupport::VERSION::MAJOR < 5
         # Rails 4 drivers don't always create PK properly. Fix that by dropping and recreating.
         ActiveRecord::Base.connection.execute("drop table adverts")
         if defined?(Mysql2)
@@ -2130,8 +2129,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       end
     end
 
-    context "for Rails #{Rails::VERSION::MAJOR}" do
-      if Rails::VERSION::MAJOR >= 5
+    context "for Rails #{ActiveSupport::VERSION::MAJOR}" do
+      if ActiveSupport::VERSION::MAJOR >= 5
         let(:optional_true) { { optional: true } }
         let(:optional_false) { { optional: false } }
       else
@@ -2237,13 +2236,13 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         migration_content = File.read(migrations.first)
         first_line = migration_content.split("\n").first
         base_class = first_line.split(' < ').last
-        expect(base_class).to eq("(Rails::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration)")
+        expect(base_class).to eq("(ActiveSupport::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration)")
       end
     end
 
     context 'Does not generate migrations' do
       it 'for aliased fields bigint -> integer limit 8' do
-        if Rails::VERSION::MAJOR >= 5 || !ActiveRecord::Base.connection.class.name.match?(/SQLite3Adapter/)
+        if ActiveSupport::VERSION::MAJOR >= 5 || !ActiveRecord::Base.connection.class.name.match?(/SQLite3Adapter/)
           class Advert < active_record_base_class.constantize
             declare_schema do
               bigint :price
@@ -2255,7 +2254,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
           migrations = Dir.glob('db/migrate/*declare_schema_migration*.rb')
           expect(migrations.size).to eq(1), migrations.inspect
 
-          if defined?(Mysql2) && Rails::VERSION::MAJOR < 5
+          if defined?(Mysql2) && ActiveSupport::VERSION::MAJOR < 5
             ActiveRecord::Base.connection.execute("ALTER TABLE adverts ADD PRIMARY KEY (id)")
           end
 

--- a/spec/lib/declare_schema/model/column_spec.rb
+++ b/spec/lib/declare_schema/model/column_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails'
-
 begin
   require 'mysql2'
 rescue LoadError
@@ -16,7 +14,7 @@ RSpec.describe DeclareSchema::Model::Column do
 
   describe 'class methods' do
     describe '.native_type?' do
-      if Rails::VERSION::MAJOR >= 5
+      if ActiveSupport::VERSION::MAJOR >= 5
         let(:native_types) { [:string, :text, :integer, :float, :decimal, :datetime, :time, :date, :binary, :boolean, :json] }
       else
         let(:native_types) { [:string, :text, :integer, :float, :decimal, :datetime, :time, :date, :binary, :boolean] }
@@ -65,9 +63,7 @@ RSpec.describe DeclareSchema::Model::Column do
     end
 
     describe '.deserialize_default_value' do
-      require 'rails'
-
-      if ::Rails::VERSION::MAJOR >= 5
+      if ::ActiveSupport::VERSION::MAJOR >= 5
         it 'deserializes :boolean' do
           expect(described_class.deserialize_default_value(nil, :boolean, 'true')).to eq(true)
           expect(described_class.deserialize_default_value(nil, :boolean, 'false')).to eq(false)

--- a/spec/lib/declare_schema/model/habtm_model_shim_spec.rb
+++ b/spec/lib/declare_schema/model/habtm_model_shim_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails'
-
 begin
   require 'mysql2'
 rescue LoadError

--- a/spec/lib/declare_schema/model/index_definition_spec.rb
+++ b/spec/lib/declare_schema/model/index_definition_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
             let(:model_class) { IndexDefinitionCompoundIndexModel }
 
             it 'returns the indexes for the model' do
-              if Rails::VERSION::MAJOR < 5
+              if ActiveSupport::VERSION::MAJOR < 5
                 expect(model_class.connection).to receive(:primary_key).with('index_definition_compound_index_models').and_return(nil)
                 connection_stub = instance_double(ActiveRecord::Base.connection.class, "connection")
                 expect(connection_stub).to receive(:indexes).
@@ -219,7 +219,7 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
             let(:model_class) { IndexDefinitionCompoundIndexModel }
 
             it 'returns the indexes for the model' do
-              if Rails::VERSION::MAJOR < 5
+              if ActiveSupport::VERSION::MAJOR < 5
                 expect(model_class.connection).to receive(:primary_key).with('index_definition_compound_index_models').and_return(nil)
                 connection_stub = instance_double(ActiveRecord::Base.connection.class, "connection")
                 expect(connection_stub).to receive(:indexes).

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,7 @@ RSpec.configure do |config|
   RSpec::Support::ObjectFormatter.default_instance.max_formatted_output_length = 2_000
 
   def active_record_base_class
-    if Rails::VERSION::MAJOR == 4
+    if ActiveSupport::VERSION::MAJOR == 4
       'ActiveRecord::Base'
     else
       'ApplicationRecord'


### PR DESCRIPTION
## [0.11.0] - Unreleased
### Removed
- Removed `g|m|c` prompt entirely, since it was confusing. Instead, the migration is always generated; the user may press ^C at the filename prompt to cancel. The migration will be run if `--migrate` is passed; otherwise, the migrate command will be displayed to be run later.
### Added
- Added the new configuration option `DeclareSchema.@db_migrate_command =`.