### PR TITLE
TECH-16946: fix bug on new model with polymorphic belongs_to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] - Unreleased
+### Fixed
+- Fixed bug where a new model where `belongs_to :owner, polymorphic: true` would cause
+  a "Mysql2::Error: Table '<new table>' doesn't exist:" exception when generating a migration.
+
 ## [2.3.0] - 2024-10-31
 ### Updated
 - Updated the `current_adapter` method to use `connection_db_config` for Rails 6.1 and higher, while retaining `connection_config` for earlier versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 ## [2.3.1] - Unreleased
 ### Fixed
-- Fixed bug where a new model where `belongs_to :owner, polymorphic: true` would cause
+- Fixed bug where a new model with `belongs_to :owner, polymorphic: true` would cause
   a "Mysql2::Error: Table '<new table>' doesn't exist:" exception when generating a migration.
 
 ## [2.3.0] - 2024-10-31

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (2.3.0)
+    declare_schema (2.3.1)
       rails (>= 6.0)
 
 GEM

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -240,7 +240,7 @@ module DeclareSchema
 
       def _infer_fk_limit(foreign_key_column, reflection)
         if reflection.options[:polymorphic]
-          if (foreign_key_column = columns_hash[foreign_key_column.to_s]) && foreign_key_column.type == :integer
+          if (foreign_key_column = _column(foreign_key_column)) && foreign_key_column.type == :integer
             foreign_key_column.limit
           end
         else

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "2.3.0"
+  VERSION = "2.3.1"
 end

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -1305,6 +1305,7 @@ RSpec.describe 'DeclareSchema Migration Generator' do
               belongs_to :id_default
               belongs_to :id4
               belongs_to :id8
+              belongs_to :owner, polymorphic: true
             end
           end
 
@@ -1332,20 +1333,24 @@ RSpec.describe 'DeclareSchema Migration Generator' do
           it 'infers the correct FK type from the create_table id: type' do
             up = Generators::DeclareSchema::Migration::Migrator.run.first
 
-            create_fks = up.split("\n").grep(/t\.integer /).map { |command| command.gsub(', null: false', '').gsub(/^ +/, '') }
+            create_fks = up.split("\n").grep(/t\.integer|string /).map { |command| command.gsub(', null: false', '').gsub(/^ +/, '') }
             if current_adapter == 'sqlite3'
               create_fks.map! { |command| command.gsub(/limit: [a-z0-9]+/, 'limit: X') }
               expect(create_fks).to eq([
                                          't.integer :id_default_id, limit: X',
                                          't.integer :id4_id, limit: X',
-                                         't.integer :id8_id, limit: X'
-                                       ]), up
+                                         't.integer :id8_id, limit: X',
+                                         't.integer :owner_id, limit: X',
+                                         't.string  :owner_type, limit: X'
+                                       ])
             else
               expect(create_fks).to eq([
                                          't.integer :id_default_id, limit: 8',
                                          't.integer :id4_id, limit: 4',
-                                         't.integer :id8_id, limit: 8'
-                                       ]), up
+                                         't.integer :id8_id, limit: 8',
+                                         't.integer :owner_id, limit: 8',
+                                         "t.string  :owner_type, limit: 255#{charset_and_collation}"
+                                       ])
             end
           end
 


### PR DESCRIPTION
## [2.3.1] - Unreleased
### Fixed
- Fixed bug where a new model with `belongs_to :owner, polymorphic: true` would cause
  a "Mysql2::Error: Table '<new table>' doesn't exist:" exception when generating a migration.
