### PR TITLE
Tech 18196 fix bug in value validations and expand functionality of timestamps dsl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.3] - Unreleased
+### Changed
+- The `timestamps` DSL method to create `created_at` and `updated_at` columns now defaults to `null: false` for `datetime` columns
+- The `timestamps` DSL method to allow additional options to be passed to the `datetime` fields
+
+### Fixed
+- Fixed a bug where `#validate` methods on core object classes with required arguments were cuasing model validations to fail
+
 ## [2.3.2] - 2025-02-21
 ### Fixed
 - Removed require of `activesupport/proxy_object` which is removed in Rails 8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 - The `timestamps` DSL method to allow additional options to be passed to the `datetime` fields
 
 ### Fixed
-- Fixed a bug where `#validate` methods on core object classes with required arguments were cuasing model validations to fail
+- Fixed a bug where `#validate` methods on core object classes with required arguments was causing model validations to fail
 
 ## [2.3.2] - 2025-02-21
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.3.3] - Unreleased
+## [3.0.0] - Unreleased
 ### Changed
 - The `timestamps` DSL method to create `created_at` and `updated_at` columns now defaults to `null: false` for `datetime` columns
 - The `timestamps` DSL method to allow additional options to be passed to the `datetime` fields

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (2.3.3.pre.1)
+    declare_schema (3.0.0.pre.1)
       rails (>= 6.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (2.3.2)
+    declare_schema (2.3.3)
       rails (>= 6.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    declare_schema (2.3.3)
+    declare_schema (2.3.3.pre.1)
       rails (>= 6.0)
 
 GEM

--- a/lib/declare_schema/dsl.rb
+++ b/lib/declare_schema/dsl.rb
@@ -17,9 +17,9 @@ module DeclareSchema
 
     attr_reader :model
 
-    def timestamps
-      field(:created_at, :datetime, null: true)
-      field(:updated_at, :datetime, null: true)
+    def timestamps(**options)
+      field(:created_at, :datetime, null: false, **options)
+      field(:updated_at, :datetime, null: false, **options)
     end
 
     def optimistic_lock

--- a/lib/declare_schema/model.rb
+++ b/lib/declare_schema/model.rb
@@ -310,7 +310,7 @@ module DeclareSchema
 
         # Support for custom validations
         if (type_class = DeclareSchema.to_class(type))
-          if type_class.public_method_defined?("validate")
+          if type_class.public_method_defined?("validate") && type_class.instance_method("validate").arity.zero?
             validate do |record|
               v = record.send(name)&.validate
               record.errors.add(name, v) if v.is_a?(String)

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "2.3.2"
+  VERSION = "2.3.3"
 end

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "2.3.3"
+  VERSION = "2.3.3.pre.1"
 end

--- a/lib/declare_schema/version.rb
+++ b/lib/declare_schema/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclareSchema
-  VERSION = "2.3.3.pre.1"
+  VERSION = "3.0.0.pre.1"
 end

--- a/spec/lib/declare_schema/migration_generator_spec.rb
+++ b/spec/lib/declare_schema/migration_generator_spec.rb
@@ -471,8 +471,8 @@ RSpec.describe 'DeclareSchema Migration Generator' do
 
       expect(Generators::DeclareSchema::Migration::Migrator.run).to(
         migrate_up(<<~EOS.strip)
-          add_column :adverts, :created_at, :datetime, null: true
-          add_column :adverts, :updated_at, :datetime, null: true
+          add_column :adverts, :created_at, :datetime, null: false
+          add_column :adverts, :updated_at, :datetime, null: false
           add_column :adverts, :lock_version, :integer#{lock_version_limit}, null: false, default: 1
         EOS
         .and(migrate_down(<<~EOS.strip))
@@ -485,6 +485,30 @@ RSpec.describe 'DeclareSchema Migration Generator' do
       Advert.field_specs.delete(:updated_at)
       Advert.field_specs.delete(:created_at)
       Advert.field_specs.delete(:lock_version)
+
+      ### Timestamps with null: true
+
+      # `updated_at` and `created_at` can be declared with the shorthand `timestamps` passed with null: true override
+
+      class Advert < ActiveRecord::Base # rubocop:disable Lint/ConstantDefinitionInBlock
+        declare_schema do
+          timestamps null: true
+        end
+      end
+
+      expect(Generators::DeclareSchema::Migration::Migrator.run).to(
+        migrate_up(<<~EOS.strip)
+          add_column :adverts, :created_at, :datetime, null: true
+          add_column :adverts, :updated_at, :datetime, null: true
+        EOS
+        .and(migrate_down(<<~EOS.strip))
+          remove_column :adverts, :updated_at
+          remove_column :adverts, :created_at
+        EOS
+      )
+
+      Advert.field_specs.delete(:updated_at)
+      Advert.field_specs.delete(:created_at)
 
       ### Indices
 


### PR DESCRIPTION
## [2.3.3] - Unreleased
### Changed
- The `timestamps` DSL method to create `created_at` and `updated_at` columns now defaults to `null: false` for `datetime` columns
- The `timestamps` DSL method to allow additional options to be passed to the `datetime` fields

### Fixed
- Fixed a bug where `#validate` methods on core object classes with required arguments were cuasing model validations to fail