### PR TITLE
TECH-13204/support partial (aka prefix) indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.4] - Unreleased
+## [1.4.0] - 2024-01-24
 ### Added
 - Added support for partial indexes with `length:` option.
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4] - Unreleased
+### Added
+- Added support for partial indexes with `length:` option.
+### Changed
+- Deprecate index: 'name' and unique: true|false in favor of index: { name: 'name', unique: true|false }.
+
 ## [1.3.6] - 2024-01-22
 ### Fixed
 - Add missing commits around connection: and Array check for composite declared primary key.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (1.4.0.colin.11)
+    declare_schema (1.4.0)
       rails (>= 5.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (1.3.6)
+    declare_schema (1.4.0.colin.11)
       rails (>= 5.0)
 
 GEM

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -116,6 +116,17 @@ module DeclareSchema
       # 2. declares an index on the foreign key (optional)
       # 3. declares a foreign_key constraint (optional)
       def belongs_to(name, scope = nil, **options)
+        if options[:null].in?([true, false]) && options[:optional] == options[:null]
+          STDERR.puts("[declare_schema warning] belongs_to #{name.inspect}, null: with the same value as optional: is redundant; omit null: #{options[:null]} (called from #{caller[0]})")
+        elsif !options.has_key?(:optional)
+          case options[:null]
+          when true
+            STDERR.puts("[declare_schema] belongs_to #{name.inspect}, null: true is deprecated in favor of optional: true (called from #{caller[0]})")
+          when false
+            STDERR.puts("[declare_schema] belongs_to #{name.inspect}, null: false is implied and can be omitted (called from #{caller[0]})")
+          end
+        end
+
         column_options = {}
 
         column_options[:null] = if options.has_key?(:null)
@@ -140,18 +151,18 @@ module DeclareSchema
           index_options = {} # create an index
           case index_value
           when String, Symbol
-            ActiveSupport::Deprecation.warn("belongs_to #{name.inspect}, index: 'name' is deprecated; use index: { name: 'name' } instead (in #{self.name})")
+            ActiveSupport::Deprecation.warn("[declare_schema] belongs_to #{name.inspect}, index: 'name' is deprecated; use index: { name: 'name' } instead (in #{self.name})")
             index_options[:name] = index_value.to_s
           when true
           when nil
           when Hash
             index_options = index_value
           else
-            raise ArgumentError, "belongs_to #{name.inspect}, index: must be true or false or a Hash; got #{index_value.inspect} (in #{self.name})"
+            raise ArgumentError, "[declare_schema] belongs_to #{name.inspect}, index: must be true or false or a Hash; got #{index_value.inspect} (in #{self.name})"
           end
 
           if options.has_key?(:unique)
-            ActiveSupport::Deprecation.warn("belongs_to #{name.inspect}, unique: true|false is deprecated; use index: { unique: true|false } instead (in #{self.name})")
+            ActiveSupport::Deprecation.warn("[declare_schema] belongs_to #{name.inspect}, unique: true|false is deprecated; use index: { unique: true|false } instead (in #{self.name})")
             index_options[:unique] = options.delete(:unique)
           end
 

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -115,6 +115,25 @@ module DeclareSchema
       # 1. creates a FieldSpec for the foreign key
       # 2. declares an index on the foreign key (optional)
       # 3. declares a foreign_key constraint (optional)
+      # @param name [Symbol] the name of the association to pass to super
+      # @param scope [Proc] the scope of the association to pass to super
+      # @option options [Boolean] :optional (default: false) whether the foreign key column should be nullable and whether
+      #   ActiveRecord should validate presence of the foreign key (passed through to super)
+      # @option options [Boolean] :null (default: inferred from options[:optional]) whether the foreign key column should be nullable
+      #   (`null:` should only be passed if it is the inverse of `optional:`; otherwise it is redundant)
+      # @option options [Integer] :limit (default: inferred from the primary key limit:) the limit of the foreign key column size (4 or 8)
+      # @option options [Boolean|Hash<Symbol>] :index (default: true) whether to create an index on the foreign key; can be true or false
+      #   or a hash of options to pass to the index declaration, with keys like { name: ..., unique: ... }
+      # @option options [Boolean] :allow_equivalent (default: false) whether to allow an existing index with a different name
+      # @option options [Boolean|String] :constraint (default: true) whether to create a foreign key constraint on the foreign key;
+      #   may be true or false or a string to use as the constraint name
+      # @option options [Boolean] :polymorphic (default: false) whether this is a polymorphic belongs_to with a _type column next to
+      #   the foreign key _id column (also passed through to super)
+      # @option options [Boolean] :far_end_dependent (default: nil) whether to add a dependent: :delete to the far end of the foreign key
+      #   constraint
+      # @option options [String] :foreign_type (default: "#{name}_type") the name prefix for the _type column for a polymorphic belongs_to
+      #   (passed through to super)
+      # Other options are passed through to super
       def belongs_to(name, scope = nil, **options)
         if options[:null].in?([true, false]) && options[:optional] == options[:null]
           STDERR.puts("[declare_schema warning] belongs_to #{name.inspect}, null: with the same value as optional: is redundant; omit null: #{options[:null]} (called from #{caller[0]})")

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -49,10 +49,10 @@ module DeclareSchema
     end
 
     module ClassMethods
-      def index(columns, name: nil, allow_equivalent: false, unique: false, where: nil)
+      def index(columns, name: nil, allow_equivalent: false, unique: false, where: nil, length: nil)
         index_definitions << ::DeclareSchema::Model::IndexDefinition.new(
           columns,
-          name: name, table_name: table_name, allow_equivalent: allow_equivalent, unique: unique, where: where
+          name: name, table_name: table_name, allow_equivalent: allow_equivalent, unique: unique, where: where, length: length
         )
       end
 

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -111,7 +111,7 @@ module DeclareSchema
         column_options[:default] = options.delete(:default) if options.has_key?(:default)
         if options.has_key?(:limit)
           options.delete(:limit)
-          ActiveSupport::Deprecation.warn("belongs_to limit: is deprecated since it is now inferred")
+          ActiveSupport::Deprecation.warn("belongs_to #{name.inspect}, limit: is deprecated since it is now inferred")
         end
 
         # index: true means create an index on the foreign key
@@ -125,18 +125,18 @@ module DeclareSchema
           index_options = {} # create an index
           case index_value
           when String, Symbol
-            Kernel.warn("belongs_to index: 'name' is deprecated; use index: { name: 'name' } instead (in #{name})")
+            ActiveSupport::Deprecation.warn("belongs_to #{name.inspect}, index: 'name' is deprecated; use index: { name: 'name' } instead (in #{self.name})")
             index_options[:name] = index_value.to_s
           when true
           when nil
           when Hash
             index_options = index_value
           else
-            raise ArgumentError, "belongs_to index: must be true or false or a Hash; got #{index_value.inspect} (in #{name})"
+            raise ArgumentError, "belongs_to #{name.inspect}, index: must be true or false or a Hash; got #{index_value.inspect} (in #{self.name})"
           end
 
           if options.has_key?(:unique)
-            Kernel.warn("belongs_to unique: true|false is deprecated; use index: { unique: true|false } instead (in #{name})")
+            ActiveSupport::Deprecation.warn("belongs_to #{name.inspect}, unique: true|false is deprecated; use index: { unique: true|false } instead (in #{self.name})")
             index_options[:unique] = options.delete(:unique)
           end
 

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -118,14 +118,15 @@ module DeclareSchema
         # index: false means do not create an index on the foreign key
         # index: { ... } means create an index on the foreign key with the given options
         index_value = options.delete(:index)
-        if index_value != false || options.has_key?(:unique) || options.has_key?(:allow_equivalent)
-          index_options = {} # truthy iff we want an index
+        if index_value == false # don't create an index
+          options.delete(:unique)
+          options.delete(:allow_equivalent)
+        else
+          index_options = {} # create an index
           case index_value
           when String, Symbol
             Kernel.warn("belongs_to index: 'name' is deprecated; use index: { name: 'name' } instead (in #{name})")
             index_options[:name] = index_value.to_s
-          when false
-            raise ArgumentError, "belongs_to index: false contradicts others options #{options.inspect} (in #{name})"
           when true
           when nil
           when Hash

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -115,24 +115,30 @@ module DeclareSchema
         end
 
         # index: true means create an index on the foreign key
-        # index: :name|'name' is the same as above, but explicitly name the index 'name'
         # index: false means do not create an index on the foreign key
+        # index: { ... } means create an index on the foreign key with the given options
         index_value = options.delete(:index)
-        if index_value == false # don't create an index
-          options.delete(:unique)
-          options.delete(:allow_equivalent)
-        else
-          index_options = {} # create an index
+        if index_value != false || options.has_key?(:unique) || options.has_key?(:allow_equivalent)
+          index_options = {} # truthy iff we want an index
           case index_value
           when String, Symbol
+            Kernel.warn("belongs_to index: 'name' is deprecated; use index: { name: 'name' } instead (in #{name})")
             index_options[:name] = index_value.to_s
+          when false
+            raise ArgumentError, "belongs_to index: false contradicts others options #{options.inspect} (in #{name})"
           when true
           when nil
+          when Hash
+            index_options = index_value
           else
-            raise ArgumentError, "belongs_to #{name.inspect}, index: must be true|false|String|Symbol; got #{index_value.inspect} (in #{name})"
+            raise ArgumentError, "belongs_to index: must be true or false or a Hash; got #{index_value.inspect} (in #{name})"
           end
 
-          index_options[:unique] = options.delete(:unique) if options.has_key?(:unique)
+          if options.has_key?(:unique)
+            Kernel.warn("belongs_to unique: true|false is deprecated; use index: { unique: true|false } instead (in #{name})")
+            index_options[:unique] = options.delete(:unique)
+          end
+
           index_options[:allow_equivalent] = options.delete(:allow_equivalent) if options.has_key?(:allow_equivalent)
         end
 

--- a/lib/declare_schema/model/index_definition.rb
+++ b/lib/declare_schema/model/index_definition.rb
@@ -18,7 +18,7 @@ module DeclareSchema
 
       def initialize(columns, table_name:, name: nil, allow_equivalent: false, unique: false, where: nil, length: nil)
         @table_name = table_name
-        @name = name || self.class.default_index_name(table_name, columns)
+        @name = (name || self.class.default_index_name(table_name, columns)).to_s
         @columns = Array.wrap(columns).map(&:to_s)
         @explicit_name = @name if !allow_equivalent
         unique.in?([false, true]) or raise ArgumentError, "unique must be true or false: got #{unique.inspect}"

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "1.3.6"
+  VERSION = "1.4.0.colin.10"
 end

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "1.4.0.colin.11"
+  VERSION = "1.4.0"
 end

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "1.4.0.colin.10"
+  VERSION = "1.4.0.colin.11"
 end

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -538,16 +538,16 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
       Advert.index_definitions.delete_if { |spec| spec.fields == ["title"] }
 
-      # The available options for the index function are :unique, :name, and :where.
+      # The available options for the index function are :unique, :name, :where, and :length.
 
       class Advert < ActiveRecord::Base
-        index :title, unique: false, name: 'my_index'
+        index :title, unique: false, name: 'my_index', length: 10
       end
 
       expect(Generators::DeclareSchema::Migration::Migrator.run).to(
         migrate_up(<<~EOS.strip)
           add_column :adverts, :title, :string, limit: 250, null: true#{charset_and_collation}
-          add_index :adverts, [:title], name: :my_index
+          add_index :adverts, [:title], name: :my_index, length: { title: 10 }
         EOS
       )
 

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -414,7 +414,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
       # You can specify the index name with index: 'name' [deprecated]
 
-      expect(Kernel).to receive(:warn).with(/belongs_to index: 'name' is deprecated; use index: \{ name: 'name' \} instead/i)
+      expect(ActiveSupport::Deprecation).to receive(:warn).with(/belongs_to :category, index: 'name' is deprecated; use index: \{ name: 'name' \} instead/i)
 
       class Category < ActiveRecord::Base; end
       class Advert < ActiveRecord::Base
@@ -487,8 +487,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
       # You can add an index to a field definition
 
-      expect(Kernel).to receive(:warn).with(/belongs_to index: 'name' is deprecated; use index: \{ name: 'name' \} instead/i)
-      expect(Kernel).to receive(:warn).with(/belongs_to unique: true\|false is deprecated; use index: \{ unique: true\|false \} instead/i)
+      expect(ActiveSupport::Deprecation).to receive(:warn).with(/belongs_to :category, index: 'name' is deprecated; use index: \{ name: 'name' \} instead/i)
+      expect(ActiveSupport::Deprecation).to receive(:warn).with(/belongs_to :category, unique: true\|false is deprecated; use index: \{ unique: true\|false \} instead/i)
 
       class Advert < ActiveRecord::Base
         declare_schema do
@@ -1200,7 +1200,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
           end
 
           it 'deprecates limit:' do
-            expect(ActiveSupport::Deprecation).to receive(:warn).with("belongs_to limit: is deprecated since it is now inferred")
+            expect(ActiveSupport::Deprecation).to receive(:warn).with("belongs_to :ad_category, limit: is deprecated since it is now inferred")
             eval <<~EOS
               class UsingLimit < ActiveRecord::Base
                 declare_schema { }

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -412,12 +412,34 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       Advert.index_definitions.delete_if { |spec| spec.fields == ["category_id"] }
       Advert.constraint_definitions.delete_if { |spec| spec.foreign_key_column == "category_id" }
 
-      # You can specify the index name with index: 'name'
+      # You can specify the index name with index: 'name' [deprecated]
+
+      expect(Kernel).to receive(:warn).with(/belongs_to index: 'name' is deprecated; use index: \{ name: 'name' \} instead/i)
 
       class Category < ActiveRecord::Base; end
       class Advert < ActiveRecord::Base
         declare_schema { }
         belongs_to :category, index: 'my_index'
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :category_id, :integer, limit: 8, null: false
+          add_index :adverts, [:category_id], name: :my_index
+          #{"add_foreign_key :adverts, :categories, column: :category_id, name: :my_index" if defined?(Mysql2)}
+        EOS
+      )
+
+      Advert.field_specs.delete(:category_id)
+      Advert.index_definitions.delete_if { |spec| spec.fields == ["category_id"] }
+      Advert.constraint_definitions.delete_if { |spec| spec.foreign_key_column == "category_id" }
+
+      # You can specify the index name with index: { name: }'name', unique: true|false }
+
+      class Category < ActiveRecord::Base; end
+      class Advert < ActiveRecord::Base
+        declare_schema { }
+        belongs_to :category, index: { name: 'my_index', unique: false }
       end
 
       expect(Generators::DeclareSchema::Migration::Migrator.run).to(
@@ -464,6 +486,9 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       ### Indices
 
       # You can add an index to a field definition
+
+      expect(Kernel).to receive(:warn).with(/belongs_to index: 'name' is deprecated; use index: \{ name: 'name' \} instead/i)
+      expect(Kernel).to receive(:warn).with(/belongs_to unique: true\|false is deprecated; use index: \{ unique: true\|false \} instead/i)
 
       class Advert < ActiveRecord::Base
         declare_schema do

--- a/spec/lib/declare_schema/model/index_definition_spec.rb
+++ b/spec/lib/declare_schema/model/index_definition_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
           it 'returns the indexes for the model' do
             expect(subject.map(&:to_key)).to eq([
               ["index_definition_test_models_on_name", ["name"], { unique: true, where: nil, length: nil }],
-              (["index_definition_test_models_on_name_partial", ["name"], { unique: false, where: nil, length: 10 }] if defined?(Mysql2)),
+              (["index_definition_test_models_on_name_partial", ["name"], { unique: false, where: nil, length: { name: 10 } }] if defined?(Mysql2)),
               ["PRIMARY", ["id"], { unique: true, where: nil, length: nil }]
             ].compact)
           end
@@ -185,7 +185,7 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
 
           it 'skips the ignored index' do
             expect(subject.map(&:to_key)).to eq([
-              (["index_definition_test_models_on_name_partial", ["name"], { unique: false, where: nil, length: 10 }] if defined?(Mysql2)),
+              (["index_definition_test_models_on_name_partial", ["name"], { unique: false, where: nil, length: { name: 10 } }] if defined?(Mysql2)),
               ["PRIMARY", ["id"], { length: nil, unique: true, where: nil }]
             ].compact)
           end


### PR DESCRIPTION
## [1.4] - Unreleased
### Added
- Added support for partial indexes with `length:` option.
### Changed
- Deprecate `index: 'name'` and `unique: true|false` in favor of `index: { name: 'name', unique: true|false }`.

Note: README refactor is entirely over here, since it was so interleaved.
