### PR TITLE
no-jira: fix empty up/down bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2021-03-26
+### Fixed
+- Fixed a bug where up and down in generated migration would be empty in Rails 4.
+
 ## [0.11.0] - 2021-03-22
 ### Removed
 - Removed `g|m|c` prompt entirely, since it was confusing. Instead, the migration is
@@ -164,6 +168,7 @@ using the appropriate Rails configuration attributes.
 ### Added
 - Initial version from https://github.com/Invoca/hobo_fields v4.1.0.
 
+[0.11.1]: https://github.com/Invoca/declare_schema/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/Invoca/declare_schema/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/Invoca/declare_schema/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/Invoca/declare_schema/compare/v0.9.0...v0.10.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (0.11.0)
+    declare_schema (0.11.1)
       rails (>= 4.2)
 
 GEM

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "0.11.0"
+  VERSION = "0.11.1"
 end

--- a/lib/generators/declare_schema/migration/migration_generator.rb
+++ b/lib/generators/declare_schema/migration/migration_generator.rb
@@ -73,8 +73,8 @@ module DeclareSchema
         end ||
         default_migration_name
 
-      @up = indent(up, 4)
-      @down = indent(down, 4)
+      @up = indent(up.strip, 4)
+      @down = indent(down.strip, 4)
       @migration_class_name = final_migration_name.camelize
 
       migration_template('migration.rb.erb', "db/migrate/#{final_migration_name.underscore}.rb")
@@ -100,7 +100,7 @@ module DeclareSchema
     if ActiveSupport::VERSION::MAJOR < 5
       def indent(string, columns)
         whitespace = ' ' * columns
-        string.gsub("\n", "\n#{whitespace}").gsub!(/ +\n/, "\n")
+        string.gsub("\n", "\n#{whitespace}").gsub(/ +\n/, "\n")
       end
     end
 

--- a/lib/generators/declare_schema/migration/templates/migration.rb.erb
+++ b/lib/generators/declare_schema/migration/templates/migration.rb.erb
@@ -1,9 +1,9 @@
 class <%= @migration_class_name %> < (ActiveSupport::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration)
   def self.up
-    <%= @up %>
+    <%= @up.presence or raise "no @up given!" %>
   end
 
   def self.down
-    <%= @down %>
+    <%= @down.presence or raise "no @down given!" %>
   end
 end


### PR DESCRIPTION
## [0.11.1] - 2021-03-26
### Fixed
- Fixed a bug where up and down in generated migration would be empty in Rails 4.