### PR TITLE
non-production: move sort into HabtmModelShim#initialize; omit connection and foreign_key_classes

### DIFF
--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -49,11 +49,14 @@ module DeclareSchema
     end
 
     module ClassMethods
-      def index(fields, **options)
+      def index(fields, name: nil, allow_equivalent: false, unique: false, where: nil)
         # make index idempotent
         index_fields_s = Array.wrap(fields).map(&:to_s)
         unless index_definitions.any? { |index_spec| index_spec.fields == index_fields_s }
-          index_definitions << ::DeclareSchema::Model::IndexDefinition.new(self, fields, **options)
+          index_definitions << ::DeclareSchema::Model::IndexDefinition.new(
+            table_name, fields,
+            name: name, allow_equivalent: allow_equivalent, unique: unique, where: where
+          )
         end
       end
 
@@ -208,7 +211,7 @@ module DeclareSchema
       end
 
       def _rails_default_primary_key
-        ::DeclareSchema::Model::IndexDefinition.new(self, [_declared_primary_key.to_sym], unique: true, name: DeclareSchema::Model::IndexDefinition::PRIMARY_KEY_NAME)
+        ::DeclareSchema::Model::IndexDefinition.new(table_name, [_declared_primary_key], unique: true, name: DeclareSchema::Model::IndexDefinition::PRIMARY_KEY_NAME)
       end
 
       # Declares the "foo_type" field that accompanies the "foo_id"

--- a/lib/declare_schema/model/habtm_model_shim.rb
+++ b/lib/declare_schema/model/habtm_model_shim.rb
@@ -10,16 +10,16 @@ module DeclareSchema
         end
       end
 
-      attr_reader :join_table, :foreign_keys, :table_names
+      attr_reader :join_table, :foreign_keys, :parent_table_names
 
-      def initialize(join_table, foreign_keys, table_names)
+      def initialize(join_table, foreign_keys, parent_table_names)
         foreign_keys.is_a?(Array) && foreign_keys.size == 2 or
           raise ArgumentError, "foreign_keys must be <Array[2]>; got #{foreign_keys.inspect}"
-        table_names.is_a?(Array) && table_names.size == 2 or
-          raise ArgumentError, "table_names must be <Array[2]>; got #{table_names.inspect}"
+        parent_table_names.is_a?(Array) && parent_table_names.size == 2 or
+          raise ArgumentError, "parent_table_names must be <Array[2]>; got #{parent_table_names.inspect}"
         @join_table = join_table
-        @foreign_keys = foreign_keys.sort
-        @table_names = @foreign_keys == foreign_keys ? table_names : table_names.reverse
+        @foreign_keys = foreign_keys.sort # Rails requires these be in alphabetical order
+        @parent_table_names = @foreign_keys == foreign_keys ? parent_table_names : parent_table_names.reverse # match the above sort
       end
 
       def _table_options
@@ -59,8 +59,8 @@ module DeclareSchema
 
       def constraint_specs
         [
-          ForeignKeyDefinition.new(foreign_keys.first, child_table: @join_table, parent_table: table_names.first, constraint_name: "#{join_table}_FK1", dependent: :delete),
-          ForeignKeyDefinition.new(foreign_keys.last, child_table: @join_table, parent_table: table_names.last, constraint_name: "#{join_table}_FK2", dependent: :delete)
+          ForeignKeyDefinition.new(foreign_keys.first, child_table: @join_table, parent_table: parent_table_names.first, constraint_name: "#{join_table}_FK1", dependent: :delete),
+          ForeignKeyDefinition.new(foreign_keys.last, child_table: @join_table, parent_table: parent_table_names.last, constraint_name: "#{join_table}_FK2", dependent: :delete)
         ]
       end
     end

--- a/lib/declare_schema/model/habtm_model_shim.rb
+++ b/lib/declare_schema/model/habtm_model_shim.rb
@@ -46,8 +46,8 @@ module DeclareSchema
 
       def index_definitions_with_primary_key
         [
-          IndexDefinition.new(table_name, foreign_keys, unique: true, name: Model::IndexDefinition::PRIMARY_KEY_NAME), # creates a primary composite key on both foreign keys
-          IndexDefinition.new(table_name, foreign_keys.last) # not unique by itself; combines with primary key to be unique
+          IndexDefinition.new(foreign_keys, name: Model::IndexDefinition::PRIMARY_KEY_NAME, unique: true), # creates a primary composite key on both foreign keys
+          IndexDefinition.new(foreign_keys.last, table_name: table_name, unique: false) # index for queries where we only have the last foreign key
         ]
       end
 

