### PR TITLE
TECH-5417: infer foreign key limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - Unreleased
+### Added
+- `belongs_to` now always infers the `limit:` of the foreign key to match that of the primary key it points to.
+ Note: this isn't possible for polymorphic foreign keys, so it assumes `limit: 8` there...unless the schema
+ was migrated in the past with `limit: 4`.
+
 ## [0.11.1] - 2021-03-26
 ### Fixed
 - Fixed a bug where up and down in generated migration would be empty in Rails 4.
@@ -168,6 +174,7 @@ using the appropriate Rails configuration attributes.
 ### Added
 - Initial version from https://github.com/Invoca/hobo_fields v4.1.0.
 
+[0.12.0]: https://github.com/Invoca/declare_schema/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/Invoca/declare_schema/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/Invoca/declare_schema/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/Invoca/declare_schema/compare/v0.10.0...v0.10.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (0.11.1)
+    declare_schema (0.12.0.pre.1)
       rails (>= 4.2)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (0.12.0.pre.1)
+    declare_schema (0.12.0.pre.2)
       rails (>= 4.2)
 
 GEM

--- a/lib/declare_schema/extensions/active_record/fields_declaration.rb
+++ b/lib/declare_schema/extensions/active_record/fields_declaration.rb
@@ -7,12 +7,14 @@ require 'declare_schema/field_declaration_dsl'
 
 module DeclareSchema
   module Macros
+    attr_reader :_table_options
+
     def fields(table_options = {}, &block)
       # Any model that calls 'fields' gets DeclareSchema::Model behavior
       DeclareSchema::Model.mix_in(self)
 
       @include_in_migration = true
-      @table_options        = table_options
+      @_table_options        = table_options
 
       if block
         dsl = DeclareSchema::FieldDeclarationDsl.new(self)
@@ -31,7 +33,7 @@ module DeclareSchema
 
       # @include_in_migration = false #||= options.fetch(:include_in_migration, true); options.delete(:include_in_migration)
       @include_in_migration = true # TODO: Add back or delete the include_in_migration feature
-      @table_options        = table_options
+      @_table_options        = table_options
 
       if block
         dsl = DeclareSchema::Dsl.new(self, null: false)

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -183,7 +183,7 @@ module DeclareSchema
               4
             end
           else
-            if klass.table_exists? && (pk_column = klass.columns_hash[klass._defined_primary_key])
+            if klass.table_exists? && (pk_column = klass.columns_hash[klass._declared_primary_key])
               pk_id_type = pk_column.type
               if pk_id_type == :integer
                 pk_column.limit
@@ -201,27 +201,27 @@ module DeclareSchema
 
       # returns the primary key (String) as declared with primary_key =
       # unlike the `primary_key` method, DOES NOT query the database to find the actual primary key in use right now
-      # if no explicit primary key set, returns the default_defined_primary_key
-      def _defined_primary_key
+      # if no explicit primary key set, returns the _default_declared_primary_key
+      def _declared_primary_key
         if defined?(@primary_key)
           @primary_key&.to_s
-        end || _default_defined_primary_key
+        end || _default_declared_primary_key
       end
 
       private
 
-      # if this is a derived class, returns the base class's _defined_primary_key
+      # if this is a derived class, returns the base class's _declared_primary_key
       # otherwise, returns 'id'
-      def _default_defined_primary_key
+      def _default_declared_primary_key
         if self == base_class
           'id'
         else
-          base_class._defined_primary_key
+          base_class._declared_primary_key
         end
       end
 
       def _rails_default_primary_key
-        ::DeclareSchema::Model::IndexDefinition.new(self, [_defined_primary_key.to_sym], unique: true, name: DeclareSchema::Model::IndexDefinition::PRIMARY_KEY_NAME)
+        ::DeclareSchema::Model::IndexDefinition.new(self, [_declared_primary_key.to_sym], unique: true, name: DeclareSchema::Model::IndexDefinition::PRIMARY_KEY_NAME)
       end
 
       # Declares the "foo_type" field that accompanies the "foo_id"

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -99,7 +99,10 @@ module DeclareSchema
         end
       end
 
