### PR TITLE
TECH-16372: allow_equivalent: true and separate ignore_equivalent_definitions: false

### DIFF
--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -49,7 +49,7 @@ module DeclareSchema
     end
 
     module ClassMethods
-      def index(columns, name: nil, allow_equivalent: false, unique: false, where: nil, length: nil)
+      def index(columns, name: nil, allow_equivalent: true, ignore_equivalent_definitions: false, unique: false, where: nil, length: nil)
         index_definition = ::DeclareSchema::Model::IndexDefinition.new(
           columns,
           name: name, table_name: table_name, allow_equivalent: allow_equivalent, unique: unique, where: where, length: length
@@ -59,9 +59,9 @@ module DeclareSchema
           if equivalent == index_definition
             # identical is always idempotent
           else
-            # equivalent is idempotent iff allow_equivalent: true passed
-            allow_equivalent or
-              raise ArgumentError, "equivalent index definition found (pass allow_equivalent: true to ignore):\n" \
+            # equivalent is idempotent iff ignore_equivalent_definitions: true passed
+            ignore_equivalent_definitions or
+              raise ArgumentError, "equivalent index definition found (pass ignore_equivalent_definitions: true to ignore):\n" \
                                    "#{index_definition.inspect}\n#{equivalent.inspect}"
           end
         else
@@ -156,8 +156,8 @@ module DeclareSchema
                                 end || false
         column_options[:default] = options.delete(:default) if options.has_key?(:default)
         if options.has_key?(:limit)
-          options.delete(:limit)
-          DeclareSchema.deprecator.warn("belongs_to #{name.inspect}, limit: is deprecated since it is now inferred")
+          limit = options.delete(:limit)
+          DeclareSchema.deprecator.warn("belongs_to #{name.inspect}, limit: #{limit} is deprecated since it is now inferred")
         end
 
         # index: true means create an index on the foreign key

--- a/lib/declare_schema/model/index_definition.rb
+++ b/lib/declare_schema/model/index_definition.rb
@@ -16,9 +16,9 @@ module DeclareSchema
 
       PRIMARY_KEY_NAME = "PRIMARY"
 
-      def initialize(columns, table_name:, name: nil, allow_equivalent: false, unique: false, where: nil, length: nil)
+      def initialize(columns, table_name:, name: nil, allow_equivalent: true, unique: false, where: nil, length: nil)
         @table_name = table_name
-        @name = (name || self.class.default_index_name(table_name, columns)).to_s
+        @name = name&.to_s || self.class.default_index_name(table_name, columns)
         @columns = Array.wrap(columns).map(&:to_s)
         @allow_equivalent = allow_equivalent
         unique.in?([false, true]) or raise ArgumentError, "unique must be true or false: got #{unique.inspect}"

--- a/lib/declare_schema/model/index_definition.rb
+++ b/lib/declare_schema/model/index_definition.rb
@@ -8,7 +8,7 @@ module DeclareSchema
       include Comparable
 
       OPTIONS = [:name, :unique, :where, :length].freeze
-      attr_reader :columns, :explicit_name, :table_name, *OPTIONS
+      attr_reader :columns, :allow_equivalent, :table_name, *OPTIONS
 
       alias fields columns # TODO: change callers to use columns. -Colin
 
@@ -20,7 +20,7 @@ module DeclareSchema
         @table_name = table_name
         @name = (name || self.class.default_index_name(table_name, columns)).to_s
         @columns = Array.wrap(columns).map(&:to_s)
-        @explicit_name = @name if !allow_equivalent
+        @allow_equivalent = allow_equivalent
         unique.in?([false, true]) or raise ArgumentError, "unique must be true or false: got #{unique.inspect}"
         if @name == PRIMARY_KEY_NAME
           unique or raise ArgumentError, "primary key index must be unique"
@@ -165,7 +165,7 @@ module DeclareSchema
       end
 
       def with_name(new_name)
-        self.class.new(@columns, name: new_name, table_name: @table_name, unique: @unique, allow_equivalent: @explicit_name.nil?, where: @where, length: @length)
+        self.class.new(@columns, name: new_name, table_name: @table_name, unique: @unique, allow_equivalent: @allow_equivalent, where: @where, length: @length)
       end
 
       alias eql? ==

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -439,7 +439,9 @@ module Generators
           model_indexes_with_equivalents = model.index_definitions_with_primary_key.to_a
           model_indexes = model_indexes_with_equivalents.map do |index|
             if index.allow_equivalent
-              if (existing = existing_indexes.find { |existing_index| index != existing_index && existing_index.equivalent?(index) })
+              if (existing = existing_indexes.find { |existing_index| index != existing_index && existing_index.equivalent?(index) }) &&
+                  # TODO: push this logic into IndexDefinition so that it knows about column renames and includes the (renamed) columns in the settings it compares. -Colin
+                  existing.columns.map { |col_name| to_rename[col_name] || col_name } == index.columns
                 index.with_name(existing.name)
               end
             end || index

--- a/lib/generators/declare_schema/migration/migrator.rb
+++ b/lib/generators/declare_schema/migration/migrator.rb
@@ -437,12 +437,12 @@ module Generators
           new_table_name = model.table_name
           existing_indexes = ::DeclareSchema::Model::IndexDefinition.for_table(old_table_name || new_table_name, model.ignore_indexes, model.connection)
           model_indexes_with_equivalents = model.index_definitions_with_primary_key.to_a
-          model_indexes = model_indexes_with_equivalents.map do |i|
-            if i.explicit_name.nil?
-              if (existing = existing_indexes.find { |e| i != e && e.equivalent?(i) })
-                i.with_name(existing.name)
+          model_indexes = model_indexes_with_equivalents.map do |index|
+            if index.allow_equivalent
+              if (existing = existing_indexes.find { |existing_index| index != existing_index && existing_index.equivalent?(index) })
+                index.with_name(existing.name)
               end
-            end || i
+            end || index
           end
           existing_primary_keys, existing_indexes_without_primary_key = existing_indexes.partition { |i| i.primary_key? }
           defined_primary_keys, model_indexes_without_primary_key = model_indexes.partition { |i| i.primary_key? }

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -436,7 +436,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       Advert.index_definitions.clear
       Advert.constraint_definitions.clear
 
-      # You can specify the index name with index: { name: }'name', unique: true|false }
+      # You can specify the index name with index: { name: 'name', unique: true|false }
 
       class Category < ActiveRecord::Base; end # rubocop:disable Lint/ConstantDefinitionInBlock
 
@@ -570,7 +570,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
       Advert.index_definitions.clear
 
-      # The available options for the index function are :unique, :name, :where, and :length.
+      # The available options for the index function are :unique, :name, :where, and :length (as well as :allow_equivalent, :ignore_equivalent_definitions).
 
       class Advert < ActiveRecord::Base # rubocop:disable Lint/ConstantDefinitionInBlock
         index :title, unique: false, name: 'my_index', length: 10
@@ -1274,7 +1274,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
           end
 
           it 'deprecates limit:' do
-            expect(DeclareSchema.deprecator).to receive(:warn).with("belongs_to :ad_category, limit: is deprecated since it is now inferred")
+            expect(DeclareSchema.deprecator).to receive(:warn).with("belongs_to :ad_category, limit: 4 is deprecated since it is now inferred")
             eval <<~EOS # rubocop:disable Style/EvalWithLocation
               class UsingLimit < ActiveRecord::Base
                 declare_schema { }
@@ -1544,7 +1544,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
       it "when equivalent and marked to allow, it is idempotent and doesn't raise" do
         expect do
-          Advert.index [:ad_category_id], name: :on_ad_category_id, allow_equivalent: true
+          Advert.index [:ad_category_id], name: :on_ad_category_id, ignore_equivalent_definitions: true
         end.to_not change { Advert.index_definitions.size }
       end
 

--- a/spec/lib/declare_schema/model/index_definition_spec.rb
+++ b/spec/lib/declare_schema/model/index_definition_spec.rb
@@ -56,19 +56,13 @@ RSpec.describe DeclareSchema::Model::IndexDefinition do
           it { is_expected.to eq(fields) }
         end
 
-        describe '#explicit_name' do
-          subject { instance.explicit_name }
+        describe '#allow_equivalent' do
+          subject { instance.allow_equivalent }
 
           context 'with allow_equivalent' do
             let(:options) { { table_name: table_name, allow_equivalent: true } }
 
-            it { is_expected.to eq(nil) }
-          end
-
-          context 'with name option' do
-            let(:options) { { table_name: table_name, name: 'index_auth_users_on_names' } }
-
-            it { is_expected.to eq('index_auth_users_on_names') }
+            it { is_expected.to eq(true) }
           end
         end
 


### PR DESCRIPTION
When integrating `declare_schema` into web, a lot of false migrations (in Warehouse) got kicked off because the `allow_equivalent: false` which was also partially true in this gem. The problem was overloading that for two purposes which are now separated here:

- `allow_equivalent: true` This allows an index of a different name but same settings to suffice. Setting it to `false` will cause the old index to be dropped and the new one added if the name is different (which is very common since we've changed the default names so many times!).
- `ignore_equivalent_definitions: false` This makes index definition idempotent. That wouldn't come up when indexes are declared by hand, but Warehouse needs it in 1 or 2 places because it's code generating the definitions.