--- a/lib/declare_schema/model/habtm_model_shim.rb
+++ b/lib/declare_schema/model/habtm_model_shim.rb
@@ -59,8 +59,8 @@ module DeclareSchema
 
       def constraint_specs
         [
-          ForeignKeyDefinition.new(self, foreign_keys.first, parent_table: table_names.first, constraint_name: "#{join_table}_FK1", dependent: :delete),
-          ForeignKeyDefinition.new(self, foreign_keys.last, parent_table: table_names.last, constraint_name: "#{join_table}_FK2", dependent: :delete)
+          ForeignKeyDefinition.new(foreign_keys.first, child_table: @join_table, parent_table: table_names.first, constraint_name: "#{join_table}_FK1", dependent: :delete),
+          ForeignKeyDefinition.new(foreign_keys.last, child_table: @join_table, parent_table: table_names.last, constraint_name: "#{join_table}_FK2", dependent: :delete)
         ]
       end
     end

--- a/lib/declare_schema/model/habtm_model_shim.rb
+++ b/lib/declare_schema/model/habtm_model_shim.rb
@@ -46,8 +46,8 @@ module DeclareSchema
 
       def index_definitions_with_primary_key
         [
-          IndexDefinition.new(self, foreign_keys, unique: true, name: Model::IndexDefinition::PRIMARY_KEY_NAME), # creates a primary composite key on both foreign keys
-          IndexDefinition.new(self, foreign_keys.last) # not unique by itself; combines with primary key to be unique
+          IndexDefinition.new(table_name, foreign_keys, unique: true, name: Model::IndexDefinition::PRIMARY_KEY_NAME), # creates a primary composite key on both foreign keys
+          IndexDefinition.new(table_name, foreign_keys.last) # not unique by itself; combines with primary key to be unique
         ]
       end
 

--- a/lib/declare_schema/model/index_definition.rb
+++ b/lib/declare_schema/model/index_definition.rb
@@ -19,7 +19,7 @@ module DeclareSchema
       def initialize(columns, name: nil, table_name: nil, allow_equivalent: false, unique: false, where: nil)
         @name = name || self.class.default_index_name(table_name, columns)
         @columns = Array.wrap(columns).map(&:to_s)
-        @explicit_name = name unless allow_equivalent
+        @explicit_name = @name unless allow_equivalent
         unique.in?([false, true]) or raise ArgumentError, "unique must be true or false: got #{unique.inspect}"
         if @name == PRIMARY_KEY_NAME
           unique or raise ArgumentError, "primary key index must be unique"

--- a/lib/declare_schema/model/index_definition.rb
+++ b/lib/declare_schema/model/index_definition.rb
@@ -7,19 +7,18 @@ module DeclareSchema
     class IndexDefinition
       include Comparable
 
-      # TODO: replace `fields` with `columns` and remove alias. -Colin
-      attr_reader :table_name, :fields, :explicit_name, :name, :unique, :where
-      alias columns fields
+      attr_reader :table_name, :columns, :explicit_name, :name, :unique, :where
+      alias fields columns # TODO: change callers to use columns. -Colin
 
       class IndexNameTooLongError < RuntimeError; end
 
       PRIMARY_KEY_NAME = "PRIMARY"
 
-      def initialize(table_name, fields, name: nil, allow_equivalent: false, unique: false, where: nil)
+      def initialize(table_name, columns, name: nil, allow_equivalent: false, unique: false, where: nil)
         @table_name = table_name
-        @fields = Array.wrap(fields).map(&:to_s)
+        @columns = Array.wrap(columns).map(&:to_s)
         @explicit_name = name unless allow_equivalent
-        @name = name || self.class.default_index_name(@table_name, @fields)
+        @name = name || self.class.default_index_name(@table_name, @columns)
         @unique = unique || @name == PRIMARY_KEY_NAME || false
 
         if DeclareSchema.max_index_and_constraint_name_length && @name.length > DeclareSchema.max_index_and_constraint_name_length
@@ -56,10 +55,10 @@ module DeclareSchema
           index_definitions
         end
 
-        def default_index_name(table_name, fields)
+        def default_index_name(table_name, columns)
           index_name = nil
           [:long_index_name, :short_index_name].find do |method_name|
-            index_name = send(method_name, table_name, fields)
+            index_name = send(method_name, table_name, columns)
             if DeclareSchema.max_index_and_constraint_name_length.nil? || index_name.length <= DeclareSchema.max_index_and_constraint_name_length
               break index_name
             end
@@ -101,11 +100,11 @@ module DeclareSchema
       end
 
       def to_key
-        @to_key ||= [table_name, fields, name, unique, where].map(&:to_s)
+        @to_key ||= [table_name, columns, name, unique, where].map(&:to_s)
       end
 
       def settings
-        @settings ||= [table_name, fields, unique].map(&:to_s)
+        @settings ||= [table_name, columns, unique].map(&:to_s)
       end
 
       def hash
@@ -121,7 +120,7 @@ module DeclareSchema
       end
 
       def with_name(new_name)
