### PR TITLE
TECH-8177: add ability to use rake for migration generation for non-rails applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - Unreleased
+### Added
+- Added a rake task definition that can be optionally included into a non-Rails project to generate
+  schema migrations.
+
 ## [1.1.0] - 2022-07-22
 ### Changed
 - Fixed a bug where `DeclareSchema::Model::HabtmModelShim` `indexes` and `integer limits` were not being generated properly. Use `limit 8` for ids and primary composite key for habtm model.
@@ -229,6 +234,7 @@ using the appropriate Rails configuration attributes.
 ### Added
 - Initial version from https://github.com/Invoca/hobo_fields v4.1.0.
 
+[1.2.0]: https://github.com/Invoca/declare_schema/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/Invoca/declare_schema/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/Invoca/declare_schema/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/Invoca/declare_schema/compare/v1.0.0...v1.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 - Added a rake task definition that can be optionally included into a non-Rails project to generate
   schema migrations.
 
+### Fixed
+- Fixed a bug where not aliasing column names was allowing mysql to return them using their uppercase
+  variants
+
 ## [1.1.0] - 2022-07-22
 ### Changed
 - Fixed a bug where `DeclareSchema::Model::HabtmModelShim` `indexes` and `integer limits` were not being generated properly. Use `limit 8` for ids and primary composite key for habtm model.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (1.1.0)
