### PR TITLE
TECH-6171: fix indentation and triple spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.1] - Unreleased
+### Fixed
+- Fixed migration file indentation bug in Rails 5 where the first line was indented an extra 4 characters.
+ And fixed the longstanding triple-spacing bug to use double spacing.
+
 ## [0.13.0] - 2020-06-11
 ### Added
 - Added support for `default_schema` block to apply a default schema to every model, unless disabled for that model with `default_schema: false`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (0.13.0)
+    declare_schema (0.13.1)
       rails (>= 4.2)
 
 GEM

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "0.13.0"
+  VERSION = "0.13.1"
 end

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -299,7 +299,7 @@ module Generators
           up   = migration_commands.map(&:up  ).select(&:present?)
           down = migration_commands.map(&:down).select(&:present?).reverse
 
-          [up * "\n\n", down * "\n\n"]
+          [up * "\n", down * "\n"]
         end
 
         def create_table_options(model, disable_auto_increment)

--- a/lib/generators/declare_schema/migration/templates/migration.rb.erb
+++ b/lib/generators/declare_schema/migration/templates/migration.rb.erb
@@ -1,9 +1,9 @@
 class <%= @migration_class_name %> < (ActiveSupport::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration)
   def self.up
-    <%= @up.presence or raise "no @up given!" %>
+<%= @up.presence or raise "no @up given!" %>
   end
 
   def self.down
-    <%= @down.presence or raise "no @down given!" %>
+<%= @down.presence or raise "no @down given!" %>
   end
 end


### PR DESCRIPTION
## [0.13.1] - Unreleased
### Fixed
- Fixed migration file indentation bug in Rails 5 where the first line was indented an extra 4 characters.
 And fixed the longstanding triple-spacing bug to use double spacing.

# Demo
## Before
```
class DeclareSchemaMigration1 < (ActiveSupport::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration)
  def self.up
        add_column :deploy_targets, :a, :string, limit: 10, null: false, charset: "utf8mb4", collation: "utf8mb4_general_ci"


    add_column :deploy_targets, :b, :string, limit: 15, null: false, charset: "utf8mb4", collation: "utf8mb4_general_ci"
  end

  def self.down
        remove_column :deploy_targets, :b


    remove_column :deploy_targets, :a
  end
end

```
## After
```
class DeclareSchemaMigration1 < (ActiveSupport::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration)
  def self.up
    add_column :deploy_targets, :a, :string, limit: 10, null: false, charset: "utf8mb4", collation: "utf8mb4_general_ci"

    add_column :deploy_targets, :b, :string, limit: 15, null: false, charset: "utf8mb4", collation: "utf8mb4_general_ci"
  end

  def self.down
    remove_column :deploy_targets, :b

    remove_column :deploy_targets, :a
  end
end
```