### PR TITLE
non-production: autoload column_remove in schem_change all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - Unreleased
+### Fixed
+- Fixed a bug where `SchemaChange::ColumnRemove` was not loaded and causing an exception to raise
+when a column was being removed during migration generation
+
 ## [1.0.1] - 2022-07-12
 ### Fixed
 - Remove lingering usage of `fallback_find_primary_key` method that was removed in `0.14.0`
@@ -219,6 +224,7 @@ using the appropriate Rails configuration attributes.
 ### Added
 - Initial version from https://github.com/Invoca/hobo_fields v4.1.0.
 
+[1.0.2]: https://github.com/Invoca/declare_schema/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/Invoca/declare_schema/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/Invoca/declare_schema/compare/v0.14.3...v1.0.0
 [0.14.3]: https://github.com/Invoca/declare_schema/compare/v0.14.2...v0.14.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (1.0.1)
+    declare_schema (1.0.2)
       rails (>= 5.0)
 
 GEM

--- a/lib/declare_schema/schema_change/all.rb
+++ b/lib/declare_schema/schema_change/all.rb
@@ -7,6 +7,7 @@ module DeclareSchema
     autoload :Base, 'declare_schema/schema_change/base'
     autoload :ColumnAdd, 'declare_schema/schema_change/column_add'
     autoload :ColumnChange, 'declare_schema/schema_change/column_change'
+    autoload :ColumnRemove, 'declare_schema/schema_change/column_remove'
     autoload :ColumnRename, 'declare_schema/schema_change/column_rename'
     autoload :ForeignKeyAdd, 'declare_schema/schema_change/foreign_key_add'
     autoload :ForeignKeyRemove, 'declare_schema/schema_change/foreign_key_remove'

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
## [1.0.2] - Unreleased
### Fixed
- Fixed a bug where `SchemaChange::ColumnRemove` was not loaded and causing an exception to raise
when a column was being removed during migration generation