-      # Extend belongs_to so that it creates a FieldSpec for the foreign key
+      # Extend belongs_to so that it
+      # 1. creates a FieldSpec for the foreign key
+      # 2. declares an index on the foreign key
+      # 3. declares a foreign_key constraint
       def belongs_to(name, scope = nil, **options)
         column_options = {}
 

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -112,7 +112,10 @@ module DeclareSchema
                                   options[:optional] # infer :null from :optional
                                 end || false
         column_options[:default] = options.delete(:default) if options.has_key?(:default)
-        column_options[:limit] = options.delete(:limit) if options.has_key?(:limit)
+        if options.has_key?(:limit)
+          options.delete(:limit)
+          ActiveSupport::Deprecation.warn("belongs_to limit: is deprecated since it is now inferred")
+        end
 
         index_options = {}
         index_options[:name]   = options.delete(:index) if options.has_key?(:index)

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -142,7 +142,9 @@ module DeclareSchema
 
         refl = reflections[name.to_s] or raise "Couldn't find reflection #{name} in #{reflections.keys}"
         fkey = refl.foreign_key or raise "Couldn't find foreign_key for #{name} in #{refl.inspect}"
-        declare_field(fkey.to_sym, :integer, column_options)
+        klass = refl.klass or raise "Couldn't find belongs_to klass for #{name} in #{refl.inspect}"
+        pk_id_type = klass._table_options&.[](:id)
+        declare_field(fkey.to_sym,  pk_id_type || :bigint, column_options)
         if refl.options[:polymorphic]
           foreign_type = options[:foreign_type] || "#{name}_type"
           _declare_polymorphic_type_field(foreign_type, column_options)

--- a/lib/declare_schema/model/column.rb
+++ b/lib/declare_schema/model/column.rb
@@ -59,7 +59,7 @@ module DeclareSchema
             # might be getting migrated to a new type. We should be using just type as below. -Colin
             column.type_cast_from_database(default_value)
           else
-            cast_type = ActiveRecord::Base.connection.send(:lookup_cast_type, type) or
+            cast_type = ActiveRecord::Base.connection.send(:lookup_cast_type, type.to_s) or
               raise "cast_type not found for #{type}"
             cast_type.deserialize(default_value)
           end

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -99,8 +99,8 @@ module DeclareSchema
 
         if @type.in?([:text, :string])
           if ActiveRecord::Base.connection.class.name.match?(/mysql/i)
-            @options[:charset]   ||= model._table_options[:charset]   || ::DeclareSchema.default_charset
-            @options[:collation] ||= model._table_options[:collation] || ::DeclareSchema.default_collation
+            @options[:charset]   ||= model._table_options&.[](:charset)   || ::DeclareSchema.default_charset
+            @options[:collation] ||= model._table_options&.[](:collation) || ::DeclareSchema.default_collation
           else
             @options.delete(:charset)
             @options.delete(:collation)

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -47,9 +47,9 @@ module DeclareSchema
       end
 
       def initialize(model, name, type, position: 0, **options)
-        _defined_primary_key = model._defined_primary_key
+        _declared_primary_key = model._declared_primary_key
 
-        name.to_s == _defined_primary_key and raise ArgumentError, "you may not provide a field spec for the primary key #{name.inspect}"
+        name.to_s == _declared_primary_key and raise ArgumentError, "you may not provide a field spec for the primary key #{name.inspect}"
 
         @model = model
         @name = name.to_sym

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -99,8 +99,8 @@ module DeclareSchema
 
         if @type.in?([:text, :string])
           if ActiveRecord::Base.connection.class.name.match?(/mysql/i)
-            @options[:charset]   ||= model.table_options[:charset]   || ::DeclareSchema.default_charset
-            @options[:collation] ||= model.table_options[:collation] || ::DeclareSchema.default_collation
+            @options[:charset]   ||= model._table_options[:charset]   || ::DeclareSchema.default_charset
+            @options[:collation] ||= model._table_options[:collation] || ::DeclareSchema.default_collation
           else
             @options.delete(:charset)
             @options.delete(:collation)

--- a/lib/declare_schema/model/habtm_model_shim.rb
+++ b/lib/declare_schema/model/habtm_model_shim.rb
@@ -47,7 +47,7 @@ module DeclareSchema
         false # no single-column primary key in database
       end
 
-      def _defined_primary_key
+      def _declared_primary_key
         false # no single-column primary key declared
       end
 