-        self.class.new(@table_name, @fields, table_name: @table_name, index_name: @index_name, unique: @unique, name: new_name)
+        self.class.new(@table_name, @columns, unique: @unique, name: new_name)
       end
 
       alias eql? ==

--- a/lib/declare_schema/model/index_definition.rb
+++ b/lib/declare_schema/model/index_definition.rb
@@ -8,26 +8,25 @@ module DeclareSchema
       include Comparable
 
       # TODO: replace `fields` with `columns` and remove alias. -Colin
-      attr_reader :table, :fields, :explicit_name, :name, :unique, :where
+      attr_reader :table_name, :fields, :explicit_name, :name, :unique, :where
       alias columns fields
 
       class IndexNameTooLongError < RuntimeError; end
 
       PRIMARY_KEY_NAME = "PRIMARY"
 
-      def initialize(model, fields, **options)
-        @model = model
-        @table = options.delete(:table_name) || model.table_name
+      def initialize(table_name, fields, name: nil, allow_equivalent: false, unique: false, where: nil)
+        @table_name = table_name
         @fields = Array.wrap(fields).map(&:to_s)
-        @explicit_name = options[:name] unless options.delete(:allow_equivalent)
-        @name = options.delete(:name) || self.class.default_index_name(@table, @fields)
-        @unique = options.delete(:unique) || name == PRIMARY_KEY_NAME || false
+        @explicit_name = name unless allow_equivalent
+        @name = name || self.class.default_index_name(@table_name, @fields)
+        @unique = unique || @name == PRIMARY_KEY_NAME || false
 
         if DeclareSchema.max_index_and_constraint_name_length && @name.length > DeclareSchema.max_index_and_constraint_name_length
           raise IndexNameTooLongError, "Index '#{@name}' exceeds configured limit of #{DeclareSchema.max_index_and_constraint_name_length} characters. Give it a shorter name, or adjust DeclareSchema.max_index_and_constraint_name_length if you know your database can accept longer names."
         end
 
-        if (where = options[:where])
+        if where
           @where = where.start_with?('(') ? where : "(#{where})"
         end
       end
@@ -35,33 +34,32 @@ module DeclareSchema
       class << self
         # extract IndexSpecs from an existing table
         # includes the PRIMARY KEY index
-        def for_model(model, old_table_name = nil)
-          t = old_table_name || model.table_name
-
-          primary_key_columns = Array(model.connection.primary_key(t)).presence
-          primary_key_columns or raise "could not find primary key for table #{t} in #{model.connection.columns(t).inspect}"
+        def for_model(model, table_name)
+          table_name ||= model.table_name
+          primary_key_columns = Array(model.connection.primary_key(table_name))
+          primary_key_columns.present? or raise "could not find primary key for table #{table_name} in #{model.connection.columns(table_name).inspect}"
 
           primary_key_found = false
-          index_definitions = model.connection.indexes(t).map do |i|
+          index_definitions = model.connection.indexes(table_name).map do |i|
             model.ignore_indexes.include?(i.name) and next
             if i.name == PRIMARY_KEY_NAME
               i.columns == primary_key_columns && i.unique or
-                raise "primary key on #{t} was not unique on #{primary_key_columns} (was unique=#{i.unique} on #{i.columns})"
+                raise "primary key on #{table_name} was not unique on #{primary_key_columns} (was unique=#{i.unique} on #{i.columns})"
               primary_key_found = true
             end
-            new(model, i.columns, name: i.name, unique: i.unique, where: i.where, table_name: old_table_name)
+            new(table_name, i.columns, name: i.name, unique: i.unique, where: i.where)
           end.compact
 
           if !primary_key_found
-            index_definitions << new(model, primary_key_columns, name: PRIMARY_KEY_NAME, unique: true, where: nil, table_name: old_table_name)
+            index_definitions << new(table_name, primary_key_columns, name: PRIMARY_KEY_NAME, unique: true, where: nil)
           end
           index_definitions
         end
 
-        def default_index_name(table, fields)
+        def default_index_name(table_name, fields)
           index_name = nil
           [:long_index_name, :short_index_name].find do |method_name|
-            index_name = send(method_name, table, fields)
+            index_name = send(method_name, table_name, fields)
             if DeclareSchema.max_index_and_constraint_name_length.nil? || index_name.length <= DeclareSchema.max_index_and_constraint_name_length
               break index_name
             end
@@ -103,11 +101,11 @@ module DeclareSchema
       end
 
       def to_key
-        @key ||= [table, fields, name, unique, where].map(&:to_s)
+        @to_key ||= [table_name, fields, name, unique, where].map(&:to_s)
       end
 
       def settings
-        @settings ||= [table, fields, unique].map(&:to_s)
+        @settings ||= [table_name, fields, unique].map(&:to_s)
       end
 
       def hash
@@ -123,7 +121,7 @@ module DeclareSchema
       end
 
       def with_name(new_name)
