### PR TITLE
issue #154: shorten table name with sha256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - Unreleased
+### Fixed
+- Fix bug in default index anme when table name + __ + column suffix exceeds `DeclareSchema.max_index_and_constraint_name_length`.
+  In this case we truncate the table name and append part of its hash.
+
 ## [1.3.0] - 2023-07-10
 ### Added
 - Added `DeclareSchema.max_index_and_constraint_name_length` with default of 64.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (1.3.0)
+    declare_schema (1.3.1.colin.1)
       rails (>= 5.0)
 
 GEM

--- a/lib/declare_schema/model/index_definition.rb
+++ b/lib/declare_schema/model/index_definition.rb
@@ -66,7 +66,7 @@ module DeclareSchema
               break index_name
             end
           end or raise IndexNameTooLongError,
-                       "Index '#{index_name}' exceeds configured limit of #{DeclareSchema.max_index_and_constraint_name_length} characters."
+                       "Default index name '#{index_name}' exceeds configured limit of #{DeclareSchema.max_index_and_constraint_name_length} characters. Use the `name:` option to give it a shorter name, or adjust DeclareSchema.max_index_and_constraint_name_length if you know your database can accept longer names."
         end
 
         private

--- a/lib/declare_schema/model/index_definition.rb
+++ b/lib/declare_schema/model/index_definition.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'digest/sha2'
+
 module DeclareSchema
   module Model
     class IndexDefinition
@@ -69,12 +71,30 @@ module DeclareSchema
 
         private
 
+        SHA_SUFFIX_LENGTH = 4
+
+        def shorten_name(name, max_len)
+          if name.size <= max_len
+            name
+          else
+            name_prefix = name.first(max_len >= SHA_SUFFIX_LENGTH*2 ? (max_len - SHA_SUFFIX_LENGTH) : ((max_len + 1)/2))
+            sha = Digest::SHA256.hexdigest(name)
+            (name_prefix + sha).first(max_len)
+          end
+        end
+
         def long_index_name(table_name, columns)
           "index_#{table_name}_on_#{Array(columns).join("_and_")}"
         end
 
         def short_index_name(table_name, columns)
-          "#{table_name}__#{Array(columns).join("_")}"
+          columns_suffix = "__" + Array(columns).join('_')
+          if DeclareSchema.max_index_and_constraint_name_length.nil?
+            table_name + columns_suffix
+          else
+            max_name_len = [DeclareSchema.max_index_and_constraint_name_length - columns_suffix.length, 0].max
+            shorten_name(table_name, max_name_len) + columns_suffix
+          end
         end
       end
 

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "1.3.0"
+  VERSION = "1.3.1.colin.1"
 end

--- a/spec/lib/declare_schema/model/index_definition_spec.rb
+++ b/spec/lib/declare_schema/model/index_definition_spec.rb
@@ -133,6 +133,46 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
 
         it { is_expected.to eq("users__last_name_first_name_middle_name") }
       end
+
+      context 'with long table name' do
+        let(:table_name2) { 'user_domains_extra' }
+        {
+          34 => '__last_name_first_name_middle_name',
+          35 => 'u__last_name_first_name_middle_name',
+          36 => 'u4__last_name_first_name_middle_name',
+          37 => 'us4__last_name_first_name_middle_name',
+          38 => 'us48__last_name_first_name_middle_name',
+          39 => 'use48__last_name_first_name_middle_name',
+          40 => 'use481__last_name_first_name_middle_name',
+          41 => 'user481__last_name_first_name_middle_name',
+          42 => 'user4814__last_name_first_name_middle_name',
+          43 => 'user_4814__last_name_first_name_middle_name',
+          44 => 'user_d4814__last_name_first_name_middle_name',
+          45 => 'user_do4814__last_name_first_name_middle_name',
+          46 => 'user_dom4814__last_name_first_name_middle_name',
+          47 => 'user_doma4814__last_name_first_name_middle_name',
+          48 => 'user_domai4814__last_name_first_name_middle_name',
+          49 => 'user_domain4814__last_name_first_name_middle_name',
+          50 => 'user_domains4814__last_name_first_name_middle_name',
+          51 => 'user_domains_4814__last_name_first_name_middle_name',
+          52 => 'user_domains_extra__last_name_first_name_middle_name',
+        }.each do |len, index_name|
+          context "with max_index_and_constraint_name_length of #{len}" do
+            let(:max_index_and_constraint_name_length) { len }
+
+            it { is_expected.to eq(index_name) }
+          end
+        end
+
+        context "with max_index_and_constraint_name_length shorter than columns suffix" do
+          let(:max_index_and_constraint_name_length) { 33 }
+
+          it 'raises' do
+            expect { subject }.to raise_exception(DeclareSchema::Model::IndexDefinition::IndexNameTooLongError,
+                                                  /Index '__last_name_first_name_middle_name' exceeds configured limit of 33 characters/)
+          end
+        end
+      end
     end
   end
   # TODO: fill out remaining tests

--- a/spec/lib/declare_schema/model/index_definition_spec.rb
+++ b/spec/lib/declare_schema/model/index_definition_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
 
           it 'raises' do
             expect { subject }.to raise_exception(DeclareSchema::Model::IndexDefinition::IndexNameTooLongError,
-                                                  /Index '__last_name_first_name_middle_name' exceeds configured limit of 33 characters/)
+                                                  /Default index name '__last_name_first_name_middle_name' exceeds configured limit of 33 characters\. Use the `name:` option to give it a shorter name, or adjust DeclareSchema\.max_index_and_constraint_name_length/i)
           end
         end
       end

--- a/spec/lib/declare_schema/model/index_definition_spec.rb
+++ b/spec/lib/declare_schema/model/index_definition_spec.rb
@@ -156,6 +156,7 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
           50 => 'user_domains4814__last_name_first_name_middle_name',
           51 => 'user_domains_4814__last_name_first_name_middle_name',
           52 => 'user_domains_extra__last_name_first_name_middle_name',
+          53 => 'user_domains_extra__last_name_first_name_middle_name',
         }.each do |len, index_name|
           context "with max_index_and_constraint_name_length of #{len}" do
             let(:max_index_and_constraint_name_length) { len }


### PR DESCRIPTION
A bug came up when the table name is so long that the short default index name is still too long. To address this, we now fall back to the prefix of the table name, plus up to 4 characters of its sha256. [Slack thread](https://invoca.slack.com/archives/CRGB17J59/p1697040014363769?thread_ts=1697037804.977329&cid=CRGB17J59).