--- a/lib/declare_schema/model/habtm_model_shim.rb
+++ b/lib/declare_schema/model/habtm_model_shim.rb
@@ -29,7 +29,7 @@ module DeclareSchema
         @connection = connection
       end
 
-      def table_options
+      def _table_options
         {}
       end
 

--- a/lib/declare_schema/schema_change/column_add.rb
+++ b/lib/declare_schema/schema_change/column_add.rb
@@ -6,9 +6,9 @@ module DeclareSchema
   module SchemaChange
     class ColumnAdd < Base
       def initialize(table_name, column_name, column_type, **column_options)
-        @table_name = table_name
-        @column_name = column_name
-        @column_type = column_type
+        @table_name = table_name or raise ArgumentError, "must provide table_name"
+        @column_name = column_name or raise ArgumentError, "must provide column_name"
+        @column_type = column_type or raise ArgumentError, "must provide column_type"
         @column_options = column_options
       end
 

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "0.12.0.pre.1"
+  VERSION = "0.12.0.pre.2"
 end

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "0.11.1"
+  VERSION = "0.12.0.pre.1"
 end

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -318,8 +318,8 @@ module Generators
             {}
           else
             {
-              charset:   model.table_options[:charset] || ::DeclareSchema.default_charset,
-              collation: model.table_options[:collation] || ::DeclareSchema.default_collation
+              charset:   model._table_options&.[](:charset) || ::DeclareSchema.default_charset,
+              collation: model._table_options&.[](:collation) || ::DeclareSchema.default_collation
             }
           end
         end

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -187,6 +187,12 @@ module Generators
           models, db_tables = models_and_tables
           models_by_table_name = {}
           models.each do |m|
+            m.try(:field_specs)&.each do |_name, field_spec|
+              if (pre_migration = field_spec.options.delete(:pre_migration))
+                pre_migration.call(field_spec)
+              end
+            end
+
             if !models_by_table_name.has_key?(m.table_name)
               models_by_table_name[m.table_name] = m
             elsif m.superclass == models_by_table_name[m.table_name].superclass.superclass

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -348,18 +348,17 @@ module Generators
           new_table_name = model.table_name
 
           db_columns = model.connection.columns(current_table_name).index_by(&:name)
-          key_missing = db_columns[model._defined_primary_key].nil? && model._defined_primary_key.present?
-          if model._defined_primary_key.present?
-            db_columns.delete(model._defined_primary_key)
+          if (pk = model._defined_primary_key.presence)
+            key_was_in_db_columns = db_columns.delete(pk)
           end
 
           model_column_names = model.field_specs.keys.map(&:to_s)
           db_column_names = db_columns.keys.map(&:to_s)
 
           to_add = model_column_names - db_column_names
-          to_add += [model._defined_primary_key] if key_missing && model._defined_primary_key.present?
+          to_add += [pk] unless key_was_in_db_columns
           to_remove = db_column_names - model_column_names
-          to_remove -= [model._defined_primary_key.to_sym] if model._defined_primary_key.present?
+          to_remove -= [pk.to_sym] if pk    # TODO: The .to_sym here means this code is always a no-op, right? -Colin
 
           to_rename = extract_column_renames!(to_add, to_remove, new_table_name)
 

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -309,7 +309,7 @@ module Generators
         end
 
         def create_table_options(model, disable_auto_increment)
-          primary_key = model._defined_primary_key
+          primary_key = model._declared_primary_key
           if primary_key.blank? || disable_auto_increment
             { id: false }
           elsif primary_key == "id"
@@ -348,7 +348,7 @@ module Generators
           new_table_name = model.table_name
 
           db_columns = model.connection.columns(current_table_name).index_by(&:name)
-          if (pk = model._defined_primary_key.presence)
+          if (pk = model._declared_primary_key.presence)
             key_was_in_db_columns = db_columns.delete(pk)
           end
 

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -209,8 +209,8 @@ module Generators
 
           to_create = model_table_names - db_tables
           to_drop = db_tables - model_table_names - self.class.always_ignore_tables
-          to_change = model_table_names
           to_rename = extract_table_renames!(to_create, to_drop)
+          to_change = model_table_names
 
           renames = to_rename.map do |old_name, new_name|
             ::DeclareSchema::SchemaChange::TableRename.new(old_name, new_name)