-        self.class.new(@model, @fields, table_name: @table_name, index_name: @index_name, unique: @unique, name: new_name)
+        self.class.new(@table_name, @fields, table_name: @table_name, index_name: @index_name, unique: @unique, name: new_name)
       end
 
       alias eql? ==

--- a/lib/declare_schema/model/index_definition.rb
+++ b/lib/declare_schema/model/index_definition.rb
@@ -33,14 +33,13 @@ module DeclareSchema
       class << self
         # extract IndexSpecs from an existing table
         # includes the PRIMARY KEY index
-        def for_model(model, table_name)
-          table_name ||= model.table_name
-          primary_key_columns = Array(model.connection.primary_key(table_name))
-          primary_key_columns.present? or raise "could not find primary key for table #{table_name} in #{model.connection.columns(table_name).inspect}"
+        def for_table(table_name, ignore_indexes, connection)
+          primary_key_columns = Array(connection.primary_key(table_name))
+          primary_key_columns.present? or raise "could not find primary key for table #{table_name} in #{connection.columns(table_name).inspect}"
 
           primary_key_found = false
-          index_definitions = model.connection.indexes(table_name).map do |i|
-            model.ignore_indexes.include?(i.name) and next
+          index_definitions = connection.indexes(table_name).map do |i|
+            ignore_indexes.include?(i.name) and next
             if i.name == PRIMARY_KEY_NAME
               i.columns == primary_key_columns && i.unique or
                 raise "primary key on #{table_name} was not unique on #{primary_key_columns} (was unique=#{i.unique} on #{i.columns})"

--- a/lib/declare_schema/model/index_definition.rb
+++ b/lib/declare_schema/model/index_definition.rb
@@ -125,7 +125,7 @@ module DeclareSchema
       end
 
       def with_name(new_name)
-        self.class.new(@columns, name: new_name, unique: @unique, where: @where)
+        self.class.new(@columns, name: new_name, unique: @unique, allow_equivalent: @explicit_name.nil?, where: @where)
       end
 
       alias eql? ==

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -3,6 +3,7 @@
 require 'active_record'
 require 'active_record/connection_adapters/abstract_adapter'
 require 'declare_schema/schema_change/all'
+require_relative '../../../declare_schema/model/habtm_model_shim'
 
 module Generators
   module DeclareSchema
@@ -485,7 +486,7 @@ module Generators
           ActiveRecord::Base.connection.class.name.match?(/SQLite3Adapter/) and raise ArgumentError, 'SQLite does not support foreign keys'
           ::DeclareSchema.default_generate_foreign_keys or return []
 
-          if model.is_a?(DeclareSchema::Model::HabtmModelShim)
+          if model.is_a?(::DeclareSchema::Model::HabtmModelShim)
             force_dependent_delete = :delete
           end
 

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -500,13 +500,13 @@ module Generators
 
           drop_fks = (fks_to_drop - renamed_fks_to_drop).map do |fk|
             ::DeclareSchema::SchemaChange::ForeignKeyRemove.new(fk.child_table_name, fk.parent_table_name,
-                                                                column_name: fk.foreign_key_name, name: fk.constraint_name)
+                                                                column_name: fk.foreign_key_column, name: fk.constraint_name)
           end
 
           add_fks = (fks_to_add - renamed_fks_to_add).map do |fk|
             # next if fk.parent.constantize.abstract_class || fk.parent == fk.model.class_name
             ::DeclareSchema::SchemaChange::ForeignKeyAdd.new(fk.child_table_name, fk.parent_table_name,
-                                                             column_name: fk.foreign_key_name, name: fk.constraint_name)
+                                                             column_name: fk.foreign_key_column, name: fk.constraint_name)
           end
 
           [drop_fks + add_fks]

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -485,7 +485,7 @@ module Generators
           ActiveRecord::Base.connection.class.name.match?(/SQLite3Adapter/) and raise ArgumentError, 'SQLite does not support foreign keys'
           ::DeclareSchema.default_generate_foreign_keys or return []
 
-          existing_fks = ::DeclareSchema::Model::ForeignKeyDefinition.for_model(model, old_table_name)
+          existing_fks = ::DeclareSchema::Model::ForeignKeyDefinition.for_model(model, old_table_name: old_table_name)
           model_fks = model.constraint_specs
 
           fks_to_drop = existing_fks - model_fks

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -425,7 +425,7 @@ module Generators
           ::DeclareSchema.default_generate_indexing or return []
 
           new_table_name = model.table_name
-          existing_indexes = ::DeclareSchema::Model::IndexDefinition.for_model(model, old_table_name)
+          existing_indexes = ::DeclareSchema::Model::IndexDefinition.for_table(old_table_name || new_table_name, model.ignore_indexes, model.connection)
           model_indexes_with_equivalents = model.index_definitions_with_primary_key
           model_indexes = model_indexes_with_equivalents.map do |i|
             if i.explicit_name.nil?

