### PR TITLE
TECH-5882: renaming a foreign key currently generates incorrect migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.3] - Unreleased
+### Changed
+- Fixed a bug where renaming a foreign key resulted in an incorrect migration
+
 ## [1.2.2] - 2023-01-27
 ### Changed
 - Documented `belongs_to` and `has_and_belongs_to_many` behavior

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (1.2.3.pre.ga.5)
+    declare_schema (1.2.3.pre.ga.6)
       rails (>= 5.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (1.2.3.pre.ga.9)
+    declare_schema (1.2.3.pre.ga.10)
       rails (>= 5.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (1.2.3.pre.ga.6)
+    declare_schema (1.2.3.pre.ga.7)
       rails (>= 5.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (1.2.3.pre.ga.2)
+    declare_schema (1.2.3.pre.ga.4)
       rails (>= 5.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (1.2.2)
+    declare_schema (1.2.3.pre.ga.2)
       rails (>= 5.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (1.2.3.pre.ga.4)
+    declare_schema (1.2.3.pre.ga.5)
       rails (>= 5.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (1.2.3.pre.ga.7)
+    declare_schema (1.2.3.pre.ga.8)
       rails (>= 5.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (1.2.3.pre.ga.8)
+    declare_schema (1.2.3.pre.ga.9)
       rails (>= 5.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (1.2.3.pre.ga.10)
+    declare_schema (1.2.3.pre.ga.11)
       rails (>= 5.0)
 
 GEM

--- a/lib/declare_schema/model/foreign_key_definition.rb
+++ b/lib/declare_schema/model/foreign_key_definition.rb
@@ -12,7 +12,7 @@ module DeclareSchema
 
       def initialize(model, foreign_key, **options)
         @model = model
-        @foreign_key = foreign_key.to_s.presence or raise ArgumentError "Foreign key cannot be empty: #{foreign_key.inspect}"
+        @foreign_key = foreign_key.to_s.presence or raise ArgumentError "Foreign key must not be empty: #{foreign_key.inspect}"
         @options = options
 
         @child_table_name = model.table_name # unless a table rename, which would happen when a class is renamed??

--- a/lib/declare_schema/model/foreign_key_definition.rb
+++ b/lib/declare_schema/model/foreign_key_definition.rb
@@ -12,7 +12,7 @@ module DeclareSchema
 
       def initialize(model, foreign_key, **options)
         @model = model
-        @foreign_key = foreign_key.to_s.presence
+        @foreign_key = foreign_key.to_s.presence or raise ArgumentError "Foreign key cannot be empty: #{foreign_key.inspect}"
         @options = options
 
         @child_table_name = model.table_name # unless a table rename, which would happen when a class is renamed??

--- a/lib/declare_schema/model/habtm_model_shim.rb
+++ b/lib/declare_schema/model/habtm_model_shim.rb
@@ -53,7 +53,7 @@ module DeclareSchema
 
       def index_definitions_with_primary_key
         [
-          IndexDefinition.new(self, foreign_keys, unique: true, name: "PRIMARY KEY"), # creates a primary composite key on both foreign keys
+          IndexDefinition.new(self, foreign_keys, unique: true, name: Model::IndexDefinition::PRIMARY_KEY_NAME), # creates a primary composite key on both foreign keys
           IndexDefinition.new(self, foreign_keys.last) # not unique by itself; combines with primary key to be unique
         ]
       end

--- a/lib/declare_schema/model/habtm_model_shim.rb
+++ b/lib/declare_schema/model/habtm_model_shim.rb
@@ -37,10 +37,6 @@ module DeclareSchema
         join_table
       end
 
-      def index_name
-        "index_#{table_name}_on_#{foreign_keys.first}_#{foreign_keys.last}"
-      end
-
       def field_specs
         foreign_keys.each_with_index.each_with_object({}) do |(v, position), result|
           result[v] = ::DeclareSchema::Model::FieldSpec.new(self, v, :bigint, position: position, null: false)
@@ -57,7 +53,7 @@ module DeclareSchema
 
       def index_definitions_with_primary_key
         [
-          IndexDefinition.new(self, foreign_keys, unique: true, name: index_name), # creates a primary composite key on both foreign keys
+          IndexDefinition.new(self, foreign_keys, unique: true, name: "PRIMARY KEY"), # creates a primary composite key on both foreign keys
           IndexDefinition.new(self, foreign_keys.last) # not unique by itself; combines with primary key to be unique
         ]
       end

--- a/lib/declare_schema/model/habtm_model_shim.rb
+++ b/lib/declare_schema/model/habtm_model_shim.rb
@@ -57,7 +57,7 @@ module DeclareSchema
 
       def index_definitions_with_primary_key
         [
-          IndexDefinition.new(self, foreign_keys, unique: true, name: index_name), # creates a primary composite key on both foriegn keys
+          IndexDefinition.new(self, foreign_keys, unique: true, name: index_name), # creates a primary composite key on both foreign keys
           IndexDefinition.new(self, foreign_keys.last) # not unique by itself; combines with primary key to be unique
         ]
       end

--- a/lib/declare_schema/model/index_definition.rb
+++ b/lib/declare_schema/model/index_definition.rb
@@ -33,14 +33,11 @@ module DeclareSchema
 
       class << self
         # extract IndexSpecs from an existing table
-        # always includes the PRIMARY KEY index for Model unless it is a HABTM Model.
         def for_model(model, old_table_name = nil)
           t = old_table_name || model.table_name
 
-          habtm_model = model.is_a?(DeclareSchema::Model::HabtmModelShim)
-
           primary_key_columns = Array(model.connection.primary_key(t)).presence
-          primary_key_columns || habtm_model or
+          primary_key_columns or
             raise "could not find primary key for table #{t} in #{model.connection.columns(t).inspect}"
 
           primary_key_found = false
@@ -50,14 +47,14 @@ module DeclareSchema
               i.columns == primary_key_columns && i.unique or
                 raise "primary key on #{t} was not unique on #{primary_key_columns} (was unique=#{i.unique} on #{i.columns})"
               primary_key_found = true
-            elsif i.columns == primary_key_columns && i.unique && !habtm_model
+            elsif i.columns == primary_key_columns && i.unique
               # skip this primary key index since we'll create it below, with PRIMARY_KEY_NAME
               next
             end
             new(model, i.columns, name: i.name, unique: i.unique, where: i.where, table_name: old_table_name)
           end.compact
 
-          if !primary_key_found && !habtm_model
+          if !primary_key_found
             index_definitions << new(model, primary_key_columns, name: PRIMARY_KEY_NAME, unique: true, where: nil, table_name: old_table_name)
           end
           index_definitions

--- a/lib/declare_schema/model/index_definition.rb
+++ b/lib/declare_schema/model/index_definition.rb
@@ -33,6 +33,7 @@ module DeclareSchema
 
       class << self
         # extract IndexSpecs from an existing table
+        # includes the PRIMARY KEY index
         def for_model(model, old_table_name = nil)
           t = old_table_name || model.table_name
 

--- a/lib/declare_schema/model/index_definition.rb
+++ b/lib/declare_schema/model/index_definition.rb
@@ -19,7 +19,7 @@ module DeclareSchema
         @table = options.delete(:table_name) || model.table_name
         @fields = Array.wrap(fields).map(&:to_s)
         @explicit_name = options[:name] unless options.delete(:allow_equivalent)
-        @name = options.delete(:name) || self.class.index_name(@fields)
+        @name = options.delete(:name) || self.class.default_index_name(@fields)
         @unique = options.delete(:unique) || name == PRIMARY_KEY_NAME || false
 
         if @name.length > MYSQL_INDEX_NAME_MAX_LENGTH
@@ -60,7 +60,7 @@ module DeclareSchema
           index_definitions
         end
 
-        def index_name(columns)
+        def default_index_name(columns)
           "on_#{Array(columns).join("_and_")}"
         end
       end

--- a/lib/declare_schema/model/index_definition.rb
+++ b/lib/declare_schema/model/index_definition.rb
@@ -37,8 +37,7 @@ module DeclareSchema
           t = old_table_name || model.table_name
 
           primary_key_columns = Array(model.connection.primary_key(t)).presence
-          primary_key_columns or
-            raise "could not find primary key for table #{t} in #{model.connection.columns(t).inspect}"
+          primary_key_columns or raise "could not find primary key for table #{t} in #{model.connection.columns(t).inspect}"
 
           primary_key_found = false
           index_definitions = model.connection.indexes(t).map do |i|

--- a/lib/declare_schema/model/index_definition.rb
+++ b/lib/declare_schema/model/index_definition.rb
@@ -47,9 +47,6 @@ module DeclareSchema
               i.columns == primary_key_columns && i.unique or
                 raise "primary key on #{t} was not unique on #{primary_key_columns} (was unique=#{i.unique} on #{i.columns})"
               primary_key_found = true
-            elsif i.columns == primary_key_columns && i.unique
-              # skip this primary key index since we'll create it below, with PRIMARY_KEY_NAME
-              next
             end
             new(model, i.columns, name: i.name, unique: i.unique, where: i.where, table_name: old_table_name)
           end.compact

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "1.2.3.pre.ga.7"
+  VERSION = "1.2.3.pre.ga.8"
 end

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "1.2.3.pre.ga.3"
+  VERSION = "1.2.3.pre.ga.4"
 end

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "1.2.3.pre.ga.6"
+  VERSION = "1.2.3.pre.ga.7"
 end

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "1.2.3.pre.ga.4"
+  VERSION = "1.2.3.pre.ga.5"
 end

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "1.2.3.pre.ga.9"
+  VERSION = "1.2.3.pre.ga.10"
 end

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "1.2.3.pre.ga.8"
+  VERSION = "1.2.3.pre.ga.9"
 end

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "1.2.3.pre.ga.2"
+  VERSION = "1.2.3.pre.ga.3"
 end

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "1.2.3.pre.ga.10"
+  VERSION = "1.2.3.pre.ga.11"
 end

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "1.2.2"
+  VERSION = "1.2.3.pre.ga.2"
 end

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "1.2.3.pre.ga.5"
+  VERSION = "1.2.3.pre.ga.6"
 end

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -469,7 +469,7 @@ module Generators
         end
 
         def index_changes_due_to_column_renames(indexes_to_drop, indexes_to_add, to_rename)
-          indexes_to_drop.each_with_object([], []) do |index_to_drop, (renamed_indexes_to_drop, renamed_indexes_to_add)|
+          indexes_to_drop.each_with_object([[], []]) do |index_to_drop, (renamed_indexes_to_drop, renamed_indexes_to_add)|
             renamed_columns = index_to_drop.columns.map do |column|
               to_rename.fetch(column, column)
             end.sort
@@ -508,16 +508,15 @@ module Generators
         end
 
         def foreign_key_changes_due_to_column_renames(fks_to_drop, fks_to_add, to_rename)
-          fks_to_drop.each_with_object([], []) do |fk_to_drop, (renamed_fks_to_drop, renamed_fks_to_add)|
-            if (fks_to_add = fks_to_add.find do |fk_to_add|
+          fks_to_drop.each_with_object([[], []]) do |fk_to_drop, (renamed_fks_to_drop, renamed_fks_to_add)|
+            if (fk_to_add = fks_to_add.find do |fk_to_add|
               fk_to_add.foreign_key.nil? and raise "Foreign key is not allowed to be nil for #{fk_to_add.inspect}"
-              if fk_to_add.child_table_name == fk_to_drop.child_table_name &&
-                fk_to_add.parent_table_name == fk_to_drop.parent_table_name &&
-                fk_to_add.foreign_key == to_rename[fk_to_drop.foreign_key]
-              end
+              fk_to_add.child_table_name == fk_to_drop.child_table_name &&
+              fk_to_add.parent_table_name == fk_to_drop.parent_table_name &&
+              fk_to_add.foreign_key == to_rename[fk_to_drop.foreign_key]
             end)
               renamed_fks_to_drop << fk_to_drop
-              renamed_fks_to_add << fks_to_add
+              renamed_fks_to_add << fk_to_add
             end
           end
         end

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -446,7 +446,7 @@ module Generators
           if !ActiveRecord::Base.connection.class.name.match?(/SQLite3Adapter/)
             change_primary_key =
               if (existing_primary_key || defined_primary_key) &&
-                existing_primary_key_columns != defined_primary_key&.columns
+                 existing_primary_key_columns != defined_primary_key&.columns
                 ::DeclareSchema::SchemaChange::PrimaryKeyChange.new(new_table_name, existing_primary_key_columns, defined_primary_key&.columns)
               end
           end
@@ -509,12 +509,14 @@ module Generators
 
         def foreign_key_changes_due_to_column_renames(fks_to_drop, fks_to_add, to_rename)
           fks_to_drop.each_with_object([[], []]) do |fk_to_drop, (renamed_fks_to_drop, renamed_fks_to_add)|
-            if (fk_to_add = fks_to_add.find do |fk_to_add|
+            fk_to_add = fks_to_add.find do |fk_to_add|
               fk_to_add.foreign_key.nil? and raise "Foreign key is not allowed to be nil for #{fk_to_add.inspect}"
               fk_to_add.child_table_name == fk_to_drop.child_table_name &&
-              fk_to_add.parent_table_name == fk_to_drop.parent_table_name &&
-              fk_to_add.foreign_key == to_rename[fk_to_drop.foreign_key]
-            end)
+                fk_to_add.parent_table_name == fk_to_drop.parent_table_name &&
+                fk_to_add.foreign_key == to_rename[fk_to_drop.foreign_key]
+            end
+
+            if fk_to_add
               renamed_fks_to_drop << fk_to_drop
               renamed_fks_to_add << fk_to_add
             end

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -459,7 +459,7 @@ module Generators
 
           indexes_to_drop.each { |index_to_drop|
             renamed_columns = index_to_drop.columns.map do |column|
-              to_rename[column]
+              to_rename[column] || column
             end
 
             indexes_to_add.each { |index_to_add|

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -510,7 +510,6 @@ module Generators
         def foreign_key_changes_due_to_column_renames(fks_to_drop, fks_to_add, to_rename)
           fks_to_drop.each_with_object([[], []]) do |fk_to_drop, (renamed_fks_to_drop, renamed_fks_to_add)|
             fk_to_add = fks_to_add.find do |fk_to_add|
-              fk_to_add.foreign_key.nil? and raise "Foreign key is not allowed to be nil for #{fk_to_add.inspect}"
               fk_to_add.child_table_name == fk_to_drop.child_table_name &&
                 fk_to_add.parent_table_name == fk_to_drop.parent_table_name &&
                 fk_to_add.foreign_key == to_rename[fk_to_drop.foreign_key]

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -522,6 +522,7 @@ module Generators
             fks_to_add.each { |fk_to_add|
               if fk_to_add.child_table_name == fk_to_drop.child_table_name &&
                 fk_to_add.parent_table_name == fk_to_drop.parent_table_name &&
+                !fk_to_add.foreign_key.nil? &&
                 fk_to_add.foreign_key == to_rename[fk_to_drop.foreign_key]
 
                 renamed_fks_to_drop.append(fk_to_drop)

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -459,7 +459,7 @@ module Generators
 
           indexes_to_drop.each { |index_to_drop|
             renamed_columns = index_to_drop.columns.map do |column|
-              to_rename[column] || column
+              to_rename.fetch(column, column)
             end
 
             indexes_to_add.each { |index_to_add|

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -463,7 +463,7 @@ module Generators
             end
 
             indexes_to_add.each { |index_to_add|
-              if renamed_columns == index_to_add.columns
+              if Set.new(renamed_columns) == Set.new(index_to_add.columns)
                 renamed_indexes_to_drop.append(index_to_drop)
                 renamed_indexes_to_add.append(index_to_add)
               end

--- a/spec/lib/declare_schema/model/foreign_key_definition_spec.rb
+++ b/spec/lib/declare_schema/model/foreign_key_definition_spec.rb
@@ -49,11 +49,10 @@ RSpec.describe DeclareSchema::Model::ForeignKeyDefinition do
         end
 
         context 'when all options passed' do
-          let(:foreign_key) { nil }
           let(:options) { { parent_table: :networks, foreign_key: :the_network_id, constraint_name: :constraint_1, dependent: :delete } }
 
           it 'normalizes symbols to strings' do
-            expect(subject.foreign_key).to be_nil
+            expect(subject.foreign_key).to eq('network_id')
             expect(subject.foreign_key_name).to eq('the_network_id')
             expect(subject.parent_table_name).to eq('networks')
             expect(subject.constraint_name).to eq('constraint_1')

--- a/spec/lib/declare_schema/model/habtm_model_shim_spec.rb
+++ b/spec/lib/declare_schema/model/habtm_model_shim_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe DeclareSchema::Model::HabtmModelShim do
         expect(result.size).to eq(2), result.inspect
 
         expect(result.first).to be_a(::DeclareSchema::Model::IndexDefinition)
-        expect(result.first.name).to eq('PRIMARY KEY')
+        expect(result.first.name).to eq('PRIMARY')
         expect(result.first.fields).to eq(['parent_1_id', 'parent_2_id'])
         expect(result.first.unique).to be_truthy
       end
@@ -127,7 +127,7 @@ RSpec.describe DeclareSchema::Model::HabtmModelShim do
         result = subject.index_definitions_with_primary_key
         expect(result.size).to eq(2), result.inspect
         expect(result.first).to be_a(::DeclareSchema::Model::IndexDefinition)
-        expect(result.first.name).to eq('PRIMARY KEY')
+        expect(result.first.name).to eq('PRIMARY')
         expect(result.first.fields).to eq(['advertiser_campaign', 'tracking_pixel'])
         expect(result.first.unique).to be_truthy
       end

--- a/spec/lib/declare_schema/model/habtm_model_shim_spec.rb
+++ b/spec/lib/declare_schema/model/habtm_model_shim_spec.rb
@@ -102,8 +102,33 @@ RSpec.describe DeclareSchema::Model::HabtmModelShim do
         expect(result.size).to eq(2), result.inspect
 
         expect(result.first).to be_a(::DeclareSchema::Model::IndexDefinition)
-        expect(result.first.name).to eq('index_parent_1_parent_2_on_parent_1_id_parent_2_id')
+        expect(result.first.name).to eq('PRIMARY KEY')
         expect(result.first.fields).to eq(['parent_1_id', 'parent_2_id'])
+        expect(result.first.unique).to be_truthy
+      end
+    end
+
+    context 'when table and foreign key names are long' do
+      let(:join_table) { "advertiser_campaigns_tracking_pixels" }
+      let(:foreign_keys) { ['advertiser_campaign', 'tracking_pixel'] }
+      let(:foreign_key_classes) { [Table1, Table2] }
+
+      before do
+        class Table1 < ActiveRecord::Base
+          self.table_name = 'advertiser_campaign'
+        end
+
+        class Table2 < ActiveRecord::Base
+          self.table_name = 'tracking_pixel'
+        end
+      end
+
+      it 'returns two index definitions and does not raise a IndexNameTooLongError' do
+        result = subject.index_definitions_with_primary_key
+        expect(result.size).to eq(2), result.inspect
+        expect(result.first).to be_a(::DeclareSchema::Model::IndexDefinition)
+        expect(result.first.name).to eq('PRIMARY KEY')
+        expect(result.first.fields).to eq(['advertiser_campaign', 'tracking_pixel'])
         expect(result.first.unique).to be_truthy
       end
     end


### PR DESCRIPTION
When a foreign key is renamed, `declare_schema` creates a migration that includes more than just a column rename. It also includes additions and removals of an index and foreign key. This PR gets rid of everything except the column rename.