@@ -228,12 +228,6 @@ module Generators
               if disable_auto_increment
                 [:integer, :id, limit: 8, auto_increment: false, primary_key: true]
               end
-
-            model.field_specs.each do |name, field_spec|
-              if (pre_migration = field_spec.options.delete(:pre_migration))
-                pre_migration.call(field_spec)
-              end
-            end
 
             field_definitions = model.field_specs.values.sort_by(&:position).map do |f|
               [f.type, f.name, f.sql_options]

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -223,6 +223,12 @@ module Generators
                 [:integer, :id, limit: 8, auto_increment: false, primary_key: true]
               end
 
+            model.field_specs.each do |name, field_spec|
+              if (pre_migration = field_spec.options.delete(:pre_migration))
+                pre_migration.call(field_spec)
+              end
+            end
+
             field_definitions = model.field_specs.values.sort_by(&:position).map do |f|
               [f.type, f.name, f.sql_options]
             end

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -350,7 +350,7 @@ module Generators
           db_column_names = db_columns.keys.map(&:to_s)
 
           to_add = model_column_names - db_column_names
-          to_add += [pk] unless key_was_in_db_columns
+          to_add << pk if pk && !key_was_in_db_columns
           to_remove = db_column_names - model_column_names
           to_remove -= [pk.to_sym] if pk    # TODO: The .to_sym here means this code is always a no-op, right? -Colin
 

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -343,16 +343,15 @@ module Generators
 
           db_columns = model.connection.columns(current_table_name).index_by(&:name)
           if (pk = model._declared_primary_key.presence)
-            key_was_in_db_columns = db_columns.delete(pk)
+            pk_was_in_db_columns = db_columns.delete(pk)
           end
 
           model_column_names = model.field_specs.keys.map(&:to_s)
           db_column_names = db_columns.keys.map(&:to_s)
 
           to_add = model_column_names - db_column_names
-          to_add << pk if pk && !key_was_in_db_columns
+          to_add << pk if pk && !pk_was_in_db_columns
           to_remove = db_column_names - model_column_names
-          to_remove -= [pk.to_sym] if pk    # TODO: The .to_sym here means this code is always a no-op, right? -Colin
 
           to_rename = extract_column_renames!(to_add, to_remove, new_table_name)
 

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -304,7 +304,7 @@ module Generators
             { id: :bigint }
           else
             { primary_key: primary_key.to_sym }
-          end
+          end.merge(model._table_options)
         end
 
         def table_options_for_model(model)

--- a/spec/lib/declare_schema/api_spec.rb
+++ b/spec/lib/declare_schema/api_spec.rb
@@ -41,10 +41,12 @@ RSpec.describe 'DeclareSchema API' do
 
       if ActiveSupport::VERSION::MAJOR == 5
         # TODO: get this to work on Travis for Rails 6
+        # TODO: uncomment since we're not on Travis any more? -Colin
         generate_migrations '-n', '-m'
       end
 
       require 'advert'
+      Advert.reset_primary_key
 
       ## The Basics
 

--- a/spec/lib/declare_schema/api_spec.rb
+++ b/spec/lib/declare_schema/api_spec.rb
@@ -40,8 +40,6 @@ RSpec.describe 'DeclareSchema API' do
       load_models
 
       if ActiveSupport::VERSION::MAJOR == 5
-        # TODO: get this to work on Travis for Rails 6
-        # TODO: uncomment since we're not on Travis any more? -Colin
         generate_migrations '-n', '-m'
       end
 
@@ -49,8 +47,6 @@ RSpec.describe 'DeclareSchema API' do
       Advert.reset_primary_key
 
       ## The Basics
-
-      # The main feature of DeclareSchema, aside from the migration generator, is the ability to declare rich types for your fields. For example, you can declare that a field is an email address, and the field will be automatically validated for correct email address syntax.
 
       ### Field Types
 

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -6,7 +6,7 @@ rescue LoadError
 end
 
 RSpec.describe DeclareSchema::Model::FieldSpec do