--- a/spec/lib/declare_schema/model/habtm_model_shim_spec.rb
+++ b/spec/lib/declare_schema/model/habtm_model_shim_spec.rb
@@ -10,7 +10,7 @@ require_relative '../../../../lib/declare_schema/model/habtm_model_shim'
 RSpec.describe DeclareSchema::Model::HabtmModelShim do
   let(:join_table) { "customers_users" }
   let(:foreign_keys) { ["user_id", "customer_id"] }
-  let(:table_names) { ["users", "customers"] }
+  let(:parent_table_names) { ["users", "customers"] }
 
   before do
     load File.expand_path('../prepare_testapp.rb', __dir__)
@@ -36,7 +36,7 @@ RSpec.describe DeclareSchema::Model::HabtmModelShim do
 
         expect(result).to be_a(described_class)
         expect(result.foreign_keys).to eq(foreign_keys.reverse)
-        expect(result.table_names).to eq(table_names.reverse)
+        expect(result.parent_table_names).to eq(parent_table_names.reverse)
       end
     end
   end
@@ -44,7 +44,7 @@ RSpec.describe DeclareSchema::Model::HabtmModelShim do
   describe 'instance methods' do
     let(:connection) { instance_double(ActiveRecord::Base.connection.class, "connection") }
 
-    subject { described_class.new(join_table, foreign_keys, table_names) }
+    subject { described_class.new(join_table, foreign_keys, parent_table_names) }
 
     describe '#initialize' do
       it 'stores initialization attributes' do
@@ -112,7 +112,7 @@ RSpec.describe DeclareSchema::Model::HabtmModelShim do
       let(:join_table) { "advertiser_campaigns_tracking_pixels" }
       let(:foreign_keys_and_table_names) { [["advertiser_id", "advertisers"], ["campaign_id", "campaigns"]] }
       let(:foreign_keys) { foreign_keys_and_table_names.map(&:first) }
-      let(:table_names) { foreign_keys_and_table_names.map(&:last) }
+      let(:parent_table_names) { foreign_keys_and_table_names.map(&:last) }
 
       before do
         class Table1 < ActiveRecord::Base

--- a/spec/lib/declare_schema/model/habtm_model_shim_spec.rb
+++ b/spec/lib/declare_schema/model/habtm_model_shim_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe DeclareSchema::Model::HabtmModelShim do
         expect(indexes.first.fields).to eq(foreign_keys)
         expect(indexes.first.unique).to be_truthy
         expect(indexes.last).to be_a(::DeclareSchema::Model::IndexDefinition)
-        expect(indexes.last.name).to eq('on_campaign_id')
+        expect(indexes.last.name).to eq('index_advertiser_campaigns_tracking_pixels_on_campaign_id')
         expect(indexes.last.fields).to eq([foreign_keys.last])
         expect(indexes.last.unique).to be_falsey
       end

--- a/spec/lib/declare_schema/model/habtm_model_shim_spec.rb
+++ b/spec/lib/declare_schema/model/habtm_model_shim_spec.rb
@@ -154,17 +154,10 @@ RSpec.describe DeclareSchema::Model::HabtmModelShim do
     describe '#constraint_specs' do
       it 'returns 2 foreign keys' do
         constraints = subject.constraint_specs
-        expect(constraints.size).to eq(2), constraints.inspect
-
-        expect(constraints.first).to be_a(::DeclareSchema::Model::ForeignKeyDefinition)
-        expect(constraints.first.foreign_key).to eq(foreign_keys.reverse.first)
-        expect(constraints.first.parent_table_name).to be("customers")
-        expect(constraints.first.on_delete_cascade).to be_truthy
-
-        expect(constraints.last).to be_a(::DeclareSchema::Model::ForeignKeyDefinition)
-        expect(constraints.last.foreign_key).to eq(foreign_keys.reverse.last)
-        expect(constraints.last.parent_table_name).to be("users")
-        expect(constraints.last.on_delete_cascade).to be_truthy
+        expect(constraints.map(&:key)).to eq([
+          ["customers", "customer_id", :delete],
+          ["users", "user_id", :delete]
+        ])
       end
     end
   end

--- a/spec/lib/declare_schema/model/habtm_model_shim_spec.rb
+++ b/spec/lib/declare_schema/model/habtm_model_shim_spec.rb
@@ -8,19 +8,19 @@ end
 require_relative '../../../../lib/declare_schema/model/habtm_model_shim'
 
 RSpec.describe DeclareSchema::Model::HabtmModelShim do
-  let(:join_table) { "parent_1_parent_2" }
-  let(:foreign_keys) { ["parent_1_id", "parent_2_id"] }
-  let(:foreign_key_classes) { [Parent1, Parent2] }
+  let(:join_table) { "customers_users" }
+  let(:foreign_keys) { ["user_id", "customer_id"] }
+  let(:table_names) { ["users", "customers"] }
 
   before do
     load File.expand_path('../prepare_testapp.rb', __dir__)
 
