### PR TITLE
TECH-11529: Allow IndexDefinitions for HABTM models defined without a…

### DIFF
--- a/lib/declare_schema/model/habtm_model_shim.rb
+++ b/lib/declare_schema/model/habtm_model_shim.rb
@@ -37,6 +37,10 @@ module DeclareSchema
         join_table
       end
 
+      def index_name
+        "index_#{table_name}_on_#{foreign_keys.first}_#{foreign_keys.last}"
+      end
+
       def field_specs
         foreign_keys.each_with_index.each_with_object({}) do |(v, position), result|
           result[v] = ::DeclareSchema::Model::FieldSpec.new(self, v, :bigint, position: position, null: false)
@@ -53,7 +57,7 @@ module DeclareSchema
 
       def index_definitions_with_primary_key
         [
-          IndexDefinition.new(self, foreign_keys, unique: true, name: Model::IndexDefinition::PRIMARY_KEY_NAME), # creates a primary composite key on both foreign keys
+          IndexDefinition.new(self, foreign_keys, unique: true, name: index_name), # creates a primary composite key on both foreign keys
           IndexDefinition.new(self, foreign_keys.last) # not unique by itself; combines with primary key to be unique
         ]
       end

--- a/lib/declare_schema/model/index_definition.rb
+++ b/lib/declare_schema/model/index_definition.rb
@@ -36,9 +36,10 @@ module DeclareSchema
         # includes the PRIMARY KEY index
         def for_model(model, old_table_name = nil)
           t = old_table_name || model.table_name
-
           primary_key_columns = Array(model.connection.primary_key(t)).presence
-          primary_key_columns or raise "could not find primary key for table #{t} in #{model.connection.columns(t).inspect}"
+          # Needed for backwards compatibility with HABTM models that were generated without a PRIMARY KEY
+          # This allows the migrator to replace the unique index on both foreign keys with a composite primary key
+          primary_key_columns || model.is_a?(DeclareSchema::Model::HabtmModelShim) or raise "could not find primary key for table #{t} in #{model.connection.columns(t).inspect}"
 
           primary_key_found = false
           index_definitions = model.connection.indexes(t).map do |i|

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -281,10 +281,10 @@ module Generators
                                 ColumnRename
                                 ColumnChange
                                   PrimaryKeyChange
+                                  IndexRemove
                                   IndexAdd
                                     ForeignKeyAdd
                                     ForeignKeyRemove
-                                  IndexRemove
                                 ColumnRemove
                               TableRemove ]
 
@@ -464,7 +464,6 @@ module Generators
             ::DeclareSchema::SchemaChange::IndexAdd.new(new_table_name, i.columns, unique: i.unique, where: i.where, name: i.name)
           end
 
-          # the order is important here - adding a :unique, for instance needs to remove then add
           [Array(change_primary_key) + drop_indexes + add_indexes]
         end
 

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -469,8 +469,8 @@ module Generators
 
         def index_changes_due_to_column_renames(indexes_to_drop, indexes_to_add, to_rename)
           indexes_to_drop.each_with_object([[], []]) do |index_to_drop, (renamed_indexes_to_drop, renamed_indexes_to_add)|
-            renamed_columns = index_to_drop.columns.map do |column|
-              to_rename.fetch(column, column)
+            renamed_columns = index_to_drop.columns.map_compact do |column|
+              to_rename[column]
             end.sort
 
             if (index_to_add = indexes_to_add.find { |index_to_add| renamed_columns == index_to_add.columns.sort })

--- a/spec/lib/declare_schema/model/habtm_model_shim_spec.rb
+++ b/spec/lib/declare_schema/model/habtm_model_shim_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe DeclareSchema::Model::HabtmModelShim do
         expect(result.size).to eq(2), result.inspect
 
         expect(result.first).to be_a(::DeclareSchema::Model::IndexDefinition)
-        expect(result.first.name).to eq('PRIMARY')
+        expect(result.first.name).to eq('index_parent_1_parent_2_on_parent_1_id_parent_2_id')
         expect(result.first.fields).to eq(['parent_1_id', 'parent_2_id'])
         expect(result.first.unique).to be_truthy
       end
@@ -123,13 +123,8 @@ RSpec.describe DeclareSchema::Model::HabtmModelShim do
         end
       end
 
-      it 'returns two index definitions and does not raise a IndexNameTooLongError' do
-        result = subject.index_definitions_with_primary_key
-        expect(result.size).to eq(2), result.inspect
-        expect(result.first).to be_a(::DeclareSchema::Model::IndexDefinition)
-        expect(result.first.name).to eq('PRIMARY')
-        expect(result.first.fields).to eq(['advertiser_campaign', 'tracking_pixel'])
-        expect(result.first.unique).to be_truthy
+      it 'raises an IndexNameTooLongError' do
+        expect { subject.index_definitions_with_primary_key }.to raise_error(DeclareSchema::Model::IndexDefinition::IndexNameTooLongError, /exceeds MySQL limit of 64 characters/)
       end
     end
 

--- a/spec/lib/declare_schema/model/index_definition_spec.rb
+++ b/spec/lib/declare_schema/model/index_definition_spec.rb
@@ -139,11 +139,8 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
                 ActiveRecord::Base.connection.schema_cache.clear!
               end
 
-              it 'returns the indexes for the model' do
-                expect(subject.size).to eq(1), subject.inspect
-                expect([:name, :columns, :unique].map { |attr| subject[0].send(attr) }).to eq(
-                                                                                               ['PRIMARY', ['index_definition_pizza_id', 'index_definition_topping_id'], true]
-                                                                                           )
+              it 'returns an empty array' do
+                expect(subject).to eq([]), subject.inspect
               end
             end
 
@@ -163,11 +160,9 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
               end
 
               it 'returns the indexes for the model' do
-                expect(subject.size).to eq(2), subject.inspect
+                expect(subject.size).to eq(1), subject.inspect
                 expect([:name, :columns, :unique].map { |attr| subject[0].send(attr) })
                   .to eq(['index_index_definition_pizzas_index_definition_toppings', ['index_definition_pizza_id', 'index_definition_topping_id'], true])
-                expect([:name, :columns, :unique].map { |attr| subject[1].send(attr) })
-                  .to eq(['PRIMARY', [], true])
               end
             end
           end

--- a/spec/lib/generators/declare_schema/migration/migrator_spec.rb
+++ b/spec/lib/generators/declare_schema/migration/migrator_spec.rb
@@ -90,10 +90,10 @@ module Generators
                 ColumnRename
                 ColumnChange
                 PrimaryKeyChange
+                IndexRemove
                 IndexAdd
                 ForeignKeyAdd
                 ForeignKeyRemove
-                IndexRemove
                 ColumnRemove
                 TableRemove ]
             end


### PR DESCRIPTION
… primary key

Note for reviewer: Will bump the version and update the CHANGELOG if this fix looks reasonable.

### Fixed
- Fixed a bug where a HABTM model without a primary key would cause the migration generator to fail.