-  let(:model) { double('model', table_options: {}, _defined_primary_key: 'id') }
+  let(:model) { double('model', _table_options: {}, _defined_primary_key: 'id') }
   let(:col_spec) { double('col_spec', type: :string) }
 
   before do

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -6,7 +6,7 @@ rescue LoadError
 end
 
 RSpec.describe DeclareSchema::Model::FieldSpec do
-  let(:model) { double('model', _table_options: {}, _defined_primary_key: 'id') }
+  let(:model) { double('model', _table_options: {}, _declared_primary_key: 'id') }
   let(:col_spec) { double('col_spec', type: :string) }
 
   before do

--- a/spec/lib/declare_schema/interactive_primary_key_spec.rb
+++ b/spec/lib/declare_schema/interactive_primary_key_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
       end
 
       generate_migrations '-n', '-m'
-      expect(Foo._defined_primary_key).to eq('foo_id')
+      expect(Foo._declared_primary_key).to eq('foo_id')
 
       ### migrate from
       # rename from custom primary_key
@@ -31,7 +31,7 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
 
       allow_any_instance_of(DeclareSchema::Support::ThorShell).to receive(:ask).with(/one of the rename choices or press enter to keep/) { 'id' }
       generate_migrations '-n', '-m'
-      expect(Foo._defined_primary_key).to eq('id')
+      expect(Foo._declared_primary_key).to eq('id')
 
       nuke_model_class(Foo)
 
@@ -72,7 +72,7 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
 
         allow_any_instance_of(DeclareSchema::Support::ThorShell).to receive(:ask).with(/one of the rename choices or press enter to keep/) { 'drop id' }
         generate_migrations '-n', '-m'
-        expect(Foo._defined_primary_key).to eq('foo_id')
+        expect(Foo._declared_primary_key).to eq('foo_id')
       end
     end
   end
@@ -97,7 +97,7 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
       puts "\n\e[45m Please enter 'id' (no quotes) at the next prompt \e[0m"
       allow_any_instance_of(DeclareSchema::Support::ThorShell).to receive(:ask).with(/one of the rename choices or press enter to keep/) { 'id' }
       generate_migrations '-n', '-m'
-      expect(Foo._defined_primary_key).to eq('id')
+      expect(Foo._declared_primary_key).to eq('id')
 
       nuke_model_class(Foo)
 

--- a/spec/lib/declare_schema/interactive_primary_key_spec.rb
+++ b/spec/lib/declare_schema/interactive_primary_key_spec.rb
@@ -80,8 +80,7 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
   context 'Using declare_schema' do
     it "allows alternate primary keys" do
       class Foo < ActiveRecord::Base
-        declare_schema do
-        end
+        declare_schema { }
         self.primary_key = "foo_id"
       end
 
@@ -91,15 +90,14 @@ RSpec.describe 'DeclareSchema Migration Generator interactive primary key' do
       ### migrate from
       # rename from custom primary_key
       class Foo < ActiveRecord::Base
-        declare_schema do
-        end
+        declare_schema { }
         self.primary_key = "id"
       end
 
       puts "\n\e[45m Please enter 'id' (no quotes) at the next prompt \e[0m"
       allow_any_instance_of(DeclareSchema::Support::ThorShell).to receive(:ask).with(/one of the rename choices or press enter to keep/) { 'id' }
       generate_migrations '-n', '-m'
-      expect(Foo.primary_key).to eq('id')
+      expect(Foo._defined_primary_key).to eq('id')
 
       nuke_model_class(Foo)
 

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -2319,6 +2319,20 @@ RSpec.describe 'DeclareSchema Migration Generator' do
             end
           end
         end
+
+        it 'deprecates limit:' do
+          expect(ActiveSupport::Deprecation).to receive(:warn).with("belongs_to limit: is deprecated since it is now inferred")
+          eval <<~EOS
+            class UsingLimit < ActiveRecord::Base
+              declare_schema { }
+              belongs_to :ad_category, limit: 4
+            end
+          EOS
+        end
+
+        context 'when parent object PKs have different limits' do
+          it 'infers the FK limit from the PK'
+        end
       end
     end
 

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -2346,9 +2346,9 @@ RSpec.describe 'DeclareSchema Migration Generator' do
             end
             class Fk < ActiveRecord::Base
               declare_schema { }