-    class Parent1 < ActiveRecord::Base
-      self.table_name = "parent_1s"
+    class User < ActiveRecord::Base
+      self.table_name = "users"
     end
 
-    class Parent2 < ActiveRecord::Base
-      self.table_name = "parent_2s"
+    class Customer < ActiveRecord::Base
+      self.table_name = "customers"
     end
   end
 
@@ -29,12 +29,14 @@ RSpec.describe DeclareSchema::Model::HabtmModelShim do
       let(:reflection) { double("reflection", join_table: join_table,
                                               foreign_key: foreign_keys.first,
                                               association_foreign_key: foreign_keys.last,
-                                              active_record: foreign_key_classes.first,
-                                              class_name: 'Parent1') }
+                                              active_record: User,
+                                              class_name: 'Customer') }
       it 'returns a new object' do
         result = described_class.from_reflection(reflection)
 
         expect(result).to be_a(described_class)
+        expect(result.foreign_keys).to eq(foreign_keys.reverse)
+        expect(result.table_names).to eq(table_names.reverse)
       end
     end
   end
@@ -42,14 +44,12 @@ RSpec.describe DeclareSchema::Model::HabtmModelShim do
   describe 'instance methods' do
     let(:connection) { instance_double(ActiveRecord::Base.connection.class, "connection") }
 
-    subject { described_class.new(join_table, foreign_keys, foreign_key_classes, connection) }
+    subject { described_class.new(join_table, foreign_keys, table_names) }
 
     describe '#initialize' do
       it 'stores initialization attributes' do
         expect(subject.join_table).to eq(join_table)
-        expect(subject.foreign_keys).to eq(foreign_keys)
-        expect(subject.foreign_key_classes).to be(foreign_key_classes)
-        expect(subject.connection).to be(connection)
+        expect(subject.foreign_keys).to eq(foreign_keys.reverse)
       end
     end
 
@@ -67,20 +67,20 @@ RSpec.describe DeclareSchema::Model::HabtmModelShim do
 
     describe '#field_specs' do
       it 'returns 2 field specs' do
-        result = subject.field_specs
-        expect(result.size).to eq(2), result.inspect
+        field_specs = subject.field_specs
+        expect(field_specs.size).to eq(2), field_specs.inspect
 
-        expect(result[foreign_keys.first]).to be_a(::DeclareSchema::Model::FieldSpec)
-        expect(result[foreign_keys.first].model).to eq(subject)
-        expect(result[foreign_keys.first].name.to_s).to eq(foreign_keys.first)
-        expect(result[foreign_keys.first].type).to eq(:integer)
-        expect(result[foreign_keys.first].position).to eq(0)
+        expect(field_specs[foreign_keys.first]).to be_a(::DeclareSchema::Model::FieldSpec)
+        expect(field_specs[foreign_keys.first].model).to eq(subject)
+        expect(field_specs[foreign_keys.first].name.to_s).to eq(foreign_keys.first)
+        expect(field_specs[foreign_keys.first].type).to eq(:integer)
+        expect(field_specs[foreign_keys.first].position).to eq(1)
 
-        expect(result[foreign_keys.last]).to be_a(::DeclareSchema::Model::FieldSpec)
-        expect(result[foreign_keys.last].model).to eq(subject)
-        expect(result[foreign_keys.last].name.to_s).to eq(foreign_keys.last)
-        expect(result[foreign_keys.last].type).to eq(:integer)
-        expect(result[foreign_keys.last].position).to eq(1)
+        expect(field_specs[foreign_keys.last]).to be_a(::DeclareSchema::Model::FieldSpec)
+        expect(field_specs[foreign_keys.last].model).to eq(subject)
+        expect(field_specs[foreign_keys.last].name.to_s).to eq(foreign_keys.last)
+        expect(field_specs[foreign_keys.last].type).to eq(:integer)
+        expect(field_specs[foreign_keys.last].position).to eq(0)
       end
     end
 
@@ -98,20 +98,21 @@ RSpec.describe DeclareSchema::Model::HabtmModelShim do
 
     describe '#index_definitions_with_primary_key' do
       it 'returns 2 index definitions' do
-        result = subject.index_definitions_with_primary_key
-        expect(result.size).to eq(2), result.inspect
+        index_definitions = subject.index_definitions_with_primary_key
+        expect(index_definitions.size).to eq(2), index_definitions.inspect
 
