### PR TITLE
TECH-13772: fix MySQL 8 where charset "utf8" is normalized to "utf8mb3" and collation "utf8_..." is normalized to "utf8mb3_..."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.3] - Unreleased
+## [1.3.3] - 2023-01-17
 ### Fixed
 - Fix a MySQL 8 bug where MySQL 8+ renames charset 'utf8' to 'utf8mb3' and collation 'utf8_general_ci' to
   'utf8mb3_unicode_ci'.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.3] - Unreleased
+### Fixed
+- Fix a MySQL 8 bug where MySQL 8+ renames charset 'utf8' to 'utf8mb3' and collation 'utf8_general_ci' to
+  'utf8mb3_unicode_ci'.
+
 ## [1.3.2] - 2024-01-12
 ### Fixed
 - Fix bug in migrator when table option definitions differ

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (1.3.2)
+    declare_schema (1.3.3.colin.1)
       rails (>= 5.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (1.3.3.colin.1)
+    declare_schema (1.3.3)
       rails (>= 5.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -213,6 +213,9 @@ turn all tables into `utf8mb4` supporting tables:
 DeclareSchema.default_charset   = "utf8mb4"
 DeclareSchema.default_collation = "utf8mb4_bin"
 ```
+Note: MySQL 8+ aliases charset 'utf8' to 'utf8mb3', and 'utf8_general_ci' to 'utf8mb3_unicode_ci',
+so when running on MySQL 8+, those aliases will be applied by `DeclareSchema`.
+
 #### db:migrate Command
 `declare_schema` can run the migration once it is generated, if the `--migrate` option is passed.
 If not, it will display the command to run later. By default this command is

--- a/lib/declare_schema.rb
+++ b/lib/declare_schema.rb
@@ -64,22 +64,19 @@ module DeclareSchema
     end
 
     def normalize_charset(charset)
-      if mysql_version && mysql_version >= SEMVER_8
-        if charset == 'utf8'
-          'utf8mb3'
-        end
-      end || charset
+      if mysql_version && mysql_version >= SEMVER_8 && charset == 'utf8'
+        'utf8mb3'
+      else
+        charset
+      end
     end
 
     def normalize_collation(collation)
       if mysql_version && mysql_version >= SEMVER_8
-        case collation
-        when 'utf8_general'
-          'utf8mb3_unicode'
-        when 'utf8_general_ci'
-          'utf8mb3_unicode_ci'
-        end
-      end || collation
+        collation.sub(/\Autf8_/, 'utf8mb3_')
+      else
+        collation
+      end
     end
 
     def default_charset=(charset)

--- a/lib/declare_schema.rb
+++ b/lib/declare_schema.rb
@@ -73,7 +73,10 @@ module DeclareSchema
 
     def normalize_collation(collation)
       if mysql_version && mysql_version >= SEMVER_8
-        if collation == 'utf8_general_ci'
+        case collation
+        when 'utf8_general'
+          'utf8mb3_unicode'
+        when 'utf8_general_ci'
           'utf8mb3_unicode_ci'
         end
       end || collation

--- a/lib/declare_schema.rb
+++ b/lib/declare_schema.rb
@@ -3,6 +3,7 @@
 require 'active_support'
 require 'active_support/all'
 require_relative 'declare_schema/version'
+require 'rubygems/version'
 
 ActiveSupport::Dependencies.autoload_paths |= [__dir__]
 
@@ -21,6 +22,8 @@ module DeclareSchema
     text:     String
   }.freeze
 
+  SEMVER_8 = Gem::Version.new('8.0.0').freeze
+
   @default_charset               = "utf8mb4"
   @default_collation             = "utf8mb4_bin"
   @default_text_limit            = 0xffff_ffff
@@ -32,6 +35,7 @@ module DeclareSchema
   @max_index_and_constraint_name_length = 64  # limit for MySQL
 
   class << self
+    attr_writer :mysql_version
     attr_reader :default_charset, :default_collation, :default_text_limit, :default_string_limit, :default_null,
                 :default_generate_foreign_keys, :default_generate_indexing, :db_migrate_command,
                 :max_index_and_constraint_name_length
@@ -47,14 +51,42 @@ module DeclareSchema
       end
     end
 
+    def mysql_version
+      if defined?(@mysql_version)
+        @mysql_version
+      else
+        @mysql_version =
+          if ActiveRecord::Base.connection.class.name.match?(/mysql/i)
+            version_string = ActiveRecord::Base.connection.select_value('SELECT VERSION()')
+            Gem::Version.new(version_string)
+          end
+      end
+    end
+
+    def normalize_charset(charset)
+      if mysql_version && mysql_version >= SEMVER_8
+        if charset == 'utf8'
+          'utf8mb3'
+        end
+      end || charset
+    end
+
+    def normalize_collation(collation)
+      if mysql_version && mysql_version >= SEMVER_8
+        if collation == 'utf8_general_ci'
+          'utf8mb3_unicode_ci'
+        end
+      end || collation
+    end
+
     def default_charset=(charset)
       charset.is_a?(String) or raise ArgumentError, "charset must be a string (got #{charset.inspect})"
-      @default_charset = charset
+      @default_charset = normalize_charset(charset)
     end
 
     def default_collation=(collation)
       collation.is_a?(String) or raise ArgumentError, "collation must be a string (got #{collation.inspect})"
-      @default_collation = collation
+      @default_collation = normalize_collation(collation)
     end
 
     def default_text_limit=(text_limit)

--- a/lib/declare_schema/model/field_spec.rb
+++ b/lib/declare_schema/model/field_spec.rb
@@ -107,7 +107,9 @@ module DeclareSchema
         if @type.in?([:text, :string])
           if ActiveRecord::Base.connection.class.name.match?(/mysql/i)
             @options[:charset]   ||= model._table_options&.[](:charset)   || ::DeclareSchema.default_charset
+            @options[:charset] = DeclareSchema.normalize_charset(@options[:charset])
             @options[:collation] ||= model._table_options&.[](:collation) || ::DeclareSchema.default_collation
+            @options[:collation] = DeclareSchema.normalize_collation(@options[:collation])
           else
             @options.delete(:charset)
             @options.delete(:collation)

--- a/lib/declare_schema/model/table_options_definition.rb
+++ b/lib/declare_schema/model/table_options_definition.rb
@@ -50,7 +50,17 @@ module DeclareSchema
 
       def initialize(table_name, **table_options)
         @table_name    = table_name
-        @table_options = table_options
+        @table_options = table_options.each_with_object({}) do |(k, v),result|
+          result[k] =
+            case k
+            when :charset
+              DeclareSchema.normalize_charset(v)
+            when :collation
+              DeclareSchema.normalize_collation(v)
+            else
+              v
+            end
+        end
       end
 
       def to_key

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "1.3.3.colin.1"
+  VERSION = "1.3.3"
 end

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "1.3.2"
+  VERSION = "1.3.3.colin.1"
 end

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -5,6 +5,11 @@ begin
 rescue LoadError
 end
 
+begin
+  require 'sqlite3'
+rescue LoadError
+end
+
 RSpec.describe DeclareSchema::Model::FieldSpec do
   let(:model) { double('model', _table_options: {}, _declared_primary_key: 'id') }
   let(:col_spec) { double('col_spec', type: :string) }
@@ -58,8 +63,23 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
         end
       end
 
-      it 'raises error when default_string_limit option is nil when not explicitly set in field spec' do
-        if defined?(Mysql2)
+      if defined?(Mysql2)
+        context 'when running on MySQL 8.0' do
+          around do |spec|
+            DeclareSchema.mysql_version = '8.0.21'
+            spec.run
+          ensure
+            DeclareSchema.remove_instance_variable('@mysql_version') rescue nil
+          end
+
+          it 'normalizes charset and collation' do
+            subject = described_class.new(model, :title, :string, limit: 100, null: true, charset: 'utf8', collation: 'utf8_general', position: 0)
+
+            expect(subject.schema_attributes(col_spec)).to eq(type: :string, limit: 100, null: true, charset: 'utf8mb3', collation: 'utf8mb3_unicode')
+          end
+        end
+
+        it 'raises error when default_string_limit option is nil when not explicitly set in field spec' do
           expect(::DeclareSchema).to receive(:default_string_limit) { nil }
           expect do
             described_class.new(model, :title, :string, null: true, charset: 'utf8mb4', position: 0)

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
       if defined?(Mysql2)
         context 'when running on MySQL 8.0' do
           around do |spec|
-            DeclareSchema.mysql_version = '8.0.21'
+            DeclareSchema.mysql_version = Gem::Version.new('8.0.21')
             spec.run
           ensure
             DeclareSchema.remove_instance_variable('@mysql_version') rescue nil

--- a/spec/lib/declare_schema/field_spec_spec.rb
+++ b/spec/lib/declare_schema/field_spec_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe DeclareSchema::Model::FieldSpec do
           it 'normalizes charset and collation' do
             subject = described_class.new(model, :title, :string, limit: 100, null: true, charset: 'utf8', collation: 'utf8_general', position: 0)
 
-            expect(subject.schema_attributes(col_spec)).to eq(type: :string, limit: 100, null: true, charset: 'utf8mb3', collation: 'utf8mb3_unicode')
+            expect(subject.schema_attributes(col_spec)).to eq(type: :string, limit: 100, null: true, charset: 'utf8mb3', collation: 'utf8mb3_general')
           end
         end
 

--- a/spec/lib/declare_schema/model/table_options_definition_spec.rb
+++ b/spec/lib/declare_schema/model/table_options_definition_spec.rb
@@ -9,6 +9,8 @@ require_relative '../../../../lib/declare_schema/model/table_options_definition'
 
 RSpec.describe DeclareSchema::Model::TableOptionsDefinition do
   let(:model_class) { TableOptionsDefinitionTestModel }
+  let(:charset) { DeclareSchema.normalize_charset('utf8') }
+  let(:collation) { DeclareSchema.normalize_collation('utf8_general') } # adapt so that tests will pass on MySQL 5.7 or 8+
 
   context 'Using declare_schema' do
     before do
@@ -27,12 +29,12 @@ RSpec.describe DeclareSchema::Model::TableOptionsDefinition do
 
       describe '#to_key' do
         subject { model.to_key }
-        it { should eq(['table_options_definition_test_models', '{:charset=>"utf8", :collation=>"utf8_general"}']) }
+        it { is_expected.to eq(['table_options_definition_test_models', "{:charset=>#{charset.inspect}, :collation=>#{collation.inspect}}"]) }
       end
 
       describe '#settings' do
         subject { model.settings }
-        it { should eq("CHARACTER SET utf8 COLLATE utf8_general") }
+        it { is_expected.to eq("CHARACTER SET #{charset} COLLATE #{collation}") }
 
         if defined?(Mysql2)
           context 'when running in MySQL 8' do
@@ -43,11 +45,11 @@ RSpec.describe DeclareSchema::Model::TableOptionsDefinition do
               DeclareSchema.remove_instance_variable('@mysql_version') rescue nil
             end
 
-            it { should eq("CHARACTER SET utf8mb3 COLLATE utf8mb3_general") }
+            it { is_expected.to eq("CHARACTER SET utf8mb3 COLLATE utf8mb3_general") }
 
             context 'when _ci collation' do
               let(:table_options) { { charset: "utf8", collation: "utf8_general_ci"} }
-              it { should eq("CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci") }
+              it { is_expected.to eq("CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci") }
             end
           end
         end
@@ -55,17 +57,17 @@ RSpec.describe DeclareSchema::Model::TableOptionsDefinition do
 
       describe '#hash' do
         subject { model.hash }
-        it { should eq(['table_options_definition_test_models', '{:charset=>"utf8", :collation=>"utf8_general"}'].hash) }
+        it { is_expected.to eq(['table_options_definition_test_models', "{:charset=>#{charset.inspect}, :collation=>#{collation.inspect}}"].hash) }
       end
 
       describe '#to_s' do
         subject { model.to_s }
-        it { should eq("CHARACTER SET utf8 COLLATE utf8_general") }
+        it { is_expected.to eq("CHARACTER SET #{charset} COLLATE #{collation}") }
       end
 
       describe '#alter_table_statement' do
         subject { model.alter_table_statement }
-        it { should match(/execute "ALTER TABLE .*table_options_definition_test_models.* CHARACTER SET utf8 COLLATE utf8_general"/) }
+        it { is_expected.to match(/execute "ALTER TABLE .*table_options_definition_test_models.* CHARACTER SET #{charset} COLLATE #{collation}"/) }
       end
     end
 
@@ -85,7 +87,7 @@ RSpec.describe DeclareSchema::Model::TableOptionsDefinition do
             generate_migrations '-n', '-m'
           end
 
-          it { should eq(described_class.new(model_class.table_name, **options)) }
+          it { is_expected.to eq(described_class.new(model_class.table_name, **options)) }
         end
       end
     end

--- a/spec/lib/declare_schema/model/table_options_definition_spec.rb
+++ b/spec/lib/declare_schema/model/table_options_definition_spec.rb
@@ -43,11 +43,11 @@ RSpec.describe DeclareSchema::Model::TableOptionsDefinition do
               DeclareSchema.remove_instance_variable('@mysql_version') rescue nil
             end
 
-            it { should eq("CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode") }
+            it { should eq("CHARACTER SET utf8mb3 COLLATE utf8mb3_general") }
 
             context 'when _ci collation' do
               let(:table_options) { { charset: "utf8", collation: "utf8_general_ci"} }
-              it { should eq("CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci") }
+              it { should eq("CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci") }
             end
           end
         end

--- a/spec/lib/declare_schema/model/table_options_definition_spec.rb
+++ b/spec/lib/declare_schema/model/table_options_definition_spec.rb
@@ -34,19 +34,21 @@ RSpec.describe DeclareSchema::Model::TableOptionsDefinition do
         subject { model.settings }
         it { should eq("CHARACTER SET utf8 COLLATE utf8_general") }
 
-        context 'when running in MySQL 8' do
-          around do |spec|
-            DeclareSchema.mysql_version = '8.0.21'
-            spec.run
-          ensure
-            DeclareSchema.remove_instance_variable('@mysql_version') rescue nil
-          end
+        if defined?(Mysql2)
+          context 'when running in MySQL 8' do
+            around do |spec|
+              DeclareSchema.mysql_version = Gem::Version.new('8.0.21')
+              spec.run
+            ensure
+              DeclareSchema.remove_instance_variable('@mysql_version') rescue nil
+            end
 
-          it { should eq("CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode") }
+            it { should eq("CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode") }
 
-          context 'when _ci collation' do
-            let(:table_options) { { charset: "utf8", collation: "utf8_general_ci"} }
-            it { should eq("CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci") }
+            context 'when _ci collation' do
+              let(:table_options) { { charset: "utf8", collation: "utf8_general_ci"} }
+              it { should eq("CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci") }
+            end
           end
         end
       end

--- a/spec/lib/declare_schema/model/table_options_definition_spec.rb
+++ b/spec/lib/declare_schema/model/table_options_definition_spec.rb
@@ -33,6 +33,22 @@ RSpec.describe DeclareSchema::Model::TableOptionsDefinition do
       describe '#settings' do
         subject { model.settings }
         it { should eq("CHARACTER SET utf8 COLLATE utf8_general") }
+
+        context 'when running in MySQL 8' do
+          around do |spec|
+            DeclareSchema.mysql_version = '8.0.21'
+            spec.run
+          ensure
+            DeclareSchema.remove_instance_variable('@mysql_version') rescue nil
+          end
+
+          it { should eq("CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode") }
+
+          context 'when _ci collation' do
+            let(:table_options) { { charset: "utf8", collation: "utf8_general_ci"} }
+            it { should eq("CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci") }
+          end
+        end
       end
 
       describe '#hash' do

--- a/spec/lib/declare_schema_spec.rb
+++ b/spec/lib/declare_schema_spec.rb
@@ -69,7 +69,13 @@ RSpec.describe DeclareSchema do
         described_class.remove_instance_variable('@mysql_version')
       end
 
-      context 'when explicitly set' do
+      context 'when explicitly set without _ci' do
+        before { described_class.default_collation = "utf8_general" }
+        after  { described_class.default_collation = "utf8mb4_bin" }
+        it     { is_expected.to eq("utf8mb3_unicode") }
+      end
+
+      context 'when explicitly set with _ci' do
         before { described_class.default_collation = "utf8_general_ci" }
         after  { described_class.default_collation = "utf8mb4_bin" }
         it     { is_expected.to eq("utf8mb3_unicode_ci") }

--- a/spec/lib/declare_schema_spec.rb
+++ b/spec/lib/declare_schema_spec.rb
@@ -8,10 +8,34 @@ RSpec.describe DeclareSchema do
       it { is_expected.to eq("utf8mb4") }
     end
 
-    context 'when explicitly set' do
-      before { described_class.default_charset = "utf8" }
-      after  { described_class.default_charset = "utf8mb4" }
-      it     { is_expected.to eq("utf8") }
+    context 'when running on MySQL 5.7' do
+      around do |spec|
+        described_class.mysql_version = '5.7.48'
+        spec.run
+      ensure
+        described_class.remove_instance_variable('@mysql_version') rescue nil
+      end
+
+      context 'when explicitly set' do
+        before { described_class.default_charset = "utf8" }
+        after  { described_class.default_charset = "utf8mb4" }
+        it     { is_expected.to eq("utf8") }
+      end
+    end
+
+    context 'when running on MySQL 8.0' do
+      around do |spec|
+        described_class.mysql_version = '8.0.21'
+        spec.run
+      ensure
+        described_class.remove_instance_variable('@mysql_version') rescue nil
+      end
+
+      context 'when explicitly set' do
+        before { described_class.default_charset = "utf8" }
+        after  { described_class.default_charset = "utf8mb4" }
+        it     { is_expected.to eq("utf8mb3") }
+      end
     end
   end
 
@@ -22,10 +46,34 @@ RSpec.describe DeclareSchema do
       it { is_expected.to eq("utf8mb4_bin") }
     end
 
-    context 'when explicitly set' do
-      before { described_class.default_collation = "utf8mb4_general_ci" }
-      after  { described_class.default_collation = "utf8mb4_bin" }
-      it     { is_expected.to eq("utf8mb4_general_ci") }
+    context 'when running on MySQL 5.7' do
+      around do |spec|
+        described_class.mysql_version = '5.7.48'
+        spec.run
+      ensure
+        described_class.remove_instance_variable('@mysql_version')
+      end
+
+      context 'when explicitly set' do
+        before { described_class.default_collation = "utf8_general_ci" }
+        after  { described_class.default_collation = "utf8mb4_bin" }
+        it     { is_expected.to eq("utf8_general_ci") }
+      end
+    end
+
+    context 'when running on MySQL 8.0' do
+      around do |spec|
+        described_class.mysql_version = '8.0.21'
+        spec.run
+      ensure
+        described_class.remove_instance_variable('@mysql_version')
+      end
+
+      context 'when explicitly set' do
+        before { described_class.default_collation = "utf8_general_ci" }
+        after  { described_class.default_collation = "utf8mb4_bin" }
+        it     { is_expected.to eq("utf8mb3_unicode_ci") }
+      end
     end
   end
 

--- a/spec/lib/declare_schema_spec.rb
+++ b/spec/lib/declare_schema_spec.rb
@@ -72,13 +72,13 @@ RSpec.describe DeclareSchema do
       context 'when explicitly set without _ci' do
         before { described_class.default_collation = "utf8_general" }
         after  { described_class.default_collation = "utf8mb4_bin" }
-        it     { is_expected.to eq("utf8mb3_unicode") }
+        it     { is_expected.to eq("utf8mb3_general") }
       end
 
       context 'when explicitly set with _ci' do
         before { described_class.default_collation = "utf8_general_ci" }
         after  { described_class.default_collation = "utf8mb4_bin" }
-        it     { is_expected.to eq("utf8mb3_unicode_ci") }
+        it     { is_expected.to eq("utf8mb3_general_ci") }
       end
     end
   end

--- a/spec/lib/declare_schema_spec.rb
+++ b/spec/lib/declare_schema_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DeclareSchema do
 
     context 'when running on MySQL 5.7' do
       around do |spec|
-        described_class.mysql_version = '5.7.48'
+        described_class.mysql_version = Gem::Version.new('5.7.48')
         spec.run
       ensure
         described_class.remove_instance_variable('@mysql_version') rescue nil
@@ -25,7 +25,7 @@ RSpec.describe DeclareSchema do
 
     context 'when running on MySQL 8.0' do
       around do |spec|
-        described_class.mysql_version = '8.0.21'
+        described_class.mysql_version = Gem::Version.new('8.0.21')
         spec.run
       ensure
         described_class.remove_instance_variable('@mysql_version') rescue nil
@@ -48,7 +48,7 @@ RSpec.describe DeclareSchema do
 
     context 'when running on MySQL 5.7' do
       around do |spec|
-        described_class.mysql_version = '5.7.48'
+        described_class.mysql_version = Gem::Version.new('5.7.48')
         spec.run
       ensure
         described_class.remove_instance_variable('@mysql_version')
@@ -63,7 +63,7 @@ RSpec.describe DeclareSchema do
 
     context 'when running on MySQL 8.0' do
       around do |spec|
-        described_class.mysql_version = '8.0.21'
+        described_class.mysql_version = Gem::Version.new('8.0.21')
         spec.run
       ensure
         described_class.remove_instance_variable('@mysql_version')

--- a/spec/lib/generators/declare_schema/migration/migrator_spec.rb
+++ b/spec/lib/generators/declare_schema/migration/migrator_spec.rb
@@ -12,6 +12,8 @@ module Generators
     module Migration
       RSpec.describe Migrator do
         subject { described_class.new }
+        let(:charset) { ::DeclareSchema.normalize_charset('utf8') }
+        let(:collation) { ::DeclareSchema.normalize_collation('utf8_general') } # adapt so that tests will pass on MySQL 5.7 or 8+
 
         describe '#before_generating_migration' do
           it 'requires a block be passed' do
@@ -29,7 +31,7 @@ module Generators
           context 'when explicitly set' do
             before { described_class.default_charset = "utf8" }
             after  { described_class.default_charset = "utf8mb4" }
-            it     { should eq("utf8") }
+            it     { should eq(charset) }
           end
 
           it 'should output deprecation warning' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
-require "bundler/setup"
-require "declare_schema"
-require "climate_control"
+require 'bundler/setup'
+require 'declare_schema'
+require 'climate_control'
+require 'pry'
 
 require_relative "./support/acceptance_spec_helpers"
 


### PR DESCRIPTION
## [1.3.3] - Unreleased
### Fixed
- Fix a MySQL 8 bug where MySQL 8+ renames charset 'utf8' to 'utf8mb3' and collation 'utf8_general_ci' to
  'utf8mb3_general_ci'.

This fix is applied in 3 places:
1. if specified globally in `DeclareSchema.default_charset/default_collation `;
2. if `charset` or `collation` is specified on a table;
3. if `charset` or `collation` is specified on a column