-              belongs_to :id_default
-              belongs_to :id4
-              belongs_to :id8
+              belongs_to :id_default, (ActiveSupport::VERSION::MAJOR < 5 ? { constraint: false } : {})
+              belongs_to :id4, (ActiveSupport::VERSION::MAJOR < 5 ? { constraint: false } : {})
+              belongs_to :id8, (ActiveSupport::VERSION::MAJOR < 5 ? { constraint: false } : {})
             end
           end
 

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -2370,11 +2370,20 @@ RSpec.describe 'DeclareSchema Migration Generator' do
             up = Generators::DeclareSchema::Migration::Migrator.run.first
 
             create_fks = up.split("\n").grep(/t\.integer /).map { |command| command.gsub(', null: false', '').gsub(/^ +/, '') }
-            expect(create_fks).to eq([
-                                       't.integer :id_default_id, limit: 8',
-                                       't.integer :id4_id, limit: 4',
-                                       't.integer :id8_id, limit: 8'
-                                     ])
+            if defined?(SQLite3)
+              create_fks.map! { |command| command.gsub(/limit: [a-z0-9]+/, 'limit: X') }
+              expect(create_fks).to eq([
+                                         't.integer :id_default_id, limit: X',
+                                         't.integer :id4_id, limit: X',
+                                         't.integer :id8_id, limit: X'
+                                       ])
+            else
+              expect(create_fks).to eq([
+                                         't.integer :id_default_id, limit: 8',
+                                         't.integer :id4_id, limit: 4',
+                                         't.integer :id8_id, limit: 8'
+                                       ])
+            end
           end
         end
       end

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -441,10 +441,10 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       Advert.field_specs.delete(:category_id)
       Advert.index_definitions.delete_if { |spec| spec.fields == ["category_id"] }
 
-      ### Timestamps and Optimimistic Locking
+      ### Timestamps and Optimistic Locking
 
       # `updated_at` and `created_at` can be declared with the shorthand `timestamps`.
-      # Similarly, `lock_version` can be declared with the "shorthand" `optimimistic_lock`.
+      # Similarly, `lock_version` can be declared with the "shorthand" `optimistic_lock`.
 
       class Advert < ActiveRecord::Base
         fields do

--- a/spec/lib/declare_schema/model/habtm_model_shim_spec.rb
+++ b/spec/lib/declare_schema/model/habtm_model_shim_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe DeclareSchema::Model::HabtmModelShim do
 
     describe '#table_options' do
       it 'returns empty hash' do
-        expect(subject.table_options).to eq({})
+        expect(subject._table_options).to eq({})
       end
     end
 

--- a/spec/lib/declare_schema/model/habtm_model_shim_spec.rb
+++ b/spec/lib/declare_schema/model/habtm_model_shim_spec.rb
@@ -86,13 +86,13 @@ RSpec.describe DeclareSchema::Model::HabtmModelShim do
 
     describe '#primary_key' do
       it 'returns false' do
-        expect(subject._defined_primary_key).to eq(false)
+        expect(subject._declared_primary_key).to eq(false)
       end
     end
 
-    describe '#_defined_primary_key' do
+    describe '#_declared_primary_key' do
       it 'returns false' do
-        expect(subject._defined_primary_key).to eq(false)
+        expect(subject._declared_primary_key).to eq(false)
       end
     end
 


### PR DESCRIPTION
Note: best to view with `Hide whitespace changes` since there are some indentation changed in tests.

https://ringrevenue.atlassian.net/browse/TECH-5417

Infers foreign key size from the corresponding primary key. In the case of polymorphic keys, this isn't possible, so it always uses `limit: 8` there, unless the schema has already been migrated with `limit: 4`.
```
        # Note: the foreign key limit: should match the primary key limit:. (If there is a foreign key constraint,
        # those limits _must_ match.) We'd like to call _infer_fk_limit and get the limit right from the PK.
        # But we can't here, because that will mess up the autoloader to follow every belongs_to association right
        # when it is declared. So instead we assume :bigint (integer limit: 8) below, while also registering this
        # pre_migration: callback to double-check that assumption Just In Time--right before we generate a migration.
        #
        # The one downside of this approach is that application code that asks the field_spec for the declared
        # foreign key limit: will always get 8 back even if this is a grandfathered foreign key that points to
        # a limit: 4 primary key. It seems unlikely that any application code would do this.
```