-        expect(result.first).to be_a(::DeclareSchema::Model::IndexDefinition)
-        expect(result.first.name).to eq('PRIMARY')
-        expect(result.first.fields).to eq(['parent_1_id', 'parent_2_id'])
-        expect(result.first.unique).to be_truthy
+        expect(index_definitions.first).to be_a(::DeclareSchema::Model::IndexDefinition)
+        expect(index_definitions.first.name).to eq('PRIMARY')
+        expect(index_definitions.first.fields).to eq(foreign_keys.reverse)
+        expect(index_definitions.first.unique).to be_truthy
       end
     end
 
     context 'when table and foreign key names are long' do
       let(:join_table) { "advertiser_campaigns_tracking_pixels" }
-      let(:foreign_keys) { ['advertiser_campaign', 'tracking_pixel'] }
-      let(:foreign_key_classes) { [Table1, Table2] }
+      let(:foreign_keys_and_table_names) { [["advertiser_id", "advertisers"], ["campaign_id", "campaigns"]] }
+      let(:foreign_keys) { foreign_keys_and_table_names.map(&:first) }
+      let(:table_names) { foreign_keys_and_table_names.map(&:last) }
 
       before do
         class Table1 < ActiveRecord::Base
@@ -124,19 +125,23 @@ RSpec.describe DeclareSchema::Model::HabtmModelShim do
       end
 
       it 'returns two index definitions and does not raise a IndexNameTooLongError' do
-        result = subject.index_definitions_with_primary_key
-        expect(result.size).to eq(2), result.inspect
-        expect(result.first).to be_a(::DeclareSchema::Model::IndexDefinition)
-        expect(result.first.name).to eq('PRIMARY')
-        expect(result.first.fields).to eq(['advertiser_campaign', 'tracking_pixel'])
-        expect(result.first.unique).to be_truthy
+        indexes = subject.index_definitions_with_primary_key
+        expect(indexes.size).to eq(2), indexes.inspect
+        expect(indexes.first).to be_a(::DeclareSchema::Model::IndexDefinition)
+        expect(indexes.first.name).to eq('PRIMARY')
+        expect(indexes.first.fields).to eq(foreign_keys)
+        expect(indexes.first.unique).to be_truthy
+        expect(indexes.last).to be_a(::DeclareSchema::Model::IndexDefinition)
+        expect(indexes.last.name).to eq('on_campaign_id')
+        expect(indexes.last.fields).to eq([foreign_keys.last])
+        expect(indexes.last.unique).to be_falsey
       end
     end
 
     describe '#index_definitions' do
       it 'returns index_definitions_with_primary_key' do
-        result = subject.index_definitions
-        expect(result.size).to eq(2), result.inspect
+        indexes = subject.index_definitions
+        expect(indexes.size).to eq(2), indexes.inspect
       end
     end
 
@@ -148,18 +153,18 @@ RSpec.describe DeclareSchema::Model::HabtmModelShim do
 
     describe '#constraint_specs' do
       it 'returns 2 foreign keys' do
-        result = subject.constraint_specs
-        expect(result.size).to eq(2), result.inspect
+        constraints = subject.constraint_specs
+        expect(constraints.size).to eq(2), constraints.inspect
 
-        expect(result.first).to be_a(::DeclareSchema::Model::ForeignKeyDefinition)
-        expect(result.first.foreign_key).to eq(foreign_keys.first)
-        expect(result.first.parent_table_name).to be(Parent1.table_name)
-        expect(result.first.on_delete_cascade).to be_truthy
+        expect(constraints.first).to be_a(::DeclareSchema::Model::ForeignKeyDefinition)
+        expect(constraints.first.foreign_key).to eq(foreign_keys.reverse.first)
+        expect(constraints.first.parent_table_name).to be("customers")
+        expect(constraints.first.on_delete_cascade).to be_truthy
 
-        expect(result.last).to be_a(::DeclareSchema::Model::ForeignKeyDefinition)
-        expect(result.last.foreign_key).to eq(foreign_keys.last)
-        expect(result.last.parent_table_name).to be(Parent2.table_name)
-        expect(result.last.on_delete_cascade).to be_truthy
+        expect(constraints.last).to be_a(::DeclareSchema::Model::ForeignKeyDefinition)
+        expect(constraints.last.foreign_key).to eq(foreign_keys.reverse.last)
+        expect(constraints.last.parent_table_name).to be("users")
+        expect(constraints.last.on_delete_cascade).to be_truthy
       end
     end
   end

--- a/spec/lib/declare_schema/model/index_definition_spec.rb
+++ b/spec/lib/declare_schema/model/index_definition_spec.rb
@@ -35,28 +35,27 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
       end
     end
 
-    describe 'instance methods' do
-      let(:model) { model_class.new }
-      subject { declared_class.new(table_name) }
+    # TODO: create model_spec.rb and move the Model specs below into it. -Colin
+    context 'Model class methods' do
+      describe '.has index_definitions' do
+        subject { model_class.index_definitions }
 
