### PR TITLE
TECH-13204/make default config lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.5] - 2024-01-22
+### Fixed
+- Make `default_charset=` and `default_collation=` lazy so they don't use the database connection to check the
+  MySQL version. Instead, that is checked the first time `default_charset` or `default_collation` is called.
+
 ## [1.3.4] - 2024-01-18
 ### Fixed
 - Add test for migrating `has_and_belongs_to_many` associations and fix them to properly declare their

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (1.3.4)
+    declare_schema (1.3.5.colin.1)
       rails (>= 5.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (1.3.5.colin.1)
+    declare_schema (1.3.5)
       rails (>= 5.0)
 
 GEM

--- a/lib/declare_schema.rb
+++ b/lib/declare_schema.rb
@@ -36,7 +36,7 @@ module DeclareSchema
 
   class << self
     attr_writer :mysql_version
-    attr_reader :default_charset, :default_collation, :default_text_limit, :default_string_limit, :default_null,
+    attr_reader :default_text_limit, :default_string_limit, :default_null,
                 :default_generate_foreign_keys, :default_generate_indexing, :db_migrate_command,
                 :max_index_and_constraint_name_length
 
@@ -81,12 +81,22 @@ module DeclareSchema
 
     def default_charset=(charset)
       charset.is_a?(String) or raise ArgumentError, "charset must be a string (got #{charset.inspect})"
-      @default_charset = normalize_charset(charset)
+      @default_charset_before_normalization = charset
+      @default_charset = nil
+    end
+
+    def default_charset
+      @default_charset || normalize_charset(@default_charset_before_normalization)
     end
 
     def default_collation=(collation)
       collation.is_a?(String) or raise ArgumentError, "collation must be a string (got #{collation.inspect})"
-      @default_collation = normalize_collation(collation)
+      @default_collation_before_normalization = collation
+      @default_collation = nil
+    end
+
+    def default_collation
+      @default_collation || normalize_collation(@default_collation_before_normalization)
     end
 
     def default_text_limit=(text_limit)

--- a/lib/declare_schema.rb
+++ b/lib/declare_schema.rb
@@ -86,7 +86,7 @@ module DeclareSchema
     end
 
     def default_charset
-      @default_charset || normalize_charset(@default_charset_before_normalization)
+      @default_charset ||= normalize_charset(@default_charset_before_normalization)
     end
 
     def default_collation=(collation)
@@ -96,7 +96,7 @@ module DeclareSchema
     end
 
     def default_collation
-      @default_collation || normalize_collation(@default_collation_before_normalization)
+      @default_collation ||= normalize_collation(@default_collation_before_normalization)
     end
 
     def default_text_limit=(text_limit)

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "1.3.5.colin.1"
+  VERSION = "1.3.5"
 end

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "1.3.4"
+  VERSION = "1.3.5.colin.1"
 end

--- a/spec/lib/declare_schema_spec.rb
+++ b/spec/lib/declare_schema_spec.rb
@@ -46,15 +46,14 @@ RSpec.describe DeclareSchema do
         let(:connection) { double("connection", select_value: "8.0.21") }
 
         it "is lazy, so it doesn't use the database connection until read" do
-          @connection_called = false
           expect(ActiveRecord::Base).to receive(:connection) do
             @connection_called = true
             connection
           end
           described_class.default_charset = "utf8"
-          expect(@connection_called).to eq(false)
+          expect(@connection_called).to be_falsey
           described_class.default_charset
-          expect(@connection_called).to eq(true)
+          expect(@connection_called).to be_truthy
         end
       end
     end
@@ -111,15 +110,14 @@ RSpec.describe DeclareSchema do
         let(:connection) { double("connection", select_value: "8.0.21") }
 
         it "is lazy, so it doesn't use the database connection until read" do
-          @connection_called = false
           expect(ActiveRecord::Base).to receive(:connection) do
             @connection_called = true
             connection
           end
           described_class.default_collation = "utf8_general_ci"
-          expect(@connection_called).to eq(false)
+          expect(@connection_called).to be_falsey
           described_class.default_collation
-          expect(@connection_called).to eq(true)
+          expect(@connection_called).to be_truthy
         end
       end
     end

--- a/spec/lib/declare_schema_spec.rb
+++ b/spec/lib/declare_schema_spec.rb
@@ -37,6 +37,27 @@ RSpec.describe DeclareSchema do
         it     { is_expected.to eq("utf8mb3") }
       end
     end
+
+    context 'when MySQL version not known yet' do
+      before { described_class.remove_instance_variable('@mysql_version') rescue nil }
+      after { described_class.remove_instance_variable('@mysql_version') rescue nil }
+
+      context 'when set' do
+        let(:connection) { double("connection", select_value: "8.0.21") }
+
+        it "is lazy, so it doesn't use the database connection until read" do
+          @connection_called = false
+          expect(ActiveRecord::Base).to receive(:connection) do
+            @connection_called = true
+            connection
+          end
+          described_class.default_charset = "utf8"
+          expect(@connection_called).to eq(false)
+          described_class.default_charset
+          expect(@connection_called).to eq(true)
+        end
+      end
+    end
   end
 
   describe '#default_collation' do
@@ -79,6 +100,27 @@ RSpec.describe DeclareSchema do
         before { described_class.default_collation = "utf8_general_ci" }
         after  { described_class.default_collation = "utf8mb4_bin" }
         it     { is_expected.to eq("utf8mb3_general_ci") }
+      end
+    end
+
+    context 'when MySQL version not known yet' do
+      before { described_class.remove_instance_variable('@mysql_version') rescue nil }
+      after { described_class.remove_instance_variable('@mysql_version') rescue nil }
+
+      context 'when set' do
+        let(:connection) { double("connection", select_value: "8.0.21") }
+
+        it "is lazy, so it doesn't use the database connection until read" do
+          @connection_called = false
+          expect(ActiveRecord::Base).to receive(:connection) do
+            @connection_called = true
+            connection
+          end
+          described_class.default_collation = "utf8_general_ci"
+          expect(@connection_called).to eq(false)
+          described_class.default_collation
+          expect(@connection_called).to eq(true)
+        end
       end
     end
   end


### PR DESCRIPTION
## [1.3.5] - 2024-01-22
### Fixed
- Make `default_charset=` and `default_collation=` lazy so they don't use the database connection to check the
  MySQL version. Instead, that is checked the first time `default_charset` or `default_collation` is called.
