### PR TITLE
TECH-16372: drop/add index if settings change (that order is important in case index name is identical)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - Unreleased
+### Changed
+- Drop/add index if its settings change (`unique:`, `length:`, etc.)
+- Drop indexes before adding, in case any have identical names
+- Same for foreign key constraints
+
 ## [2.1.0] - 2024-08-20
 ### Added
 - Added support for Rails 7.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,8 +172,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.3.5)
-      strscan
+    rexml (3.3.8)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -213,7 +212,6 @@ GEM
       sprockets (>= 3.0.0)
     sqlite3 (1.7.3)
       mini_portile2 (~> 2.8.0)
-    strscan (3.1.0)
     thor (1.3.1)
     timeout (0.4.1)
     tzinfo (2.0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (2.1.0)
+    declare_schema (2.2.0)
       rails (>= 6.0)
 
 GEM

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "2.1.0"
+  VERSION = "2.2.0"
 end

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -287,8 +287,8 @@ module Generators
                                   PrimaryKeyChange
                                   IndexRemove
                                   IndexAdd
-                                    ForeignKeyRemove
-                                    ForeignKeyAdd
+                                  ForeignKeyRemove
+                                  ForeignKeyAdd
                                 ColumnRemove
                               TableRemove ]
 
@@ -478,8 +478,8 @@ module Generators
           [Array(change_primary_key) + drop_indexes + add_indexes]
         end
 
-        # @return [Array<Array<IndexDefinition>>] pair of arrays of indexes that changed solely due to column renames...not any settings changes
-        # Note: if the columns have been reordered, that is considered a change of settings, not solely a column rename, so it will not be returned
+        # @return [Array<Array<IndexDefinition>>] pair of arrays of indexes that changed solely due to column renames...not any settings changes.
+        # Note: if the column order changed, that is considered a change of settings--not solely a column rename--so it will not be returned
         def index_changes_solely_due_to_column_renames(indexes_to_drop, indexes_to_add, to_rename)
           renamed_indexes_to_drop = []
           renamed_indexes_to_add = []
@@ -487,9 +487,9 @@ module Generators
           indexes_to_drop.each do |index_to_drop|
             renamed_columns = index_to_drop.columns.map do |column|
               to_rename.fetch(column, column)
-            end.sort
+            end
 
-            if (index_to_add = indexes_to_add.find { |index_to_add| renamed_columns == index_to_add.columns.sort }) &&
+            if (index_to_add = indexes_to_add.find { |index_to_add| renamed_columns == index_to_add.columns }) &&
                 index_to_add.settings == index_to_drop.settings
               renamed_indexes_to_drop << index_to_drop
               renamed_indexes_to_add << index_to_add

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -285,9 +285,9 @@ module Generators
                                 ColumnRename
                                 ColumnChange
                                   PrimaryKeyChange
-                                  IndexRemove
-                                  IndexAdd
                                   ForeignKeyRemove
+                                    IndexRemove
+                                    IndexAdd
                                   ForeignKeyAdd
                                 ColumnRemove
                               TableRemove ]

--- a/spec/fixtures/migrations/sqlite3/will_generate_unique_constraint_names_rails_6.txt
+++ b/spec/fixtures/migrations/sqlite3/will_generate_unique_constraint_names_rails_6.txt
@@ -9,7 +9,5 @@ create_table :affiliates, id: :bigint, options: "CHARACTER SET utf8mb4 COLLATE u
   t.string  :name, limit: 250, null: true, charset: "utf8mb4", collation: "utf8mb4_bin"
   t.integer :category_id, limit: 8, null: false
 end
-add_index :advertisers, [:category_id], name: :index_advertisers_on_category_id
-add_index :affiliates, [:category_id], name: :index_affiliates_on_category_id
 add_foreign_key :advertisers, :categories, column: :category_id, name: :index_advertisers_on_category_id
 add_foreign_key :affiliates, :categories, column: :category_id, name: :index_affiliates_on_category_id

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -735,7 +735,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
         .and(migrate_down(<<~EOS.strip))
           create_table "adverts"#{table_options}, force: :cascade do |t|
             t.string "title", limit: 250#{charset_and_collation}
-            t.text "body", limit: 4294967295#{charset_and_collation}
+            t.text "body"#{text_limit}#{charset_and_collation}
           end
         EOS
       )

--- a/spec/lib/generators/declare_schema/migration/migrator_spec.rb
+++ b/spec/lib/generators/declare_schema/migration/migrator_spec.rb
@@ -89,10 +89,10 @@ module Generators
                 ColumnRename
                 ColumnChange
                 PrimaryKeyChange
-                IndexAdd
-                ForeignKeyAdd
-                ForeignKeyRemove
                 IndexRemove
+                IndexAdd
+                ForeignKeyRemove
+                ForeignKeyAdd
                 ColumnRemove
                 TableRemove ]
             end

--- a/spec/lib/generators/declare_schema/migration/migrator_spec.rb
+++ b/spec/lib/generators/declare_schema/migration/migrator_spec.rb
@@ -89,9 +89,9 @@ module Generators
                 ColumnRename
                 ColumnChange
                 PrimaryKeyChange
+                ForeignKeyRemove
                 IndexRemove
                 IndexAdd
-                ForeignKeyRemove
                 ForeignKeyAdd
                 ColumnRemove
                 TableRemove ]


### PR DESCRIPTION
I ran into this bug while working  https://invoca.atlassian.net/browse/WEB-7889 . I know I'd seen it before. This time I tracked it down.

## [2.2.0] - Unreleased
### Changed
- Drop/add index if its settings change (`unique:`, `length:`, etc.)
- Drop indexes before adding, in case any have identical names (so we don't get a SQL exception about the duplicate name)
- Same for foreign key constraints
- Address CVE warning with `bundle update rexml`
