### PR TITLE
raise if Rails is defined yet Rails.application is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - Unreleased
+### Fixed
+- If Rails is defined, raise if `Rails.application` is `nil`.
+
 ## [1.2.0] - 2022-09-14
 ### Added
 - Added a rake task definition that can be optionally included into a non-Rails project to generate
@@ -238,6 +242,7 @@ using the appropriate Rails configuration attributes.
 ### Added
 - Initial version from https://github.com/Invoca/hobo_fields v4.1.0.
 
+[1.2.1]: https://github.com/Invoca/declare_schema/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/Invoca/declare_schema/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/Invoca/declare_schema/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/Invoca/declare_schema/compare/v1.0.1...v1.0.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (1.2.0)
+    declare_schema (1.2.1)
       rails (>= 5.0)
 
 GEM

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -55,6 +55,7 @@ module Generators
         def load_rails_models
           ActiveRecord::Migration.verbose = false
           if defined?(Rails)
+            Rails.application or raise "Rails is defined, so Rails.application must be set"
             Rails.application.eager_load!
             Rails::Engine.subclasses.each(&:eager_load!)
           end


### PR DESCRIPTION
## [1.2.1] - Unreleased
### Fixed
- If Rails is defined, raise if `Rails.application` is `nil`.