+    declare_schema (1.2.0.pre.1)
       rails (>= 5.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DeclareSchema
 
-Declare your Rails/active_record model schemas and have database migrations generated for you!
+Declare your Rails/ActiveRecord model schemas and have database migrations generated for you!
 
 ## Example
 
@@ -60,6 +60,20 @@ declare_schema id: :bigint do
 end
 ```
 
+## Usage without Rails
+
+When using `DeclareSchema` without Rails, you can use the `declare_schema/rake` task to generate the migration file.
+
+To do so, add the following require to your Rakefile:
+```ruby
+require 'declare_schema/rake'
+```
+
+Then, run the task:
+```sh
+rake declare_schema:generate
+```
+
 ## Migrator Configuration
 
 The following configuration options are available for the gem and can be used
@@ -117,7 +131,7 @@ declaration.
 
 For example, adding the following to your `config/initializers` directory will
 set the default `text limit` value to `0xffff`:
- 
+
 **declare_schema.rb**
 ```ruby
 # frozen_string_literal: true
@@ -133,7 +147,7 @@ declaration.
 
 For example, adding the following to your `config/initializers` directory will
 set the default `string limit` value to `255`:
- 
+
 **declare_schema.rb**
 ```ruby
 # frozen_string_literal: true
@@ -149,7 +163,7 @@ declaration.
 
 For example, adding the following to your `config/initializers` directory will
 set the default `null` value to `true`:
- 
+
 **declare_schema.rb**
 ```ruby
 # frozen_string_literal: true
@@ -163,7 +177,7 @@ This value defaults to `true` and can only be set at the global level.
 
 For example, adding the following to your `config/initializers` directory will set
 the default `generate foreign keys` value to `false`:
- 
+
 **declare_schema.rb**
 ```ruby
 # frozen_string_literal: true
@@ -177,7 +191,7 @@ This value defaults to `true` and can only be set at the global level.
 
 For example, adding the following to your `config/initializers` directory will
 set the default `generate indexing` value to `false`:
- 
+
 **declare_schema.rb**
 ```ruby
 # frozen_string_literal: true

--- a/lib/declare_schema/model/column.rb
+++ b/lib/declare_schema/model/column.rb
@@ -132,7 +132,7 @@ module DeclareSchema
         database_name = connection.current_database
 
         defaults = connection.select_one(<<~EOS)
-          SELECT C.character_set_name, C.collation_name
+          SELECT C.character_set_name as character_set_name, C.collation_name as collation_name
           FROM information_schema.`COLUMNS` C
           WHERE C.table_schema = '#{connection.quote_string(database_name)}' AND
                 C.table_name = '#{connection.quote_string(current_table_name)}' AND

--- a/lib/declare_schema/model/table_options_definition.rb
+++ b/lib/declare_schema/model/table_options_definition.rb
@@ -27,7 +27,7 @@ module DeclareSchema
         def mysql_table_options(connection, table_name)
           database = connection.current_database
           defaults = connection.select_one(<<~EOS) or raise "no defaults found for table #{table_name}"
-            SELECT CCSA.character_set_name, CCSA.collation_name
+            SELECT CCSA.character_set_name as character_set_name, CCSA.collation_name as collation_name
             FROM information_schema.TABLES as T
               JOIN information_schema.COLLATION_CHARACTER_SET_APPLICABILITY as CCSA
                 ON CCSA.collation_name = T.table_collation

--- a/lib/declare_schema/rake.rb
+++ b/lib/declare_schema/rake.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "declare_schema"
+require "declare_schema/schema_change/all"
+require "declare_schema/schema_change/column_remove"
+require "generators/declare_schema/migration/migrator"
+require "erb"
+
+namespace :declare_schema do
+  desc 'Generate migrations for the database schema'
+  task :generate => 'db:load_config' do
+    up, down = Generators::DeclareSchema::Migration::Migrator.new(renames: {}).generate
+
+    if up.blank?
+      puts "Database and models match -- nothing to change"
+      return
+    end
+
+    puts "\n---------- Up Migration ----------"
+    puts up
+    puts "----------------------------------"
+
+    puts "\n---------- Down Migration --------"
+    puts down
+    puts "----------------------------------"
+
+    final_migration_name = default_migration_name
+    migration_template   = ERB.new(<<~EOF.chomp)
+      # frozen_string_literal: true
+      class <%= @migration_class_name %> < (ActiveRecord::Migration[4.2])
+        def self.up
+      <%= @up.presence or raise "no @up given!" %>
+        end
+        def self.down
+      <%= @down.presence or raise "no @down given!" %>
+        end
+      end
+    EOF
+
+    @up = "    #{up.strip.split("\n").join("\n    ")}"
+    @down = "    #{down.strip.split("\n").join("\n    ")}"
+    @migration_class_name = final_migration_name.camelize
+
+    File.write("db/migrate/#{Time.now.to_i}_#{final_migration_name.underscore}.rb", migration_template.result(binding))
+  end
+end
+
+def default_migration_name
+  existing = Dir["db/migrate/*declare_schema_migration*"]
+  max = existing.grep(/([0-9]+)\.rb$/) { Regexp.last_match(1).to_i }.max.to_i
+  "declare_schema_migration_#{max + 1}"
+end

--- a/lib/declare_schema/rake.rb
+++ b/lib/declare_schema/rake.rb
@@ -24,29 +24,15 @@ namespace :declare_schema do
     puts down
     puts "----------------------------------"
 
-    final_migration_name = default_migration_name
-    migration_template   = ERB.new(<<~EOF.chomp)
-      # frozen_string_literal: true
-      class <%= @migration_class_name %> < (ActiveRecord::Migration[4.2])
-        def self.up
-      <%= @up.presence or raise "no @up given!" %>
-        end
-        def self.down
-      <%= @down.presence or raise "no @down given!" %>
-        end
-      end
-    EOF
+    migration_root_directory = "db/migrate"
+
+    final_migration_name = Generators::DeclareSchema::Migration::Migrator.default_migration_name(Dir["#{migration_root_directory}/*declare_schema_migration*"])
+    migration_template   = ERB.new(File.read(File.expand_path("../generators/declare_schema/migration/templates/migration.rb.erb", __dir__)))
 
     @up = "    #{up.strip.split("\n").join("\n    ")}"
     @down = "    #{down.strip.split("\n").join("\n    ")}"
     @migration_class_name = final_migration_name.camelize
 
-    File.write("db/migrate/#{Time.now.to_i}_#{final_migration_name.underscore}.rb", migration_template.result(binding))
+    File.write("#{migration_root_directory}/#{Time.now.to_i}_#{final_migration_name.underscore}.rb", migration_template.result(binding))
   end
-end
-
-def default_migration_name
-  existing = Dir["db/migrate/*declare_schema_migration*"]
-  max = existing.grep(/([0-9]+)\.rb$/) { Regexp.last_match(1).to_i }.max.to_i
-  "declare_schema_migration_#{max + 1}"
 end

--- a/lib/declare_schema/rake.rb
+++ b/lib/declare_schema/rake.rb
@@ -6,6 +6,10 @@ require "declare_schema/schema_change/column_remove"
 require "generators/declare_schema/migration/migrator"
 require "erb"
 
+# This is a set of Rake tasks that can be used to generate migrations when using
+# ActiveRecord, but not within a Rails application. If using Rails, you should
+# use the built-in generators that come with the gem instead.
+
 namespace :declare_schema do
   desc 'Generate migrations for the database schema'
   task :generate => 'db:load_config' do

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "1.1.0"
+  VERSION = "1.2.0.pre.1"
 end

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -28,9 +28,8 @@ module Generators
             Migrator.new(renames: renames).generate
           end
 
-          def default_migration_name
-            existing = Dir["#{Rails.root}/db/migrate/*declare_schema_migration*"]
-            max = existing.grep(/([0-9]+)\.rb$/) { Regexp.last_match(1).to_i }.max.to_i
+          def default_migration_name(existing_migrations = Dir["#{Rails.root}/db/migrate/*declare_schema_migration*"])
+            max = existing_migrations.grep(/([0-9]+)\.rb$/) { Regexp.last_match(1).to_i }.max.to_i
             "declare_schema_migration_#{max + 1}"
           end
 

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -55,9 +55,10 @@ module Generators
 
         def load_rails_models
           ActiveRecord::Migration.verbose = false
-
-          Rails.application.eager_load!
-          Rails::Engine.subclasses.each(&:eager_load!)
+          if defined?(Rails)
+            Rails.application.eager_load!
+            Rails::Engine.subclasses.each(&:eager_load!)
+          end
           self.class.before_generating_migration_callback&.call
         end
 

--- a/lib/generators/declare_schema/migration/templates/migration.rb.erb
+++ b/lib/generators/declare_schema/migration/templates/migration.rb.erb
@@ -1,4 +1,4 @@
-class <%= @migration_class_name %> < (ActiveRecord::Migration[4.2])
+class <%= @migration_class_name %> < ActiveRecord::Migration[4.2]
   def self.up
 <%= @up.presence or raise "no @up given!" %>
   end

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -1287,7 +1287,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         migration_content = File.read(migrations.first)
         first_line = migration_content.split("\n").first
         base_class = first_line.split(' < ').last
-        expect(base_class).to eq("(ActiveRecord::Migration[4.2])")
+        expect(base_class).to eq("ActiveRecord::Migration[4.2]")
       end
     end
 


### PR DESCRIPTION
I went with a quick and dirty solution here to the problem of generating migrations in a non-Rails application. I have a service, `fish` that is a Sinatra application using ActiveRecord and would like to be able to use declare schema to manage the database schema.


# Changelog

## [1.2.0] - Unreleased
### Added
- Added a rake task definition that can be optionally included into a non-Rails project to generate
  schema migrations.