### PR TITLE
no-jira: enforce enum symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.1] - 2021-05-10
+### Fixed
+- When an `enum` type field is declared, there is now enforcement that its `limit:` must be an array of 1 or more Symbols,
+  and its `default:`--if given--must be a Symbol or `nil`.
+
 ## [0.12.0] - 2021-04-28
 ### Added
 - `belongs_to` now always infers the `limit:` of the foreign key to match that of the primary key it points to.
@@ -174,6 +179,7 @@ using the appropriate Rails configuration attributes.
 ### Added
 - Initial version from https://github.com/Invoca/hobo_fields v4.1.0.
 
+[0.12.1]: https://github.com/Invoca/declare_schema/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/Invoca/declare_schema/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/Invoca/declare_schema/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/Invoca/declare_schema/compare/v0.10.1...v0.11.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (0.12.0)
+    declare_schema (0.12.1)
       rails (>= 4.2)
 
 GEM

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -77,6 +77,8 @@ module DeclareSchema
           @type = :integer
           @options[:limit] = 8
         when :enum
+          @options[:default].nil? || @options[:default].is_a?(Symbol) or
+            raise ArgumentError, "enum default: must be nil or a Symbol; got #{@options[:default].inspect}"
           @options[:limit].is_a?(Array) && @options[:limit].size >= 1 && @options[:limit].all? { |value| value.is_a?(Symbol) } or
             raise ArgumentError, "enum limit: must be an array of 1 or more Symbols; got #{@options[:limit].inspect}"
         end

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "0.12.0"
+  VERSION = "0.12.1"
 end

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -115,6 +115,27 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
       end
     end
 
+    describe 'enum' do
+      before do
+        allow(::DeclareSchema::Model::Column).to receive(:native_types).and_wrap_original do |m, *_args|
+          result = m.call
+          if result.has_key?(:enum)
+            result
+          else
+            result.merge(enum: { name: "enum" })
+          end
+        end
+      end
+
+      it 'raises ArgumentError if any of the limit values are not Symbols' do
+        [['first', 'second', 'third'], [1, 2, 3], nil, []].each do |limit|
+          expect do
+            described_class.new(model, :status, :enum, limit: limit, null: false, position: 2)
+          end.to raise_exception(ArgumentError, /enum limit: must be an array of 1 or more Symbols; got #{Regexp.escape(limit.inspect)}/)
+        end
+      end
+    end
+
     if defined?(Mysql2)
       describe 'varbinary' do # TODO: :varbinary is an Invoca addition to Rails; make it a configurable option
         it 'is supported' do

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -127,11 +127,32 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
         end
       end
 
-      it 'raises ArgumentError if any of the limit values are not Symbols' do
-        [['first', 'second', 'third'], [1, 2, 3], nil, []].each do |limit|
-          expect do
-            described_class.new(model, :status, :enum, limit: limit, null: false, position: 2)
-          end.to raise_exception(ArgumentError, /enum limit: must be an array of 1 or more Symbols; got #{Regexp.escape(limit.inspect)}/)
+      describe 'default' do
+        it 'allows default of nil or a Symbol' do
+          [nil, :first].each do |default|
+            expect do
+              subject = described_class.new(model, :status, :enum, limit: [:first, :second, :third], default: default, null: false, position: 2)
+              expect(subject.default).to eq(default)
+            end.to_not raise_exception
+          end
+        end
+
+        it 'raises ArgumentError if default is not nil or a Symbol' do
+          ["first", 1].each do |default|
+            expect do
+              described_class.new(model, :status, :enum, limit: [:first, :second, :third], default: default, null: false, position: 2)
+            end.to raise_exception(ArgumentError, /enum default: must be nil or a Symbol; got #{Regexp.escape(default.inspect)}/)
+          end
+        end
+      end
+
+      describe 'limit' do
+        it 'raises ArgumentError if any of the limit values are not Symbols' do
+          [['first', 'second', 'third'], [1, 2, 3], nil, []].each do |limit|
+            expect do
+              described_class.new(model, :status, :enum, limit: limit, null: false, position: 2)
+            end.to raise_exception(ArgumentError, /enum limit: must be an array of 1 or more Symbols; got #{Regexp.escape(limit.inspect)}/)
+          end
         end
       end
     end


### PR DESCRIPTION
## [0.12.1] - 2021-05-10
### Fixed
- When an `enum` type field is declared, there is now enforcement that its `limit:` must be an array of 1 or more Symbols,
  and its `default:`--if given--must be a Symbol or `nil`.