-      it 'has index_definitions' do
-        expect(model_class.index_definitions).to be_kind_of(Array)
-        expect(model_class.index_definitions.map(&:name)).to eq(['index_index_definition_test_models_on_name'])
-        expect([:name, :fields, :unique].map { |attr| model_class.index_definitions[0].send(attr)}).to eq(
-          ['index_index_definition_test_models_on_name', ['name'], false]
-        )
+        it 'returns indexes without primary key' do
+          expect(subject.map(&:to_key)).to eq([
+            ['index_index_definition_test_models_on_name', ['name'], false, nil],
+          ])
+        end
       end
 
-      it 'has index_definitions_with_primary_key' do
-        expect(model_class.index_definitions_with_primary_key).to be_kind_of(Array)
-        result = model_class.index_definitions_with_primary_key.sort_by(&:name)
-        expect(result.map(&:name)).to eq(['PRIMARY', 'index_index_definition_test_models_on_name'])
-        expect([:name, :fields, :unique].map { |attr| result[0].send(attr)}).to eq(
-          ['PRIMARY', ['id'], true]
-        )
-        expect([:name, :fields, :unique].map { |attr| result[1].send(attr)}).to eq(
-          ['index_index_definition_test_models_on_name', ['name'], false]
-        )
+      describe '.has index_definitions_with_primary_key' do
+        subject { model_class.index_definitions_with_primary_key }
+
+        it 'returns indexes with primary key' do
+          expect(subject.map(&:to_key)).to eq([
+            ['index_index_definition_test_models_on_name', ['name'], false, nil],
+            ['PRIMARY', ['id'], true, nil],
+          ])
+        end
       end
     end
 
@@ -88,19 +87,9 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
         context 'with single-column PK' do
           it 'returns the indexes for the model' do
             expect(subject.map(&:to_key)).to eq([
-              ["index_definition_test_models", ["name"].to_s, "index_definition_test_models_on_name", "true", ""],
-              ["index_definition_test_models", ["id"].to_s, "PRIMARY", "true", ""]
+              ["index_definition_test_models_on_name", ["name"], true, nil],
+              ["PRIMARY", ["id"], true, nil]
             ])
-          end
-
-          it 'returns the indexes for the model' do
-            expect(subject.size).to eq(2)
-            expect([:name, :columns, :unique].map { |attr| subject[0].send(attr) }).to eq(
-              ['index_definition_test_models_on_name', ['name'], true]
-            )
-            expect([:name, :columns, :unique].map { |attr| subject[1].send(attr) }).to eq(
-              ['PRIMARY', ['id'], true]
-            )
           end
         end
 
@@ -109,7 +98,7 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
 
           it 'returns the indexes for the model' do
             expect(subject.map(&:to_key)).to eq([
-              ["index_definition_compound_index_models", ["fk1_id", "fk2_id"].to_s, "PRIMARY", "true", ""]
+              ["PRIMARY", ["fk1_id", "fk2_id"], true, nil]
             ])
           end
         end
@@ -119,7 +108,7 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
 
           it 'skips the ignored index' do
             expect(subject.map(&:to_key)).to eq([
-              ["index_definition_test_models", ["id"].to_s, "PRIMARY", "true", ""]
+              ["PRIMARY", ["id"], true, nil]
             ])
           end
         end

--- a/spec/lib/declare_schema/model/index_definition_spec.rb
+++ b/spec/lib/declare_schema/model/index_definition_spec.rb
@@ -11,6 +11,7 @@ require_relative '../../../../lib/declare_schema/model/index_definition'
 
 RSpec.describe DeclareSchema::Model::IndexDefinition do
   let(:model_class) { IndexDefinitionTestModel }
+  let(:table_name) { model_class.table_name }
 
   context 'Using declare_schema' do
     before do
@@ -36,7 +37,7 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
 
     describe 'instance methods' do
       let(:model) { model_class.new }
-      subject { declared_class.new(model_class) }
+      subject { declared_class.new(table_name) }
 
       it 'has index_definitions' do
         expect(model_class.index_definitions).to be_kind_of(Array)
@@ -81,7 +82,7 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
       end
 
       describe 'for_model' do
-        subject { described_class.for_model(model_class) }
+          subject { described_class.for_model(model_class, nil) }
 
         context 'with single-column PK' do
           it 'returns the indexes for the model' do


### PR DESCRIPTION
Refactor `HabtmModelShim`:
- move sorting into `initialize`
- omit `connection` and `foreign_key_classes` (replace with `table_names`)

Refactor `IndexSpecification`:
- use explicit keyword args rather than `**options`
- instead of `model`, just pass in `table_name` arg (this makes the `table_name:` keyword arg unnecessary)
- address TODO by changing `fields` to `columns` (but leave alias the other way)

Refactor `ForeignKeyDefinition`:
- use explicit keyword args rather than `**options`
- instead of `model`, just pass in `foreign_key_column`, `constraint_name:`.